### PR TITLE
enhance/marketcap-widget-ux

### DIFF
--- a/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
+++ b/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
@@ -22,7 +22,7 @@ import { formatNumber, millify } from '../../utils/formatting'
 import './TotalMarketcapWidget.scss'
 
 const WidgetMarketView = {
-  TOTAL: 'Total',
+  TOTAL: 'Assets',
   LIST: 'List'
 }
 
@@ -100,7 +100,7 @@ class TotalMarketcapWidget extends Component {
           <div className='TotalMarketcapWidget__info'>
             <div className='TotalMarketcapWidget__left'>
               <h3 className='TotalMarketcapWidget__label'>{`${
-                TOTAL_LIST_MARKET && isListView ? 'List' : 'Total'
+                TOTAL_LIST_MARKET && isListView ? listName : 'All Crypto'
               } marketcap`}</h3>
               <h4 className={valueClassNames}>{totalmarketCapPrice}</h4>
             </div>
@@ -122,7 +122,7 @@ class TotalMarketcapWidget extends Component {
               option1={WidgetMarketView.LIST}
               option2={WidgetMarketView.TOTAL}
               onClick={this.toggleMarketView}
-              style={{ width: 112 }}
+              style={{ width: 122 }}
             />
           )}
         </div>
@@ -162,7 +162,7 @@ class TotalMarketcapWidget extends Component {
               strokeWidth={1.5}
               stroke='#5275FF'
               isAnimationActive={false}
-              name={`${isListView ? 'List' : 'Total'} Marketcap`}
+              name={`${isListView ? listName : 'All Crypto'} Marketcap`}
               fill='url(#total)'
             />
             {restAreas}

--- a/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
+++ b/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
@@ -28,7 +28,7 @@ const WidgetMarketView = {
 
 class TotalMarketcapWidget extends Component {
   state = {
-    view: WidgetMarketView.TOTAL
+    view: WidgetMarketView.LIST
   }
 
   toggleMarketView = () => {
@@ -118,9 +118,9 @@ class TotalMarketcapWidget extends Component {
 
           {TOTAL_LIST_MARKET && (
             <Switch
-              isSwitched={view === WidgetMarketView.LIST}
-              option1={WidgetMarketView.TOTAL}
-              option2={WidgetMarketView.LIST}
+              isSwitched={view === WidgetMarketView.TOTAL}
+              option1={WidgetMarketView.LIST}
+              option2={WidgetMarketView.TOTAL}
               onClick={this.toggleMarketView}
               style={{ width: 112 }}
             />

--- a/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
+++ b/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
@@ -65,7 +65,7 @@ class TotalMarketcapWidget extends Component {
     if (!loading && Object.keys(restProjects).length > 0) {
       const target = isListView
         ? restProjects
-        : { [listName]: TOTAL_LIST_MARKET }
+        : { [`${listName} Marketcap`]: TOTAL_LIST_MARKET }
 
       marketcapDataset = combineDataset(marketcapDataset, target)
       restAreas = getTop3Area(target, !isListView)

--- a/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
+++ b/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
@@ -28,7 +28,10 @@ const WidgetMarketView = {
 
 class TotalMarketcapWidget extends Component {
   state = {
-    view: WidgetMarketView.LIST
+    view:
+      this.props.listName === 'All Assets'
+        ? WidgetMarketView.TOTAL
+        : WidgetMarketView.LIST
   }
 
   toggleMarketView = () => {


### PR DESCRIPTION
#### Summary
More friendly `Marketcap Widget` labels.
Labels that were changed:
- `Switch` options.
- By default `List` view is selected.
- Tooltips labels -`All Crypto` and current Watchlist title.

#### Screenshots
![image](https://user-images.githubusercontent.com/25135650/50897514-66093f80-141d-11e9-92c3-89997e029174.png)
![image](https://user-images.githubusercontent.com/25135650/50897529-6dc8e400-141d-11e9-9d8e-43ffdeb9d8a9.png)
