### PR TITLE
fix/smooth-dropdown-logic

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import { configure, addDecorator, setAddon } from '@storybook/react'
 import InfoAddon, { setDefaults } from '@storybook/addon-info'
 
@@ -8,11 +8,22 @@ setDefaults({
 })
 
 addDecorator(story => (
-  <div style={{ padding: 20, background: '#F6F6F8' }}>{story()}</div>
+  <Fragment>
+    <div id='dd-modal'>
+      <template id='dd-template'>
+        <div class='dd'>
+          <div class='dd__list' />
+          <div class='dd__arrow' />
+          <div class='dd__bg' />
+        </div>
+      </template>
+    </div>
+    <div style={{ padding: 20, background: '#F6F6F8' }}>{story()}</div>
+  </Fragment>
 ))
 setAddon(InfoAddon)
 
-function loadStories () {
+function loadStories() {
   require('../stories/index.js')
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,41 +1,146 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="theme-color" content="#000000">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="mobile-web-app-capable" content="yes">
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
-    <link rel="apple-touch-icon" sizes="57x57" href="%PUBLIC_URL%/apple-icon-57x57.png">
-    <link rel="apple-touch-icon" sizes="60x60" href="%PUBLIC_URL%/apple-icon-60x60.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="%PUBLIC_URL%/apple-icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="76x76" href="%PUBLIC_URL%/apple-icon-76x76.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="%PUBLIC_URL%/apple-icon-114x114.png">
-    <link rel="apple-touch-icon" sizes="120x120" href="%PUBLIC_URL%/apple-icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="%PUBLIC_URL%/apple-icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="%PUBLIC_URL%/apple-icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-icon-180x180.png">
-    <link rel="icon" type="image/png" sizes="192x192"  href="%PUBLIC_URL%/android-icon-192x192.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="96x96" href="%PUBLIC_URL%/favicon-96x96.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16x16.png">
-    <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/index.css">
-    <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="%PUBLIC_URL%/ms-icon-144x144.png">
-    <script
-      src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,Object.entries,Intl,Intl.~locale.en">
-    </script>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link
+      rel="apple-touch-icon"
+      sizes="57x57"
+      href="%PUBLIC_URL%/apple-icon-57x57.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="60x60"
+      href="%PUBLIC_URL%/apple-icon-60x60.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="72x72"
+      href="%PUBLIC_URL%/apple-icon-72x72.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="76x76"
+      href="%PUBLIC_URL%/apple-icon-76x76.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="114x114"
+      href="%PUBLIC_URL%/apple-icon-114x114.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="120x120"
+      href="%PUBLIC_URL%/apple-icon-120x120.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="144x144"
+      href="%PUBLIC_URL%/apple-icon-144x144.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="152x152"
+      href="%PUBLIC_URL%/apple-icon-152x152.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="%PUBLIC_URL%/apple-icon-180x180.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="192x192"
+      href="%PUBLIC_URL%/android-icon-192x192.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="%PUBLIC_URL%/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="96x96"
+      href="%PUBLIC_URL%/favicon-96x96.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="%PUBLIC_URL%/favicon-16x16.png"
+    />
+    <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/index.css" />
+    <meta name="msapplication-TileColor" content="#ffffff" />
+    <meta
+      name="msapplication-TileImage"
+      content="%PUBLIC_URL%/ms-icon-144x144.png"
+    />
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,Object.entries,Intl,Intl.~locale.en"></script>
     <title>SANbase</title>
-    <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/cyjjko9u';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>
+    <script>
+      ;(function() {
+        var w = window
+        var ic = w.Intercom
+        if (typeof ic === 'function') {
+          ic('reattach_activator')
+          ic('update', intercomSettings)
+        } else {
+          var d = document
+          var i = function() {
+            i.c(arguments)
+          }
+          i.q = []
+          i.c = function(args) {
+            i.q.push(args)
+          }
+          w.Intercom = i
+          function l() {
+            var s = d.createElement('script')
+            s.type = 'text/javascript'
+            s.async = true
+            s.src = 'https://widget.intercom.io/widget/cyjjko9u'
+            var x = d.getElementsByTagName('script')[0]
+            x.parentNode.insertBefore(s, x)
+          }
+          if (w.attachEvent) {
+            w.attachEvent('onload', l)
+          } else {
+            w.addEventListener('load', l, false)
+          }
+        }
+      })()
+    </script>
   </head>
   <body>
-    <noscript>
-      You need to enable JavaScript to run this app.
-    </noscript>
+    <noscript> You need to enable JavaScript to run this app. </noscript>
+    <div id="dd-modal">
+      <template id="dd-template">
+        <div class="dd">
+          <div class="dd__list"></div>
+          <div class="dd__arrow"></div>
+          <div class="dd__bg"></div>
+        </div>
+      </template>
+    </div>
     <div id="root"></div>
-    <script src="//rum-static.pingdom.net/pa-5ad6f5e646534f0007000702.js" async></script>
+    <script
+      src="//rum-static.pingdom.net/pa-5ad6f5e646534f0007000702.js"
+      async
+    ></script>
   </body>
 </html>
-<link href="https://fonts.googleapis.com/css?family=Nunito+Sans|Source+Sans+Pro|Rubik" rel="stylesheet">
+<link
+  href="https://fonts.googleapis.com/css?family=Nunito+Sans|Source+Sans+Pro|Rubik"
+  rel="stylesheet"
+/>

--- a/public/index.html
+++ b/public/index.html
@@ -1,129 +1,39 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <meta name="theme-color" content="#000000" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="mobile-web-app-capable" content="yes" />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link
-      rel="apple-touch-icon"
-      sizes="57x57"
-      href="%PUBLIC_URL%/apple-icon-57x57.png"
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="60x60"
-      href="%PUBLIC_URL%/apple-icon-60x60.png"
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="72x72"
-      href="%PUBLIC_URL%/apple-icon-72x72.png"
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="76x76"
-      href="%PUBLIC_URL%/apple-icon-76x76.png"
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="114x114"
-      href="%PUBLIC_URL%/apple-icon-114x114.png"
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="120x120"
-      href="%PUBLIC_URL%/apple-icon-120x120.png"
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="144x144"
-      href="%PUBLIC_URL%/apple-icon-144x144.png"
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="152x152"
-      href="%PUBLIC_URL%/apple-icon-152x152.png"
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="%PUBLIC_URL%/apple-icon-180x180.png"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="192x192"
-      href="%PUBLIC_URL%/android-icon-192x192.png"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="%PUBLIC_URL%/favicon-32x32.png"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="96x96"
-      href="%PUBLIC_URL%/favicon-96x96.png"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="16x16"
-      href="%PUBLIC_URL%/favicon-16x16.png"
-    />
-    <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/index.css" />
-    <meta name="msapplication-TileColor" content="#ffffff" />
-    <meta
-      name="msapplication-TileImage"
-      content="%PUBLIC_URL%/ms-icon-144x144.png"
-    />
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,Object.entries,Intl,Intl.~locale.en"></script>
-    <title>SANbase</title>
-    <script>
-      ;(function() {
-        var w = window
-        var ic = w.Intercom
-        if (typeof ic === 'function') {
-          ic('reattach_activator')
-          ic('update', intercomSettings)
-        } else {
-          var d = document
-          var i = function() {
-            i.c(arguments)
-          }
-          i.q = []
-          i.c = function(args) {
-            i.q.push(args)
-          }
-          w.Intercom = i
-          function l() {
-            var s = d.createElement('script')
-            s.type = 'text/javascript'
-            s.async = true
-            s.src = 'https://widget.intercom.io/widget/cyjjko9u'
-            var x = d.getElementsByTagName('script')[0]
-            x.parentNode.insertBefore(s, x)
-          }
-          if (w.attachEvent) {
-            w.attachEvent('onload', l)
-          } else {
-            w.addEventListener('load', l, false)
-          }
-        }
-      })()
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#000000">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <link rel="apple-touch-icon" sizes="57x57" href="%PUBLIC_URL%/apple-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="%PUBLIC_URL%/apple-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="%PUBLIC_URL%/apple-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="%PUBLIC_URL%/apple-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="%PUBLIC_URL%/apple-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="%PUBLIC_URL%/apple-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="%PUBLIC_URL%/apple-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="%PUBLIC_URL%/apple-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-icon-180x180.png">
+    <link rel="icon" type="image/png" sizes="192x192"  href="%PUBLIC_URL%/android-icon-192x192.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="%PUBLIC_URL%/favicon-96x96.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16x16.png">
+    <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/index.css">
+    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="msapplication-TileImage" content="%PUBLIC_URL%/ms-icon-144x144.png">
+    <script
+      src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,Object.entries,Intl,Intl.~locale.en">
     </script>
+    <title>SANbase</title>
+    <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/cyjjko9u';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>
   </head>
   <body>
-    <noscript> You need to enable JavaScript to run this app. </noscript>
+    <noscript>
+      You need to enable JavaScript to run this app.
+    </noscript>
     <div id="dd-modal">
       <template id="dd-template">
         <div class="dd">
@@ -134,13 +44,7 @@
       </template>
     </div>
     <div id="root"></div>
-    <script
-      src="//rum-static.pingdom.net/pa-5ad6f5e646534f0007000702.js"
-      async
-    ></script>
+    <script src="//rum-static.pingdom.net/pa-5ad6f5e646534f0007000702.js" async></script>
   </body>
 </html>
-<link
-  href="https://fonts.googleapis.com/css?family=Nunito+Sans|Source+Sans+Pro|Rubik"
-  rel="stylesheet"
-/>
+<link href="https://fonts.googleapis.com/css?family=Nunito+Sans|Source+Sans+Pro|Rubik" rel="stylesheet">

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -5,6 +5,9 @@ import './SmoothDropdown.css'
 
 export const ddAsyncUpdateTimeout = 95
 
+const modalRoot = document.getElementById('dd-modal')
+const ddTemplate = modalRoot.querySelector('#dd-template').content
+
 export const SmoothDropdownContext = React.createContext({
   portal: {},
   currentTrigger: null,
@@ -17,6 +20,13 @@ export const SmoothDropdownContext = React.createContext({
 class SmoothDropdown extends Component {
   portalRef = React.createRef()
   dropdownWrapperRef = React.createRef()
+
+  /* portalContainer = document.createElement('div') */
+
+  ddContainer = ddTemplate.cloneNode(true).firstElementChild
+
+  portalContainer = this.ddContainer.querySelector('.dd__list')
+  bgEl = this.ddContainer.querySelector('dd__bg')
 
   state = {
     currentTrigger: null,
@@ -34,10 +44,13 @@ class SmoothDropdown extends Component {
   }
 
   componentDidMount () {
-    this.mountTimer = setTimeout(() => this.forceUpdate(), ddAsyncUpdateTimeout) // HACK TO POPULATE PORTAL AND UPDATE REFS
+    /* this.mountTimer = setTimeout(() => this.forceUpdate(), ddAsyncUpdateTimeout) // HACK TO POPULATE PORTAL AND UPDATE REFS */
+    /* this.portalContainer.classList.add('dd__list') */
+    modalRoot.appendChild(this.ddContainer)
   }
   componentWillUnmount () {
-    clearTimeout(this.mountTimer)
+    modalRoot.removeChild(this.ddContainer)
+    /* clearTimeout(this.mountTimer) */
     this.portalRef = null
     this.dropdownWrapperRef = null
   }
@@ -127,6 +140,13 @@ class SmoothDropdown extends Component {
       startCloseTimeout,
       stopCloseTimeout
     } = this
+
+    this.ddContainer.classList.toggle(
+      'has-dropdown-active',
+      currentTrigger !== null
+    )
+    this.ddContainer.classList.toggle('dd-first-time', ddFirstTime)
+
     return (
       <div
         ref={this.dropdownWrapperRef}
@@ -134,7 +154,7 @@ class SmoothDropdown extends Component {
       >
         <SmoothDropdownContext.Provider
           value={{
-            portal: this.portalRef.current || document.createElement('ul'),
+            portal: this.portalContainer,
             currentTrigger,
             handleMouseEnter,
             handleMouseLeave,
@@ -151,7 +171,7 @@ class SmoothDropdown extends Component {
               'dd-first-time': ddFirstTime
             })}
           >
-            <div className='dd__list' ref={this.portalRef} />
+            {/* <div className='dd__list' ref={this.portalRef} /> */}
             <div
               className='dd__arrow'
               style={{ left: `calc(50% + ${arrowCorrectionX}px)` }}

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -4,8 +4,6 @@ import ReactDOM from 'react-dom'
 import cx from 'classnames'
 import './SmoothDropdown.css'
 
-export const ddAsyncUpdateTimeout = 95
-
 const modalRoot = document.getElementById('dd-modal')
 const ddTemplate = modalRoot.querySelector('#dd-template').content
 

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -79,9 +79,10 @@ class SmoothDropdown extends Component {
 
   setupDropdownContent = (ddItem, ddContent) => {
     this.ddItemsRef.set(ddItem, React.createRef())
-    this.setState({
-      ddItems: new Map([...this.state.ddItems, [ddItem, ddContent]])
-    })
+    this.setState(prevState => ({
+      ...prevState,
+      ddItems: new Map([...prevState.ddItems, [ddItem, ddContent]])
+    }))
   }
 
   openDropdown = (ddItem, trigger) => {

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -5,7 +5,12 @@ import cx from 'classnames'
 import './SmoothDropdown.css'
 
 const modalRoot = document.getElementById('dd-modal')
-const ddTemplate = modalRoot.querySelector('#dd-template').content
+
+let ddTemplate
+
+if (modalRoot) {
+  ddTemplate = modalRoot.querySelector('#dd-template').content
+}
 
 export const SmoothDropdownContext = React.createContext({
   handleMouseEnter: () => {},

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -25,12 +25,6 @@ class SmoothDropdown extends Component {
 
   ddContainer = ddTemplate.cloneNode(true).firstElementChild
 
-  portalContainer = this.ddContainer.querySelector('.dd__list')
-
-  bgNode = this.ddContainer.querySelector('.dd__bg')
-
-  arrowNode = this.ddContainer.querySelector('.dd__arrow')
-
   ddItemsRef = new WeakMap()
 
   state = {
@@ -61,6 +55,12 @@ class SmoothDropdown extends Component {
     this.arrowNode = null
     this.portalRef = null
     this.dropdownWrapperRef = null
+  }
+
+  componentWillMount () {
+    this.portalContainer = this.ddContainer.querySelector('.dd__list')
+    this.bgNode = this.ddContainer.querySelector('.dd__bg')
+    this.arrowNode = this.ddContainer.querySelector('.dd__arrow')
   }
 
   startCloseTimeout = () => {

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -101,9 +101,10 @@ class SmoothDropdown extends Component {
     const leftOffset =
       triggerLeft - (ddContent.clientWidth - trigger.clientWidth) / 2
 
-    const topOffset = this.props.verticalMotion
-      ? triggerTop + triggerHeight - ddWrapperHeight
-      : ddWrapperTop + ddWrapperHeight + window.scrollY
+    const topOffset =
+      (this.props.verticalMotion
+        ? triggerTop + triggerHeight
+        : ddWrapperTop + ddWrapperHeight) + window.scrollY
 
     const correction = this.getViewportOverflowCorrection(trigger, ddContent)
 

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -151,7 +151,7 @@ class SmoothDropdown extends Component {
   }
 
   render () {
-    const { children, className } = this.props
+    const { children, className = '' } = this.props
     const {
       currentTrigger,
       dropdownStyles,
@@ -176,10 +176,7 @@ class SmoothDropdown extends Component {
     this.arrowNode.style.left = `calc(50% + ${arrowCorrectionX}px)`
 
     return (
-      <div
-        ref={this.dropdownWrapperRef}
-        className={`dd-wrapper ${className || ''}`}
-      >
+      <div ref={this.dropdownWrapperRef} className={`dd-wrapper ${className}`}>
         <SmoothDropdownContext.Provider
           value={{
             handleMouseEnter,
@@ -202,7 +199,6 @@ class SmoothDropdown extends Component {
               >
                 <div
                   className={`dd__content `}
-                  // {/* NOTE(vanguard): Fix dynamic class*/}
                   onMouseEnter={stopCloseTimeout}
                   onMouseLeave={startCloseTimeout}
                 >

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -20,8 +20,6 @@ class SmoothDropdown extends Component {
 
   dropdownWrapperRef = React.createRef()
 
-  /* portalContainer = document.createElement('div') */
-
   ddContainer = ddTemplate.cloneNode(true).firstElementChild
 
   portalContainer = this.ddContainer.querySelector('.dd__list')

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -71,20 +71,21 @@ class SmoothDropdown extends Component {
     if (!dropdownItem) return
 
     const ddContent = dropdownItem.querySelector('.dd__content')
+    const {
+      top: triggerTop,
+      left: triggerLeft,
+      height: triggerHeight
+    } = trigger.getBoundingClientRect()
 
     const leftOffset =
-      trigger.offsetLeft - (ddContent.clientWidth - trigger.clientWidth) / 2
+      triggerLeft - (ddContent.clientWidth - trigger.clientWidth) / 2
 
-    const topOffset = this.props.verticalMotion
-      ? trigger.offsetTop +
-        trigger.offsetHeight -
-        this.dropdownWrapperRef.current.offsetHeight
-      : 0
+    const topOffset = triggerTop + triggerHeight
 
     const correction = this.getViewportOverflowCorrection(trigger, ddContent)
 
     const left = leftOffset - correction.left + 'px'
-    const top = `calc(100% + ${10 + topOffset}px)`
+    const top = topOffset + 'px'
     const width = ddContent.clientWidth + 'px'
     const height = ddContent.clientHeight + 'px'
 
@@ -146,7 +147,7 @@ class SmoothDropdown extends Component {
       currentTrigger !== null
     )
     this.ddContainer.classList.toggle('dd-first-time', ddFirstTime)
-
+    Object.assign(this.ddContainer.style, dropdownStyles)
     return (
       <div
         ref={this.dropdownWrapperRef}

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -10,17 +10,14 @@ const modalRoot = document.getElementById('dd-modal')
 const ddTemplate = modalRoot.querySelector('#dd-template').content
 
 export const SmoothDropdownContext = React.createContext({
-  portal: {},
-  currentTrigger: null,
   handleMouseEnter: () => {},
   handleMouseLeave: () => {},
-  startCloseTimeout: () => {},
-  stopCloseTimeout: () => {},
   setupDropdownContent: () => {}
 })
 
 class SmoothDropdown extends Component {
   portalRef = React.createRef()
+
   dropdownWrapperRef = React.createRef()
 
   /* portalContainer = document.createElement('div') */
@@ -28,8 +25,12 @@ class SmoothDropdown extends Component {
   ddContainer = ddTemplate.cloneNode(true).firstElementChild
 
   portalContainer = this.ddContainer.querySelector('.dd__list')
+
   bgNode = this.ddContainer.querySelector('.dd__bg')
+
   arrowNode = this.ddContainer.querySelector('.dd__arrow')
+
+  ddItemsRef = new WeakMap()
 
   state = {
     currentTrigger: null,
@@ -48,13 +49,11 @@ class SmoothDropdown extends Component {
   }
 
   componentDidMount () {
-    /* this.mountTimer = setTimeout(() => this.forceUpdate(), ddAsyncUpdateTimeout) // HACK TO POPULATE PORTAL AND UPDATE REFS */
-    /* this.portalContainer.classList.add('dd__list') */
     modalRoot.appendChild(this.ddContainer)
   }
+
   componentWillUnmount () {
     modalRoot.removeChild(this.ddContainer)
-    /* clearTimeout(this.mountTimer) */
     this.ddContainer = null
     this.portalContainer = null
     this.bgNode = null
@@ -63,8 +62,9 @@ class SmoothDropdown extends Component {
     this.dropdownWrapperRef = null
   }
 
-  startCloseTimeout = () =>
-    (this.dropdownTimer = setTimeout(() => this.closeDropdown(), 150))
+  startCloseTimeout = () => {
+    this.dropdownTimer = setTimeout(() => this.closeDropdown(), 150)
+  }
 
   stopCloseTimeout = () => clearTimeout(this.dropdownTimer)
 
@@ -74,8 +74,6 @@ class SmoothDropdown extends Component {
   }
 
   handleMouseLeave = () => this.startCloseTimeout()
-
-  ddItemsRef = new WeakMap()
 
   setupDropdownContent = (ddItem, ddContent) => {
     this.ddItemsRef.set(ddItem, React.createRef())
@@ -170,7 +168,6 @@ class SmoothDropdown extends Component {
       setupDropdownContent
     } = this
 
-    console.log(currentTrigger)
     this.ddContainer.classList.toggle(
       'has-dropdown-active',
       currentTrigger !== null
@@ -186,12 +183,8 @@ class SmoothDropdown extends Component {
       >
         <SmoothDropdownContext.Provider
           value={{
-            portal: this.portalContainer,
-            currentTrigger,
             handleMouseEnter,
             handleMouseLeave,
-            startCloseTimeout,
-            stopCloseTimeout,
             setupDropdownContent
           }}
         >

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -52,6 +52,10 @@ class SmoothDropdown extends Component {
   componentWillUnmount () {
     modalRoot.removeChild(this.ddContainer)
     /* clearTimeout(this.mountTimer) */
+    this.ddContainer = null
+    this.portalContainer = null
+    this.bgNode = null
+    this.arrowNode = null
     this.portalRef = null
     this.dropdownWrapperRef = null
   }
@@ -73,6 +77,10 @@ class SmoothDropdown extends Component {
 
     const ddContent = dropdownItem.querySelector('.dd__content')
     const {
+      height: ddWrapperHeight,
+      top: ddWrapperTop
+    } = this.dropdownWrapperRef.current.getBoundingClientRect()
+    const {
       top: triggerTop,
       left: triggerLeft,
       height: triggerHeight
@@ -82,10 +90,8 @@ class SmoothDropdown extends Component {
       triggerLeft - (ddContent.clientWidth - trigger.clientWidth) / 2
 
     const topOffset = this.props.verticalMotion
-      ? triggerTop +
-        triggerHeight -
-        this.dropdownWrapperRef.current.offsetHeight
-      : this.dropdownWrapperRef.current.offsetHeight
+      ? triggerTop + triggerHeight - ddWrapperHeight
+      : ddWrapperTop + ddWrapperHeight + window.scrollY
 
     const correction = this.getViewportOverflowCorrection(trigger, ddContent)
 
@@ -147,6 +153,7 @@ class SmoothDropdown extends Component {
       stopCloseTimeout
     } = this
 
+    console.log(currentTrigger)
     this.ddContainer.classList.toggle(
       'has-dropdown-active',
       currentTrigger !== null
@@ -154,6 +161,7 @@ class SmoothDropdown extends Component {
     this.ddContainer.classList.toggle('dd-first-time', ddFirstTime)
     Object.assign(this.ddContainer.style, dropdownStyles)
     this.arrowNode.style.left = `calc(50% + ${arrowCorrectionX}px)`
+
     return (
       <div
         ref={this.dropdownWrapperRef}
@@ -170,21 +178,6 @@ class SmoothDropdown extends Component {
           }}
         >
           {children}
-          <div
-            style={dropdownStyles}
-            className={cx({
-              dd: true,
-              'has-dropdown-active': currentTrigger !== null,
-              'dd-first-time': ddFirstTime
-            })}
-          >
-            {/* <div className='dd__list' ref={this.portalRef} /> */}
-            <div
-              className='dd__arrow'
-              style={{ left: `calc(50% + ${arrowCorrectionX}px)` }}
-            />
-            <div className='dd__bg' />
-          </div>
         </SmoothDropdownContext.Provider>
       </div>
     )

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -26,7 +26,8 @@ class SmoothDropdown extends Component {
   ddContainer = ddTemplate.cloneNode(true).firstElementChild
 
   portalContainer = this.ddContainer.querySelector('.dd__list')
-  bgEl = this.ddContainer.querySelector('dd__bg')
+  bgNode = this.ddContainer.querySelector('.dd__bg')
+  arrowNode = this.ddContainer.querySelector('.dd__arrow')
 
   state = {
     currentTrigger: null,
@@ -80,12 +81,16 @@ class SmoothDropdown extends Component {
     const leftOffset =
       triggerLeft - (ddContent.clientWidth - trigger.clientWidth) / 2
 
-    const topOffset = triggerTop + triggerHeight
+    const topOffset = this.props.verticalMotion
+      ? triggerTop +
+        triggerHeight -
+        this.dropdownWrapperRef.current.offsetHeight
+      : this.dropdownWrapperRef.current.offsetHeight
 
     const correction = this.getViewportOverflowCorrection(trigger, ddContent)
 
     const left = leftOffset - correction.left + 'px'
-    const top = topOffset + 'px'
+    const top = 10 + topOffset + 'px'
     const width = ddContent.clientWidth + 'px'
     const height = ddContent.clientHeight + 'px'
 
@@ -148,6 +153,7 @@ class SmoothDropdown extends Component {
     )
     this.ddContainer.classList.toggle('dd-first-time', ddFirstTime)
     Object.assign(this.ddContainer.style, dropdownStyles)
+    this.arrowNode.style.left = `calc(50% + ${arrowCorrectionX}px)`
     return (
       <div
         ref={this.dropdownWrapperRef}

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -68,9 +68,9 @@ class SmoothDropdown extends Component {
 
   stopCloseTimeout = () => clearTimeout(this.dropdownTimer)
 
-  handleMouseEnter = (ddItem, trigger, dropdownItem) => {
+  handleMouseEnter = (ddItem, trigger) => {
     this.stopCloseTimeout()
-    this.openDropdown(ddItem, trigger, dropdownItem)
+    this.openDropdown(ddItem, trigger)
   }
 
   handleMouseLeave = () => this.startCloseTimeout()
@@ -84,8 +84,6 @@ class SmoothDropdown extends Component {
   }
 
   openDropdown = (ddItem, trigger) => {
-    /* console.log(this.state.ddItems, ddItem) */
-    /* console.log(this.ddItemsRef.get(ddItem)) */
     const dropdownItem = this.ddItemsRef.get(ddItem).current
     if (!dropdownItem) return
 

--- a/src/components/SmoothDropdown/SmoothDropdownItem.js
+++ b/src/components/SmoothDropdown/SmoothDropdownItem.js
@@ -22,7 +22,7 @@ class SmoothDropdownItem extends Component {
   }
 
   render () {
-    const { trigger, children, className, showIf } = this.props
+    const { trigger, children, showIf } = this.props
     const {
       triggerRef: { current: ddTrigger }
     } = this
@@ -36,7 +36,7 @@ class SmoothDropdownItem extends Component {
             <div
               onMouseEnter={evt => {
                 if (showIf ? showIf(evt) : true) {
-                  handleMouseEnter(this, ddTrigger, children)
+                  handleMouseEnter(this, ddTrigger)
                 }
               }}
               onMouseLeave={handleMouseLeave}

--- a/src/components/SmoothDropdown/SmoothDropdownItem.js
+++ b/src/components/SmoothDropdown/SmoothDropdownItem.js
@@ -19,7 +19,7 @@ class SmoothDropdownItem extends Component {
   }
 
   componentDidMount () {
-    this.mountTimer = setTimeout(() => this.forceUpdate(), 0) // VERY HACKY - NECESSARY TO UPDATE DROPDOWN IN DOM
+    this.mountTimer = setTimeout(() => this.forceUpdate(), 50) // VERY HACKY - NECESSARY TO UPDATE DROPDOWN IN DOM
   }
   componentWillUnmount () {
     clearTimeout(this.mountTimer)
@@ -45,13 +45,14 @@ class SmoothDropdownItem extends Component {
           handleMouseLeave,
           currentTrigger,
           startCloseTimeout,
-          stopCloseTimeout
+          stopCloseTimeout,
+          setupDropdownContent
         }) => (
           <Fragment>
             <div
               onMouseEnter={evt => {
                 if (showIf ? showIf(evt) : true) {
-                  handleMouseEnter(ddTrigger, ddDropdown)
+                  handleMouseEnter(this, ddTrigger, children)
                 }
               }}
               onMouseLeave={handleMouseLeave}
@@ -60,25 +61,7 @@ class SmoothDropdownItem extends Component {
             >
               {trigger}
             </div>
-            {ReactDOM.createPortal(
-              <div
-                id={id}
-                className={cx({
-                  dd__item: true,
-                  active: ddTrigger === currentTrigger
-                })}
-                ref={this.dropdownRef}
-              >
-                <div
-                  className={`dd__content ${className || ''}`}
-                  onMouseEnter={stopCloseTimeout}
-                  onMouseLeave={startCloseTimeout}
-                >
-                  {children}
-                </div>
-              </div>,
-              portal
-            )}
+            {setupDropdownContent(this, children)}
           </Fragment>
         )}
       </SmoothDropdownContext.Consumer>

--- a/src/components/SmoothDropdown/SmoothDropdownItem.js
+++ b/src/components/SmoothDropdown/SmoothDropdownItem.js
@@ -39,15 +39,7 @@ class SmoothDropdownItem extends Component {
     }
     return (
       <SmoothDropdownContext.Consumer>
-        {({
-          portal,
-          handleMouseEnter,
-          handleMouseLeave,
-          currentTrigger,
-          startCloseTimeout,
-          stopCloseTimeout,
-          setupDropdownContent
-        }) => (
+        {({ handleMouseEnter, handleMouseLeave, setupDropdownContent }) => (
           <Fragment>
             <div
               onMouseEnter={evt => {

--- a/src/components/SmoothDropdown/SmoothDropdownItem.js
+++ b/src/components/SmoothDropdown/SmoothDropdownItem.js
@@ -1,39 +1,31 @@
 import React, { Component, Fragment } from 'react'
-import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
-import cx from 'classnames'
-import { SmoothDropdownContext, ddAsyncUpdateTimeout } from './SmoothDropdown'
-
-const ddItemAsyncUpdateTimeout = ddAsyncUpdateTimeout + 5
+import { SmoothDropdownContext } from './SmoothDropdown'
 
 class SmoothDropdownItem extends Component {
-  dropdownRef = React.createRef()
   triggerRef = React.createRef()
 
   static propTypes = {
     children: PropTypes.oneOfType([PropTypes.element, PropTypes.string])
       .isRequired,
     trigger: PropTypes.element.isRequired,
-    showIf: PropTypes.func,
-    id: PropTypes.string
+    showIf: PropTypes.func
   }
 
   componentDidMount () {
-    this.mountTimer = setTimeout(() => this.forceUpdate(), 50) // VERY HACKY - NECESSARY TO UPDATE DROPDOWN IN DOM
+    this.mountTimer = setTimeout(() => this.forceUpdate(), 0) // VERY HACKY - NECESSARY TO UPDATE DROPDOWN IN DOM
   }
+
   componentWillUnmount () {
     clearTimeout(this.mountTimer)
-    this.dropdownRef = null
     this.triggerRef = null
   }
 
   render () {
-    const { trigger, children, id, className, showIf } = this.props
+    const { trigger, children, className, showIf } = this.props
     const {
-      triggerRef: { current: ddTrigger },
-      dropdownRef: { current: ddDropdown }
+      triggerRef: { current: ddTrigger }
     } = this
-    console.log('Waiting for rerender')
     if (!trigger) {
       return null
     }

--- a/src/components/SmoothDropdown/SmoothDropdownItem.js
+++ b/src/components/SmoothDropdown/SmoothDropdownItem.js
@@ -19,10 +19,7 @@ class SmoothDropdownItem extends Component {
   }
 
   componentDidMount () {
-    this.mountTimer = setTimeout(
-      () => this.forceUpdate(),
-      ddItemAsyncUpdateTimeout
-    ) // VERY HACKY - NECESSARY TO UPDATE DROPDOWN IN DOM
+    this.mountTimer = setTimeout(() => this.forceUpdate(), 0) // VERY HACKY - NECESSARY TO UPDATE DROPDOWN IN DOM
   }
   componentWillUnmount () {
     clearTimeout(this.mountTimer)
@@ -36,6 +33,7 @@ class SmoothDropdownItem extends Component {
       triggerRef: { current: ddTrigger },
       dropdownRef: { current: ddDropdown }
     } = this
+    console.log('Waiting for rerender')
     if (!trigger) {
       return null
     }

--- a/src/pages/assets/AssetsPageNavigation.js
+++ b/src/pages/assets/AssetsPageNavigation.js
@@ -36,50 +36,48 @@ const AssetsPageNavigation = ({ isLoggedIn = false, location: { search } }) => (
         Currencies
       </Link>
       <SmoothDropdown>
-        <SmoothDropdownItem
-          className='assets-navigation-popup'
-          trigger={EthereumBtn}
-        >
-          <Link
-            activeClassName='assets-navigation-list__dropdown-link--active'
-            className='assets-navigation-list__dropdown-link'
-            to={'/assets/erc20'}
-          >
-            ERC20 Assets
-          </Link>
-          <Link
-            activeClassName='projects-navigation-list__dropdown-link--active'
-            className='assets-navigation-list__dropdown-link'
-            to={'/ethereum-spent'}
-          >
-            ETH Spent
-          </Link>
+        <SmoothDropdownItem trigger={EthereumBtn}>
+          <div className='assets-navigation-popup'>
+            <Link
+              activeClassName='assets-navigation-list__dropdown-link--active'
+              className='assets-navigation-list__dropdown-link'
+              to={'/assets/erc20'}
+            >
+              ERC20 Assets
+            </Link>
+            <Link
+              activeClassName='projects-navigation-list__dropdown-link--active'
+              className='assets-navigation-list__dropdown-link'
+              to={'/ethereum-spent'}
+            >
+              ETH Spent
+            </Link>
+          </div>
         </SmoothDropdownItem>
-        <SmoothDropdownItem
-          className='assets-navigation-popup'
-          trigger={CategoriesBtn}
-        >
-          <Link
-            activeClassName='assets-navigation-list__dropdown-link--active'
-            className='assets-navigation-list__dropdown-link'
-            to={'/assets/list?name=stablecoins@86#shared'}
-          >
-            Stablecoins
-          </Link>
-          <Link
-            activeClassName='projects-navigation-list__dropdown-link--active'
-            className='assets-navigation-list__dropdown-link'
-            to={'/assets/list?name=usa@138#shared'}
-          >
-            US based assets
-          </Link>
-          <Link
-            activeClassName='projects-navigation-list__dropdown-link--active'
-            className='assets-navigation-list__dropdown-link'
-            to={'/assets/list?name=dex@127#shared'}
-          >
-            Decentralized Exchanges Tokens (DEXs)
-          </Link>
+        <SmoothDropdownItem trigger={CategoriesBtn}>
+          <div class='assets-navigation-popup'>
+            <Link
+              activeClassName='assets-navigation-list__dropdown-link--active'
+              className='assets-navigation-list__dropdown-link'
+              to={'/assets/list?name=stablecoins@86#shared'}
+            >
+              Stablecoins
+            </Link>
+            <Link
+              activeClassName='projects-navigation-list__dropdown-link--active'
+              className='assets-navigation-list__dropdown-link'
+              to={'/assets/list?name=usa@138#shared'}
+            >
+              US based assets
+            </Link>
+            <Link
+              activeClassName='projects-navigation-list__dropdown-link--active'
+              className='assets-navigation-list__dropdown-link'
+              to={'/assets/list?name=dex@127#shared'}
+            >
+              Decentralized Exchanges Tokens (DEXs)
+            </Link>
+          </div>
         </SmoothDropdownItem>
         <SmoothDropdownItem trigger={MyListBtn}>
           <WatchlistsPopup

--- a/src/pages/assets/AssetsPageNavigation.js
+++ b/src/pages/assets/AssetsPageNavigation.js
@@ -55,7 +55,7 @@ const AssetsPageNavigation = ({ isLoggedIn = false, location: { search } }) => (
           </div>
         </SmoothDropdownItem>
         <SmoothDropdownItem trigger={CategoriesBtn}>
-          <div class='assets-navigation-popup'>
+          <div className='assets-navigation-popup'>
             <Link
               activeClassName='assets-navigation-list__dropdown-link--active'
               className='assets-navigation-list__dropdown-link'


### PR DESCRIPTION
#### Summary
Refactoring of the `SmoothDropdown` logic.
 `SmoothDropdown` interface was not changed. 

The main change is that now `index.html` has a static `div.dd-modal` node which will be used as a portal.

##### Persisting problem
It is still necessary to asynchronously `forceUpdate` a `SmoothDropdownItem` component in order to get the `trigger` DOM `ref`. For the `n` `SmoothDropdownItem`'s there will be `n` extra updates, which are almost free  (because `trigger` almost never has complicated node hierarchy).