### PR TITLE
fix/mergetimeseries-array-overflow

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -122,23 +122,58 @@ const getYesterday = () => {
   return yesterday.toISOString()
 }
 
-const mergeTimeseriesByKey = ({ timeseries, key }) => {
-  const longestTS = timeseries.reduce((acc, val) => {
+const mergeTimeseriesByKey = ({ timeseries, key: mergeKey }) => {
+  const longestTSMut = timeseries.reduce((acc, val) => {
     return acc.length > val.length ? acc : val
   }, [])
-  return longestTS.map(data => {
-    return timeseries.reduce(
-      (acc, val) => {
-        return {
-          ...acc,
-          ...val.find(data2 => data2[key] === data[key])
-        }
-      },
-      {
-        ...data
+
+  const longestTS = longestTSMut.slice()
+  const longestTSLastIndex = longestTS.length - 1
+
+  for (const timeserie of timeseries) {
+    if (timeserie === longestTSMut) {
+      continue
+    }
+
+    let longestTSRightIndexBoundary = longestTSLastIndex
+    let timeserieRightIndex = timeserie.length - 1
+
+    if (timeserieRightIndex < 0) {
+      continue
+    }
+
+    if (mergeKey === 'datetime') {
+      for (
+        ;
+        moment(longestTS[longestTSRightIndexBoundary]['datetime']).isBefore(
+          moment(timeserie[timeserieRightIndex]['datetime'])
+        );
+        timeserieRightIndex--
+      ) {
+        longestTS.push(timeserie[timeserieRightIndex])
       }
-    )
-  })
+    }
+
+    for (; timeserieRightIndex > -1; timeserieRightIndex--) {
+      for (; longestTSRightIndexBoundary > -1; longestTSRightIndexBoundary--) {
+        const longestTSData = longestTS[longestTSRightIndexBoundary]
+        const timeserieData = timeserie[timeserieRightIndex]
+        if (longestTSData[mergeKey] === timeserieData[mergeKey]) {
+          longestTS[longestTSRightIndexBoundary] = Object.assign(
+            {},
+            longestTSData,
+            timeserieData
+          )
+          break
+        }
+      }
+      if (longestTSRightIndexBoundary === -1) {
+        break
+      }
+    }
+  }
+
+  return longestTS
 }
 
 const getTimeFromFromString = (time = '1y') => {

--- a/src/utils/utils.spec.js
+++ b/src/utils/utils.spec.js
@@ -178,14 +178,78 @@ describe('mergeTimeseriesByKey', () => {
 
   const ts4 = [
     {
-      value5: 51,
+      value4: 41,
       datetime: '2018-05-20T00:00:00Z'
     },
     {
-      value5: 52,
+      value4: 42,
       datetime: '2018-06-20T00:00:00Z'
     }
   ]
+
+  const ts5 = [
+    {
+      value5: 51,
+      datetime: '2018-08-20T00:00:00Z'
+    },
+    {
+      value5: 52,
+      datetime: '2018-09-20T00:00:00Z'
+    }
+  ]
+
+  it('should merge correctly and skip empty TS', () => {
+    const goodMerged = [
+      {
+        value1: 11,
+        value2: 21,
+        datetime: '2018-06-20T00:00:00Z'
+      },
+      {
+        value1: 12,
+        value2: 22,
+        datetime: '2018-07-20T00:00:00Z'
+      },
+      {
+        value2: 23,
+        datetime: '2018-08-20T00:00:00Z'
+      }
+    ]
+
+    const expected = mergeTimeseriesByKey({
+      timeseries: [ts1, ts2, []],
+      key: 'datetime'
+    })
+    expect(expected).toEqual(goodMerged)
+  })
+
+  it('should append longest array with missing new TS and merge existing', () => {
+    const goodMerged = [
+      {
+        value2: 21,
+        datetime: '2018-06-20T00:00:00Z'
+      },
+      {
+        value2: 22,
+        datetime: '2018-07-20T00:00:00Z'
+      },
+      {
+        value2: 23,
+        value5: 51,
+        datetime: '2018-08-20T00:00:00Z'
+      },
+      {
+        value5: 52,
+        datetime: '2018-09-20T00:00:00Z'
+      }
+    ]
+
+    const expected = mergeTimeseriesByKey({
+      timeseries: [ts2, ts5],
+      key: 'datetime'
+    })
+    expect(expected).toEqual(goodMerged)
+  })
 
   it('should merge 2 timeseries properly', () => {
     const goodMerged = [
@@ -243,7 +307,7 @@ describe('mergeTimeseriesByKey', () => {
     const goodMerged = [
       {
         value2: 21,
-        value5: 52,
+        value4: 42,
         datetime: '2018-06-20T00:00:00Z'
       },
       {


### PR DESCRIPTION
Zero-length timeseries array case fix by Lower bound check + corresponding test.

(row 141)
```
if (timeserieRightIndex < 0) {
      continue
}
```