### PR TITLE
fix/dashboard-link

### DIFF
--- a/src/components/Navbar/NavbarLabsDropdown.js
+++ b/src/components/Navbar/NavbarLabsDropdown.js
@@ -8,7 +8,7 @@ const links = [
   { link: '/ethereum-spent', label: 'ETH spent' },
   { link: '/labs/balance', label: 'Historical balance' },
   { link: '/labs/wordcloud', label: 'Word context' },
-  { link: '/dashboard', label: 'Dashboard' }
+  { link: 'https://data.santiment.net/', label: 'Dashboard' }
 ]
 
 const NavbarLabsDropdown = ({ activeLink }) => (
@@ -19,9 +19,14 @@ const NavbarLabsDropdown = ({ activeLink }) => (
           fluid
           variant='ghost'
           key={label}
-          as={Link}
+          as={props =>
+            label === 'Dashboard' ? (
+              <a {...props} target='_blank' href={link} />
+            ) : (
+              <Link {...props} to={link} />
+            )
+          }
           className={styles.item}
-          to={link}
           isActive={link === activeLink}
         >
           {label}

--- a/src/components/Navbar/NavbarLabsDropdown.js
+++ b/src/components/Navbar/NavbarLabsDropdown.js
@@ -21,7 +21,12 @@ const NavbarLabsDropdown = ({ activeLink }) => (
           key={label}
           as={props =>
             label === 'Dashboard' ? (
-              <a {...props} target='_blank' href={link} />
+              <a
+                {...props}
+                rel='noopener noreferrer'
+                target='_blank'
+                href={link}
+              />
             ) : (
               <Link {...props} to={link} />
             )


### PR DESCRIPTION
#### Summary
Dashboard link now leads to the `data.santiment.net`.
[Favro card](https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/9ff267872fcd8b7925f1d7c7?card=San-3913)