### PR TITLE
feature/insights-seo-links

### DIFF
--- a/src/components/Insight/InsightCardInternals.js
+++ b/src/components/Insight/InsightCardInternals.js
@@ -5,6 +5,7 @@ import moment from 'moment'
 import InsightTags from './InsightTags'
 import ProfileInfo from './ProfileInfo'
 import MultilineText from '../MultilineText/MultilineText'
+import { getSEOLinkFromIdAndTitle } from '../../pages/Insights/utils'
 import styles from './InsightCard.module.scss'
 
 const InsightCardInternals = ({
@@ -23,7 +24,10 @@ const InsightCardInternals = ({
         <div>
           <InsightTags tags={tags} />
         </div>
-        <Link to={`/insights/read/${id}`} className={styles.title}>
+        <Link
+          to={`/insights/read/${getSEOLinkFromIdAndTitle(id, title)}`}
+          className={styles.title}
+        >
           <MultilineText maxLines={2} id='insightCardTitle' text={title} />
         </Link>
       </div>

--- a/src/components/Insight/InsightDraftCard.js
+++ b/src/components/Insight/InsightDraftCard.js
@@ -5,6 +5,7 @@ import cx from 'classnames'
 import moment from 'moment'
 import MultilineText from '../MultilineText/MultilineText'
 import InsightDraftCardDeleteBtn from './InsightDraftCardDeleteBtn'
+import { getSEOLinkFromIdAndTitle } from '../../pages/Insights/utils'
 import styles from './InsightDraftCard.module.scss'
 
 const getInsightContent = htmlContent => {
@@ -25,7 +26,10 @@ const InsightDraftCard = ({
 }) => {
   return (
     <Panel className={cx(styles.wrapper, className)}>
-      <Link to={`/insights/read/${id}`} className={styles.title}>
+      <Link
+        to={`/insights/read/${getSEOLinkFromIdAndTitle(id, title)}`}
+        className={styles.title}
+      >
         {title}
       </Link>
       <p className={styles.text}>

--- a/src/pages/Insights/InsightPage.js
+++ b/src/pages/Insights/InsightPage.js
@@ -6,6 +6,7 @@ import { Redirect } from 'react-router-dom'
 import Loadable from 'react-loadable'
 import PageLoader from '../../components/PageLoader'
 import { INSIGHT_BY_ID_QUERY } from './InsightsGQL'
+import { getInsightIdFromSEOLink } from './utils'
 
 const LoadableInsightCreationPage = Loadable({
   loader: () => import('./InsightCreationPage'),
@@ -59,7 +60,7 @@ const enhance = compose(
         params: { id }
       }
     }) => {
-      return !Number.isInteger(+id)
+      return !Number.isInteger(getInsightIdFromSEOLink(id))
     },
     options: ({
       match: {
@@ -68,7 +69,7 @@ const enhance = compose(
     }) => ({
       fetchPolicy: 'network-only',
       variables: {
-        id: +id
+        id: getInsightIdFromSEOLink(id)
       }
     })
   })

--- a/src/pages/Insights/utils.js
+++ b/src/pages/Insights/utils.js
@@ -43,3 +43,12 @@ export const getInsightContent = htmlContent => {
   tempHTMLElement = null
   return content
 }
+
+export const getInsightIdFromSEOLink = link =>
+  +link.slice(link.lastIndexOf('-') + 1)
+
+export const getSEOLinkFromIdAndTitle = (id, title) =>
+  `${title
+    .toLowerCase()
+    .split(' ')
+    .join('-')}-${id}`

--- a/src/pages/Insights/utils.spec.js
+++ b/src/pages/Insights/utils.spec.js
@@ -1,0 +1,39 @@
+/* eslint-env jest */
+import { getInsightIdFromSEOLink, getSEOLinkFromIdAndTitle } from './utils'
+
+const insights = {
+  small: {
+    id: 0,
+    title: 'How are you?',
+    seo: 'how-are-you?-0'
+  },
+  strange: {
+    id: 1,
+    title: 'ThIS -- a., &&lre you?-0',
+    seo: 'this----a.,-&&lre-you?-0-1'
+  }
+}
+
+describe('getSEOLinkFromIdAndTitle', () => {
+  it('should transform small title', () => {
+    const { id, title, seo } = insights.small
+    expect(getSEOLinkFromIdAndTitle(id, title)).toEqual(seo)
+  })
+
+  it('should transform strange title', () => {
+    const { id, title, seo } = insights.strange
+    expect(getSEOLinkFromIdAndTitle(id, title)).toEqual(seo)
+  })
+})
+
+describe('getInsightIdFromSEOLink', () => {
+  it('should get id from small seo link', () => {
+    const { id, seo } = insights.small
+    expect(getInsightIdFromSEOLink(seo)).toEqual(id)
+  })
+
+  it('should get id from strange seo link', () => {
+    const { id, seo } = insights.strange
+    expect(getInsightIdFromSEOLink(seo)).toEqual(id)
+  })
+})


### PR DESCRIPTION
#### Summary
Accessing insights is now possible via SEO friendly link: `/read/title-of-the-insight-:id`. 
This feature is backward compatible with the old link scheme: `/read/:id`