### PR TITLE
move/github-average-metrics

### DIFF
--- a/src/pages/Projects/ProjectCard.js
+++ b/src/pages/Projects/ProjectCard.js
@@ -59,7 +59,7 @@ const ProjectCard = ({
   percentChange24h,
   volumeUsd,
   volumeChange24h,
-  averageDevActivity,
+  averageGithubActivity,
   twitterData,
   ethSpent,
   ethBalance = 0,
@@ -207,11 +207,11 @@ const ProjectCard = ({
             <StatisticElement
               name='Dev Activity 30d'
               value={
-                averageDevActivity
-                  ? parseFloat(averageDevActivity).toFixed(2)
+                averageGithubActivity
+                  ? parseFloat(averageGithubActivity).toFixed(2)
                   : '---'
               }
-              disabled={!averageDevActivity}
+              disabled={!averageGithubActivity}
             />
             <HiddenElements>
               <StatisticElement

--- a/src/pages/Projects/ProjectsTable.js
+++ b/src/pages/Projects/ProjectsTable.js
@@ -284,7 +284,7 @@ const ProjectsTable = ({
       Header: 'Dev activity (30D)',
       id: 'github_activity',
       maxWidth: 110,
-      accessor: d => d.averageDevActivity,
+      accessor: d => d.averageGithubActivity,
       Cell: ({ value }) => (
         <div className='overview-devactivity'>
           {value ? parseFloat(value).toFixed(2) : ''}

--- a/src/pages/Projects/allProjectsGQL.js
+++ b/src/pages/Projects/allProjectsGQL.js
@@ -29,7 +29,7 @@ const project = gql`
     volumeUsd
     volumeChange24h
     ethSpent
-    averageDevActivity
+    averageGithubActivity
     averageDailyActiveAddresses
     marketcapUsd
     ethBalance

--- a/src/pages/Projects/withProjectsDataMobile.js
+++ b/src/pages/Projects/withProjectsDataMobile.js
@@ -17,7 +17,7 @@ const mapDataToProps = type => ({ Projects, ownProps }) => {
   let filteredProjects = [...projects]
     .sort((a, b) => {
       if (ownProps.sortBy === 'github_activity') {
-        return simpleSort(+a.averageDevActivity, +b.averageDevActivity)
+        return simpleSort(+a.averageGithubActivity, +b.averageGithubActivity)
       }
       return simpleSort(+a.marketcapUsd, +b.marketcapUsd)
     })

--- a/src/pages/assets/asset-columns.js
+++ b/src/pages/assets/asset-columns.js
@@ -154,7 +154,7 @@ const columns = preload => [
     Header: 'Dev activity (30D)',
     id: 'github_activity',
     maxWidth: 110,
-    accessor: d => d.averageDevActivity,
+    accessor: d => d.averageGithubActivity,
     Cell: ({ value }) => (
       <div className='overview-devactivity'>
         {value ? parseFloat(value).toFixed(2) : ''}


### PR DESCRIPTION
[Link to the original PR](https://github.com/santiment/sanbase2/pull/870).

#### Summary
Rename the project type `averageDevActivty` to the more accurate `averageGithubActivity`. Add a new `avereageDevActivity` field that excludes non-dev events.