### PR TITLE
fix/sonar-insights-bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+- 2019-02-19 | v.0.31.4 'Sonar':
+  Fixed creating trending insight issues
+
 - 2019-02-14 | v.0.31.3 'Sonar':
   Using "slug" as an argument for the twitter requests
 

--- a/src/components/Insight/InsightsTrends.js
+++ b/src/components/Insight/InsightsTrends.js
@@ -20,7 +20,8 @@ const getPast3DaysInsightsByTrendTag = () =>
         return {
           variables: {
             tag: getInsightTrendTagByDate(new Date(Date.now() - timestamp))
-          }
+          },
+          fetchPolicy: 'cache-and-network'
         }
       },
       props: ({

--- a/src/pages/InsightsNew/ConfirmNewInsight.js
+++ b/src/pages/InsightsNew/ConfirmNewInsight.js
@@ -44,11 +44,12 @@ const updatePostGQL = gql`
 `
 
 const createNewPost = ({ createPost, post, user, history }) => {
+  const isTrendingInsight = window.location.search.includes('currentTrends')
   return createPost({
     variables: {
       title: post.title,
       text: post.text,
-      tags: (window.location.search.includes('currentTrends')
+      tags: (isTrendingInsight
         ? [{ label: getInsightTrendTagByDate(new Date()) }, ...post.tags]
         : post.tags
       ).map(tag => {
@@ -62,7 +63,7 @@ const createNewPost = ({ createPost, post, user, history }) => {
     }
   })
     .then(data => {
-      history.push('/insights/my')
+      history.push(isTrendingInsight ? '/sonar/' : '/insights/my')
     })
     .catch(error => {
       Raven.captureException(


### PR DESCRIPTION
#### Summary
- Redirecting to `/sonar` after creating trend insight.
- Fixed bug: Reloaded needed to load new insights on the `/sonar` page.