### PR TITLE
fix/post-visual-backtest-crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-form": "^2.16.1",
     "react-ga": "^2.3.5",
     "react-helmet": "^5.2.0",
+    "react-lazyload": "^2.5.0",
     "react-loadable": "^5.3.1",
     "react-notification": "^6.8.2",
     "react-redux": "^5.0.6",

--- a/src/components/PercentChanges.js
+++ b/src/components/PercentChanges.js
@@ -3,8 +3,8 @@ import cx from 'classnames'
 import './PercentChanges.css'
 
 export const PercentChanges = ({ changes, className }) => {
-  if (!changes) {
-    return ''
+  if (changes === 0) {
+    return 'has not changed'
   }
   const normalizedChanges = parseFloat(changes).toFixed(2)
   return (

--- a/src/components/PostList.js
+++ b/src/components/PostList.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { createSkeletonProvider } from '@trainline/react-skeletor'
+import LazyLoad from 'react-lazyload'
 import Post from './Post.js'
 import './PostList.css'
 
@@ -18,18 +19,19 @@ const PostList = ({
 }) => (
   <div className='event-posts-list'>
     {Object.keys(posts).map((key, index) => (
-      <Post
-        showStatus={!!userId}
-        index={index + 1}
-        key={posts[index].id}
-        balance={balance}
-        votePost={votePost}
-        unvotePost={unvotePost}
-        deletePost={deletePost}
-        publishPost={publishPost}
-        gotoInsight={gotoInsight}
-        {...posts[key]}
-      />
+      <LazyLoad offset={1000} key={posts[index].id}>
+        <Post
+          showStatus={!!userId}
+          index={index + 1}
+          balance={balance}
+          votePost={votePost}
+          unvotePost={unvotePost}
+          deletePost={deletePost}
+          publishPost={publishPost}
+          gotoInsight={gotoInsight}
+          {...posts[key]}
+        />
+      </LazyLoad>
     ))}
   </div>
 )

--- a/src/components/PostList.js
+++ b/src/components/PostList.js
@@ -19,7 +19,7 @@ const PostList = ({
 }) => (
   <div className='event-posts-list'>
     {Object.keys(posts).map((key, index) => (
-      <LazyLoad offset={1000} key={posts[index].id}>
+      <LazyLoad offset={1000} once key={posts[index].id}>
         <Post
           showStatus={!!userId}
           index={index + 1}

--- a/src/components/PostVisualBacktest.js
+++ b/src/components/PostVisualBacktest.js
@@ -27,7 +27,7 @@ export const PostVisualBacktest = ({
   history,
   postUpdatedAt
 }) => {
-  if (history.loading) return null
+  if (history.loading || !history.historyPrice) return null
   return (
     <div className='post-visual-backtest'>
       <div className='post-visual-backtest__info'>

--- a/src/components/PostVisualBacktest.js
+++ b/src/components/PostVisualBacktest.js
@@ -27,14 +27,14 @@ export const PostVisualBacktest = ({
   history,
   postUpdatedAt
 }) => {
-  if (!change) return null
+  if (history.loading) return null
   return (
     <div className='post-visual-backtest'>
       <div className='post-visual-backtest__info'>
         <div className='post-visual-backtest__changes'>
           {ticker} {changeProp} since publication
         </div>
-        {change && <PercentChanges changes={change} />}
+        {Number.isFinite(change) && <PercentChanges changes={change} />}
       </div>
       <PostVisualBacktestChart
         history={history}

--- a/src/components/PostVisualBacktest.spec.js
+++ b/src/components/PostVisualBacktest.spec.js
@@ -6,7 +6,14 @@ import { PostVisualBacktest } from './PostVisualBacktest'
 
 describe('PostVisualBacktest component', () => {
   it('(smoke) it should render correctly', () => {
-    const component = render(<PostVisualBacktest ticker='SAN' from='aksdfjh' />)
+    const component = render(
+      <PostVisualBacktest
+        history={{ loading: false }}
+        ticker='SAN'
+        change={3}
+        from='aksdfjh'
+      />
+    )
     expect(toJson(component)).toMatchSnapshot()
     expect(component.html()).toEqual(null)
   })
@@ -15,6 +22,7 @@ describe('PostVisualBacktest component', () => {
     const component = render(
       <PostVisualBacktest
         ticker='SAN'
+        history={{ historyPrice: [], loading: false }}
         change={25}
         changeProp='priceUsd'
         from='aksdfjh'

--- a/yarn.lock
+++ b/yarn.lock
@@ -12763,6 +12763,11 @@ react-is@^16.3.2, react-is@^16.6.0, react-is@^16.6.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
 
+react-lazyload@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-lazyload/-/react-lazyload-2.5.0.tgz#7ed20bf0408dc684c10e808060e51d904cc0ab8d"
+  integrity sha512-RkEwpJDqEUVkXodxBXAI/UDyGYUBTZCU9kdG0Lwmg8BIv8zDvP+exFwUzc7wP4HX6n33CCsz+cjG2FpwdRoxpw==
+
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"


### PR DESCRIPTION
#### Summary
* Fixing failed graphql queries for the `PostVisualBacktest`. This is done by using `LazyLoad` component.
* Fresh insights now have a chart with an indication that price has not changed.

[_Favro card_](https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/9ff267872fcd8b7925f1d7c7?card=San-2559)
