### PR TITLE
feature/trends-empty-data-as-zero

### DIFF
--- a/src/components/Trends/TrendsReChart.js
+++ b/src/components/Trends/TrendsReChart.js
@@ -197,6 +197,13 @@ export default compose(
       calcSumOfMentions
     )(chartData)
 
+    chartSummaryData.forEach(({ index }) => {
+      chartData.forEach(data => {
+        if (data[index] === undefined) {
+          data[index] = 0
+        }
+      })
+    })
     return {
       chartData,
       chartSummaryData,


### PR DESCRIPTION
#### Summary
Filling empty trends chart data with zeros

#### Screenshots
![image](https://user-images.githubusercontent.com/25135650/50274049-3cc44780-044d-11e9-8c66-b3e2b38b65a4.png)
