### PR TITLE
fix/us-tokens-correct-title

### DIFF
--- a/src/pages/assets/AssetsPageNavigation.js
+++ b/src/pages/assets/AssetsPageNavigation.js
@@ -71,7 +71,7 @@ const AssetsPageNavigation = ({ isLoggedIn = false, location: { search } }) => (
             className='assets-navigation-list__dropdown-link'
             to={'/assets/list?name=usa@138#shared'}
           >
-            USD based assets
+            US based assets
           </Link>
           <Link
             activeClassName='projects-navigation-list__dropdown-link--active'


### PR DESCRIPTION
Changing `USD Based tokens` to `US Based projects`