### PR TITLE
enhance/marketcap-widget-ui

### DIFF
--- a/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
+++ b/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
@@ -183,11 +183,6 @@ class TotalMarketcapWidget extends Component {
               orientation='right'
               tickFormatter={marketcap => millify(marketcap)}
             />
-            <CartesianGrid
-              stroke='#EBEEF5'
-              vertical={false}
-              strokeDasharray='5 10'
-            />
 
             {listYAxis}
             <Tooltip

--- a/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
+++ b/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
@@ -6,7 +6,7 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  margin: 36px 0 84px;
+  margin: 36px 0 0;
   &__label,
   &__value {
     font-family: Rubik;


### PR DESCRIPTION
#### Summary
* Removed padding between the `TotalmarketcapWidget` and the beginning of the table.
* Removed `CartesianGrid` because in current design in any variation it looks visually disturbing.