### PR TITLE
fix/smooth-dd-box-sizing

### DIFF
--- a/src/components/SmoothDropdown/SmoothDropdown.css
+++ b/src/components/SmoothDropdown/SmoothDropdown.css
@@ -25,6 +25,7 @@
 
 .dd__bg {
   background-color: #fff;
+  box-sizing: border-box;
   transition: 0.25s ease;
   border-radius: 4px;
   overflow: hidden;


### PR DESCRIPTION
#### Summary
`SmoothDropdown` background now has `box-sizing: border-box` in order to have proper width and height.