### PR TITLE
enhance/total-market-widget

### DIFF
--- a/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
+++ b/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
@@ -1,159 +1,145 @@
-import React from 'react'
+import React, { Component } from 'react'
+import cx from 'classnames'
 import { ResponsiveContainer, AreaChart, Area, XAxis } from 'recharts'
+import PercentChanges from '../PercentChanges'
 import Widget from '../Widget/Widget'
-import { formatNumber } from '../../utils/formatting'
-import { mergeTimeseriesByKey } from '../../utils/utils'
+import {
+  getTop3Area,
+  combineDataset,
+  generateWidgetData
+} from './totalMarketcapWidgetUtils'
 import './TotalMarketcapWidget.scss'
 
-const currencyFormatOptions = {
-  currency: 'USD',
-  minimumFractionDigits: 0,
-  maximumFractionDigits: 0
+const WidgetMarketView = {
+  LIST: 'List',
+  TOTAL: 'Total'
 }
 
-const COLORS = ['#dda000', '#1111bb', '#ab47bc']
-const COLORS_TEXT = ['#aa7000', '#111199', '#8a43ac']
+const MarketView = ({ currentView, handleViewSelect }) => (
+  <div className='TotalMarketcapWidget__btns'>
+    View:{' '}
+    {Object.values(WidgetMarketView).map(view => (
+      <button
+        key={view}
+        className={cx({
+          'TotalMarketcapWidget__view-btn': true,
+          active: currentView === view
+        })}
+        onClick={() => handleViewSelect(view)}
+      >
+        {view}
+      </button>
+    ))}
+  </div>
+)
 
-const generateWidgetData = historyPrice => {
-  if (!historyPrice || historyPrice.length === 0) return {}
-
-  const historyPriceLastIndex = historyPrice.length - 1
-
-  const marketcapDataset = historyPrice.map(data => ({
-    datetime: data.datetime,
-    marketcap: data.marketcap
-  }))
-
-  const volumeAmplitude =
-    historyPrice[historyPriceLastIndex].volume -
-    historyPrice[historyPriceLastIndex - 1].volume
-
-  const volumeAmplitudePrice = formatNumber(
-    volumeAmplitude,
-    currencyFormatOptions
-  )
-
-  const totalmarketCapPrice = formatNumber(
-    historyPrice[historyPriceLastIndex].marketcap,
-    currencyFormatOptions
-  )
-
-  return {
-    totalmarketCapPrice,
-    volumeAmplitudePrice,
-    marketcapDataset
-  }
-}
-
-const constructProjectMarketcapKey = projectName => `${projectName}-marketcap`
-
-const combineDataset = (totalMarketHistory, restProjects) => {
-  const LAST_INDEX = totalMarketHistory.length - 1
-  if (LAST_INDEX < 0) {
-    return
+class TotalMarketcapWidget extends Component {
+  state = {
+    view: WidgetMarketView.LIST
   }
 
-  const restProjectTimeseries = Object.keys(restProjects).map(key =>
-    (restProjects[key] || []).map(({ marketcap, datetime }) => ({
-      datetime,
-      [constructProjectMarketcapKey(key)]: marketcap
-    }))
-  )
+  handleViewSelect = view => {
+    this.setState({
+      view
+    })
+  }
 
-  const result = mergeTimeseriesByKey({
-    timeseries: [totalMarketHistory, ...restProjectTimeseries],
-    key: 'datetime'
-  })
+  render () {
+    const {
+      historyPrices: { TOTAL_MARKET, TOTAL_LIST_MARKET, ...restProjects },
+      loading,
+      listName
+    } = this.props
 
-  return result
-}
+    const { view } = this.state
+    const isListView = view === WidgetMarketView.LIST
 
-const getTop3Area = restProjects => {
-  return Object.keys(restProjects).map((key, i) => {
-    const rightMarginByIndex = (i + 1) * 16
-    return (
-      <Area
-        key={key}
-        dataKey={constructProjectMarketcapKey(key)}
-        type='monotone'
-        strokeWidth={1}
-        stroke={COLORS[i]}
-        label={({ x, y, index }) => {
-          if (index === rightMarginByIndex) {
-            return (
-              <text
-                x={x}
-                y={y}
-                dy={-8}
-                fill={COLORS_TEXT[i]}
-                fontSize={12}
-                textAnchor='middle'
-              >
-                {key}
-              </text>
-            )
-          }
-          return ''
-        }}
-        fill={COLORS[i] + '2c'}
-        isAnimationActive={false}
-      />
+    let {
+      totalmarketCapPrice = '.',
+      volumeAmplitudePrice = '.',
+      volume24PercentChange,
+      marketcapDataset = []
+    } = generateWidgetData(
+      TOTAL_LIST_MARKET && isListView ? TOTAL_LIST_MARKET : TOTAL_MARKET
     )
-  })
-}
 
-const TotalMarketcapWidget = ({
-  historyPrices: { TOTAL_MARKET, ...restProjects },
-  loading
-}) => {
-  let {
-    totalmarketCapPrice = '.',
-    volumeAmplitudePrice = '.',
-    marketcapDataset = []
-  } = generateWidgetData(TOTAL_MARKET)
+    let restAreas = null
 
-  let restAreas = null
+    if (!loading && Object.keys(restProjects).length > 0) {
+      const target = isListView
+        ? restProjects
+        : { [listName]: TOTAL_LIST_MARKET }
+      marketcapDataset = combineDataset(marketcapDataset, target)
+      restAreas = getTop3Area(target)
+    }
 
-  if (!loading && Object.keys(restProjects).length > 0) {
-    marketcapDataset = combineDataset(marketcapDataset, restProjects)
-    restAreas = getTop3Area(restProjects)
-  }
+    const valueClassNames = `TotalMarketcapWidget__value ${
+      totalmarketCapPrice === '.' ? 'TotalMarketcapWidget__value_loading' : ''
+    }`
 
-  const valueClassNames = `TotalMarketcapWidget__value ${
-    totalmarketCapPrice === '.' ? 'TotalMarketcapWidget__value_loading' : ''
-  }`
-
-  return (
-    <Widget className='TotalMarketcapWidget'>
-      <div className='TotalMarketcapWidget__info'>
-        <div className='TotalMarketcapWidget__left'>
-          <h3 className='TotalMarketcapWidget__label'>Total marketcap</h3>
-          <h4 className={valueClassNames}>{totalmarketCapPrice}</h4>
+    return (
+      <Widget
+        className='TotalMarketcapWidget'
+        // title={
+        //   TOTAL_LIST_MARKET ? (
+        //     <MarketView
+        //       currentView={view}
+        //       handleViewSelect={this.handleViewSelect}
+        //     />
+        //   ) : null
+        // }
+      >
+        <div className='TotalMarketcapWidget__info'>
+          {TOTAL_LIST_MARKET && (
+            <MarketView
+              currentView={view}
+              handleViewSelect={this.handleViewSelect}
+            />
+          )}
+          <div className='TotalMarketcapWidget__left'>
+            <h3 className='TotalMarketcapWidget__label'>{`${
+              TOTAL_LIST_MARKET && isListView ? 'List' : 'Total'
+            } marketcap`}</h3>
+            <h4 className={valueClassNames}>{totalmarketCapPrice}</h4>
+          </div>
+          <div className='TotalMarketcapWidget__right'>
+            <h3 className='TotalMarketcapWidget__label'>
+              Vol 24 hr (
+              <PercentChanges
+                changes={volume24PercentChange}
+                className='TotalMarketcapWidget__change'
+              />
+              )
+            </h3>
+            <h4 className={valueClassNames}>{volumeAmplitudePrice}</h4>
+          </div>
         </div>
-        <div className='TotalMarketcapWidget__right'>
-          <h3 className='TotalMarketcapWidget__label'>Vol 24 hr</h3>
-          <h4 className={valueClassNames}>{volumeAmplitudePrice}</h4>
-        </div>
-      </div>
-      <ResponsiveContainer width='100%' className='TotalMarketcapWidget__chart'>
-        <AreaChart
-          data={marketcapDataset}
-          margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
+        <ResponsiveContainer
+          width='100%'
+          className={cx({
+            TotalMarketcapWidget__chart: true,
+            list: !!TOTAL_LIST_MARKET
+          })}
         >
-          <XAxis dataKey='datetime' hide />
-          <Area
-            dataKey='marketcap'
-            type='monotone'
-            strokeWidth={1}
-            stroke='#2d5e39'
-            fill='rgba(214, 235, 219, .8)'
-            isAnimationActive={false}
-          />
-          {restAreas}
-        </AreaChart>
-      </ResponsiveContainer>
-    </Widget>
-  )
+          <AreaChart
+            data={marketcapDataset}
+            margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
+          >
+            <XAxis dataKey='datetime' hide />
+            <Area
+              dataKey='marketcap'
+              type='monotone'
+              strokeWidth={1}
+              stroke='#2d5e39'
+              fill='rgba(214, 235, 219, .8)'
+              isAnimationActive={false}
+            />
+            {restAreas}
+          </AreaChart>
+        </ResponsiveContainer>
+      </Widget>
+    )
+  }
 }
 
 export default TotalMarketcapWidget

--- a/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
+++ b/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
+import moment from 'moment'
 import cx from 'classnames'
-import { ResponsiveContainer, AreaChart, Area, XAxis } from 'recharts'
+import { ResponsiveContainer, AreaChart, Area, XAxis, Tooltip } from 'recharts'
 import PercentChanges from '../PercentChanges'
 import Widget from '../Widget/Widget'
 import {
@@ -8,6 +9,8 @@ import {
   combineDataset,
   generateWidgetData
 } from './totalMarketcapWidgetUtils'
+import { formatNumber } from '../../utils/formatting'
+
 import './TotalMarketcapWidget.scss'
 
 const WidgetMarketView = {
@@ -78,17 +81,7 @@ class TotalMarketcapWidget extends Component {
     }`
 
     return (
-      <Widget
-        className='TotalMarketcapWidget'
-        // title={
-        //   TOTAL_LIST_MARKET ? (
-        //     <MarketView
-        //       currentView={view}
-        //       handleViewSelect={this.handleViewSelect}
-        //     />
-        //   ) : null
-        // }
-      >
+      <Widget className='TotalMarketcapWidget'>
         <div className='TotalMarketcapWidget__info'>
           {TOTAL_LIST_MARKET && (
             <MarketView
@@ -133,8 +126,14 @@ class TotalMarketcapWidget extends Component {
               stroke='#2d5e39'
               fill='rgba(214, 235, 219, .8)'
               isAnimationActive={false}
+              name={'Total Marketcap'}
             />
             {restAreas}
+            <Tooltip
+              labelFormatter={date => moment(date).format('dddd, MMM DD YYYY')}
+              formatter={value => formatNumber(value, { currency: 'USD' })}
+              itemSorter={({ value }) => value}
+            />
           </AreaChart>
         </ResponsiveContainer>
       </Widget>

--- a/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
+++ b/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
@@ -7,7 +7,6 @@
     border-color: #4a4a4a;
   }
   &__right {
-    // text-align: right;
     margin-top: 20px;
   }
   &__info {
@@ -55,9 +54,7 @@
     position: relative;
     flex: 1;
     width: 50% !important;
-    // margin-top: 20px;
-    // min-height: 125px;
-    // max-height: 125px;
+
     &::before {
       display: block;
       content: '';

--- a/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
+++ b/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
@@ -1,16 +1,20 @@
 .TotalMarketcapWidget {
-  max-width: 250px;
+  max-width: 100%;
+  width: 100%;
   border: 1px solid #adadad;
+  display: flex;
   &.night-mode {
     border-color: #4a4a4a;
   }
   &__right {
-    text-align: right;
+    // text-align: right;
+    margin-top: 20px;
   }
   &__info {
     display: flex;
-    justify-content: space-between;
-    padding: 0 5px;
+    flex-direction: column;
+    justify-content: center;
+    padding: 0 50px;
   }
   &__label {
     color: #555;
@@ -46,10 +50,33 @@
       }
     }
   }
+
   &__chart {
-    margin-top: 20px;
-    min-height: 125px;
-    max-height: 125px;
+    position: relative;
+    flex: 1;
+    width: 50% !important;
+    // margin-top: 20px;
+    // min-height: 125px;
+    // max-height: 125px;
+    &::before {
+      display: block;
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 20px;
+      left: -5px;
+      z-index: 999;
+      background: linear-gradient(
+        to right,
+        rgba(255, 255, 255, 1) 0%,
+        rgba(255, 255, 255, 0.9) 40%,
+        rgba(225, 255, 255, 0)
+      );
+    }
+  }
+  & .Widget__content {
+    display: flex;
   }
 }
 @keyframes loading {

--- a/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
+++ b/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
@@ -78,6 +78,32 @@
   & .Widget__content {
     display: flex;
   }
+
+  &__btns {
+    margin-bottom: 20px;
+    margin-top: -20px;
+  }
+
+  &__view-btn {
+    border: none;
+    color: #ccc;
+    cursor: pointer;
+    outline: none;
+
+    &.active {
+      color: #000;
+      text-decoration: underline;
+    }
+  }
+
+  & svg:not(:root) {
+    overflow: visible;
+  }
+
+  &__change {
+    display: inline-block;
+    font-size: 13px;
+  }
 }
 @keyframes loading {
   0% {

--- a/src/components/TotalMarketcapWidget/totalMarketcapWidgetUtils.js
+++ b/src/components/TotalMarketcapWidget/totalMarketcapWidgetUtils.js
@@ -81,6 +81,7 @@ export const getTop3Area = restProjects => {
       <Area
         key={key}
         dataKey={constructProjectMarketcapKey(key)}
+        name={key}
         type='monotone'
         strokeWidth={1}
         stroke={COLORS[i]}

--- a/src/components/TotalMarketcapWidget/totalMarketcapWidgetUtils.js
+++ b/src/components/TotalMarketcapWidget/totalMarketcapWidgetUtils.js
@@ -1,0 +1,109 @@
+import React from 'react'
+import { Area } from 'recharts'
+
+import { formatNumber } from '../../utils/formatting'
+import { mergeTimeseriesByKey } from '../../utils/utils'
+
+const COLORS = ['#dda000', '#1111bb', '#ab47bc']
+const COLORS_TEXT = ['#aa7000', '#111199', '#8a43ac']
+
+const currencyFormatOptions = {
+  currency: 'USD',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0
+}
+
+export const generateWidgetData = historyPrice => {
+  if (!historyPrice || historyPrice.length === 0) return {}
+
+  const historyPriceLastIndex = historyPrice.length - 1
+
+  const marketcapDataset = historyPrice.map(data => ({
+    datetime: data.datetime,
+    marketcap: data.marketcap
+  }))
+
+  const volumeAmplitude =
+    historyPrice[historyPriceLastIndex].volume -
+    historyPrice[historyPriceLastIndex - 1].volume
+
+  const volume24PercentChange =
+    (1 -
+      historyPrice[historyPriceLastIndex].volume /
+        historyPrice[historyPriceLastIndex - 1].volume) *
+    -100
+
+  const volumeAmplitudePrice = formatNumber(
+    volumeAmplitude,
+    currencyFormatOptions
+  )
+
+  const totalmarketCapPrice = formatNumber(
+    historyPrice[historyPriceLastIndex].marketcap,
+    currencyFormatOptions
+  )
+
+  return {
+    totalmarketCapPrice,
+    volumeAmplitudePrice,
+    volume24PercentChange,
+    marketcapDataset
+  }
+}
+
+const constructProjectMarketcapKey = projectName => `${projectName}-marketcap`
+
+export const combineDataset = (totalMarketHistory, restProjects) => {
+  const LAST_INDEX = totalMarketHistory.length - 1
+  if (LAST_INDEX < 0) {
+    return
+  }
+
+  const restProjectTimeseries = Object.keys(restProjects).map(key =>
+    (restProjects[key] || []).map(({ marketcap, datetime }) => ({
+      datetime,
+      [constructProjectMarketcapKey(key)]: marketcap
+    }))
+  )
+
+  const result = mergeTimeseriesByKey({
+    timeseries: [totalMarketHistory, ...restProjectTimeseries],
+    key: 'datetime'
+  })
+
+  return result
+}
+
+export const getTop3Area = restProjects => {
+  return Object.keys(restProjects).map((key, i) => {
+    const rightMarginByIndex = (i + 1) * 16
+    return (
+      <Area
+        key={key}
+        dataKey={constructProjectMarketcapKey(key)}
+        type='monotone'
+        strokeWidth={1}
+        stroke={COLORS[i]}
+        label={({ x, y, index }) => {
+          if (index === rightMarginByIndex) {
+            return (
+              <text
+                x={x}
+                y={y}
+                dy={-8}
+                fill={COLORS_TEXT[i]}
+                fontSize={12}
+                textAnchor='middle'
+              >
+                {key}
+              </text>
+            )
+          }
+          return ''
+        }}
+        fill={COLORS[i] + '2c'}
+        isAnimationActive={false}
+      />
+    )
+  })
+}

--- a/src/components/Widget/WidgetList.js
+++ b/src/components/Widget/WidgetList.js
@@ -3,10 +3,10 @@ import GetTotalMarketcap from '../TotalMarketcapWidget/GetTotalMarketcap'
 import InsightsWidget from '../InsightsWidget/InsightsWidget'
 import LatestWatchlistsWidget from '../LatestWatchlistsWidget/LatestWatchlistsWidget'
 import './WidgetList.scss'
-const WidgetList = ({ type, isLoggedIn }) => {
+const WidgetList = ({ type, isLoggedIn, listName }) => {
   return (
     <div className='WidgetList'>
-      <GetTotalMarketcap type={type} />
+      <GetTotalMarketcap type={type} listName={listName} />
       {/* {isLoggedIn && <InsightsWidget />} */}
       {/* <LatestWatchlistsWidget /> */}
     </div>

--- a/src/components/Widget/WidgetList.js
+++ b/src/components/Widget/WidgetList.js
@@ -7,8 +7,8 @@ const WidgetList = ({ type, isLoggedIn }) => {
   return (
     <div className='WidgetList'>
       <GetTotalMarketcap type={type} />
-      {isLoggedIn && <InsightsWidget />}
-      <LatestWatchlistsWidget />
+      {/* {isLoggedIn && <InsightsWidget />} */}
+      {/* <LatestWatchlistsWidget /> */}
     </div>
   )
 }

--- a/src/pages/assets/AssetsPage.js
+++ b/src/pages/assets/AssetsPage.js
@@ -34,7 +34,11 @@ const AssetsPage = props => (
       <link rel='canonical' href={`${getOrigin()}/assets`} />
     </Helmet>
     {props.isBetaModeEnabled && (
-      <WidgetList type={props.type} isLoggedIn={props.isLoggedIn} />
+      <WidgetList
+        listName={getHeadTitle(props.type, props.location.search)}
+        type={props.type}
+        isLoggedIn={props.isLoggedIn}
+      />
     )}
     <div className='page-head page-head-projects'>
       <div className='page-head-projects__left'>
@@ -44,7 +48,7 @@ const AssetsPage = props => (
           props.location.hash !== '#shared' && <WatchlistShare />}
 
         {props.type === 'list' && <WatchlistCopy />}
-        
+
         {qs.parse(props.location.search).name === 'stablecoins@86' && (
           <StablecoinsDataDownloadBtn />
         )}


### PR DESCRIPTION
#### Summary
- Displaying volume change in percents;
- Toggling between `List` view and `Total` view;
- Tooltip when hovering on the chart;
- `TotalMarketcapWidget` now takes full width of the widget board;
- `LatestInsights` and `LatestWathlists` widgets are hidden.


#### Screenshots
![image](https://user-images.githubusercontent.com/25135650/50448388-077a9680-0932-11e9-8609-2ffa87783543.png)
![image](https://user-images.githubusercontent.com/25135650/50448394-13665880-0932-11e9-9433-4cb0635f720e.png)
![image](https://user-images.githubusercontent.com/25135650/50448400-1f521a80-0932-11e9-9496-49a0803e5deb.png)
