### PR TITLE
enhance/smoothdropdown-screen-edge-x-offset

### DIFF
--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -38,7 +38,8 @@ const rightBtns = [
 const Navbar = ({ activeLink = '/', isLoggedIn }) => {
   return (
     <SmoothDropdown
-      verticalOffset={-25}
+      screenEdgeXOffset={5}
+      verticalOffset={-15}
       showArrow={false}
       className={styles.wrapper}
     >

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -116,7 +116,7 @@ class SmoothDropdown extends Component {
       triggerLeft - (ddContent.clientWidth - trigger.clientWidth) / 2
 
     const topOffset =
-      (this.props.verticalMotion
+      (verticalMotion
         ? triggerTop + triggerHeight
         : ddWrapperTop + ddWrapperHeight) + window.scrollY
 

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -148,8 +148,9 @@ class SmoothDropdown extends Component {
   }
 
   getViewportOverflowCorrection (trigger, ddContent) {
-    const correction = { left: 0 }
     const { screenEdgeXOffset } = this.props
+
+    const correction = { left: 0 }
     const triggerViewport = trigger.getBoundingClientRect()
 
     const ddLeftCornerX =

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -42,13 +42,15 @@ class SmoothDropdown extends Component {
     ]).isRequired,
     showArrow: PropTypes.bool,
     verticalMotion: PropTypes.bool,
-    verticalOffset: PropTypes.number
+    verticalOffset: PropTypes.number,
+    screenEdgeXOffset: PropTypes.number
   }
 
   static defaultProps = {
     verticalMotion: false,
     showArrow: true,
-    verticalOffset: 0
+    verticalOffset: 10,
+    screenEdgeXOffset: 10
   }
 
   componentDidMount () {
@@ -121,7 +123,7 @@ class SmoothDropdown extends Component {
     const correction = this.getViewportOverflowCorrection(trigger, ddContent)
 
     const left = leftOffset - correction.left + 'px'
-    const top = 10 + topOffset + 'px'
+    const top = topOffset + verticalOffset + 'px'
     const width = ddContent.clientWidth + 'px'
     const height = ddContent.clientHeight + 'px'
     this.setState(prevState => ({
@@ -147,6 +149,7 @@ class SmoothDropdown extends Component {
 
   getViewportOverflowCorrection (trigger, ddContent) {
     const correction = { left: 0 }
+    const { screenEdgeXOffset } = this.props
     const triggerViewport = trigger.getBoundingClientRect()
 
     const ddLeftCornerX =
@@ -154,9 +157,9 @@ class SmoothDropdown extends Component {
     const ddRightCornerX = ddLeftCornerX + ddContent.clientWidth
 
     if (ddRightCornerX > window.innerWidth) {
-      correction.left = ddRightCornerX - window.innerWidth
+      correction.left = ddRightCornerX - window.innerWidth + screenEdgeXOffset
     } else if (ddLeftCornerX < 0) {
-      correction.left = ddLeftCornerX
+      correction.left = ddLeftCornerX - screenEdgeXOffset
     }
 
     return correction


### PR DESCRIPTION
#### Summary
`SmoothDropdown` component now provides the `screenEdgeXOffset` prop to specify padding between the `DropdownItem` and the edge of the screen. By default `screenEdgeXOffset` has 10 pixels value.