### PR TITLE
fix/mergetimeseriesbykey-logic

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -144,14 +144,19 @@ const mergeTimeseriesByKey = ({ timeseries, key: mergeKey }) => {
     }
 
     if (mergeKey === 'datetime') {
+      let timeserieMergeCount = 0
+
       for (
         ;
         moment(longestTS[longestTSRightIndexBoundary]['datetime']).isBefore(
           moment(timeserie[timeserieRightIndex]['datetime'])
-        );
+        ) && timeserieRightIndex > -1;
         timeserieRightIndex--
       ) {
-        longestTS.push(timeserie[timeserieRightIndex])
+        timeserieMergeCount++
+      }
+      if (timeserieMergeCount > 0) {
+        longestTS.push(...timeserie.slice(-timeserieMergeCount))
       }
     }
 

--- a/src/utils/utils.spec.js
+++ b/src/utils/utils.spec.js
@@ -195,6 +195,10 @@ describe('mergeTimeseriesByKey', () => {
     {
       value5: 52,
       datetime: '2018-09-20T00:00:00Z'
+    },
+    {
+      value5: 53,
+      datetime: '2018-10-20T00:00:00Z'
     }
   ]
 
@@ -241,11 +245,15 @@ describe('mergeTimeseriesByKey', () => {
       {
         value5: 52,
         datetime: '2018-09-20T00:00:00Z'
+      },
+      {
+        value5: 53,
+        datetime: '2018-10-20T00:00:00Z'
       }
     ]
 
     const expected = mergeTimeseriesByKey({
-      timeseries: [ts2, ts5],
+      timeseries: [ts5, ts2],
       key: 'datetime'
     })
     expect(expected).toEqual(goodMerged)


### PR DESCRIPTION
#### Summary
Updated logic of the `mergeTimeseriesByKey` function. 
The main change:
* Additional check for the existing element when extra-merging;
* Fixed reverse data representation when extra-merging; 