### PR TITLE
fix/marketcap-widget-switch-to-select

### DIFF
--- a/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
+++ b/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import moment from 'moment'
 import cx from 'classnames'
-import { Switch } from '@santiment-network/ui'
+import { Selector } from '@santiment-network/ui'
 import {
   ResponsiveContainer,
   AreaChart,
@@ -34,12 +34,9 @@ class TotalMarketcapWidget extends Component {
         : WidgetMarketView.LIST
   }
 
-  toggleMarketView = () => {
+  toggleMarketView = view => {
     this.setState({
-      view:
-        this.state.view === WidgetMarketView.LIST
-          ? WidgetMarketView.TOTAL
-          : WidgetMarketView.LIST
+      view
     })
   }
 
@@ -120,11 +117,11 @@ class TotalMarketcapWidget extends Component {
           </div>
 
           {TOTAL_LIST_MARKET && (
-            <Switch
-              isSwitched={view === WidgetMarketView.TOTAL}
-              option1={WidgetMarketView.LIST}
-              option2={WidgetMarketView.TOTAL}
-              onClick={this.toggleMarketView}
+            <Selector
+              variant='border'
+              options={[WidgetMarketView.LIST, WidgetMarketView.TOTAL]}
+              defaultSelected={WidgetMarketView.LIST}
+              onSelectOption={this.toggleMarketView}
               style={{ width: 122 }}
             />
           )}


### PR DESCRIPTION
#### Summary
[This bug](https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/9ff267872fcd8b7925f1d7c7?card=San-3784) was caused by the incorrect use of the `sun-ui`. `TotalMarketcapWidget` now uses `Selector` component instead of the removed `Switch`.