### PR TITLE
enhance/merge-timeseries

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -170,12 +170,50 @@ const mergeTimeseriesByKey = ({
       for (; longestTSRightIndexBoundary > -1; longestTSRightIndexBoundary--) {
         const longestTSData = longestTS[longestTSRightIndexBoundary]
         const timeserieData = timeserie[timeserieRightIndex]
+
+        console.log(`${longestTSData[mergeKey]} ${timeserieData[mergeKey]}`)
         if (longestTSData[mergeKey] === timeserieData[mergeKey]) {
           longestTS[longestTSRightIndexBoundary] = mergeData(
             longestTSData,
             timeserieData
           )
+          console.log(
+            `%c ${longestTSData[mergeKey]} ${timeserieData[mergeKey]}`,
+            'color: red;'
+          )
+          longestTSRightIndexBoundary--
           break
+        }
+
+        const longestDate = new Date(longestTSData[mergeKey])
+        if (longestDate < new Date(timeserieData[mergeKey])) {
+          const to = timeserieRightIndex
+          timeserieRightIndex--
+          while (
+            longestDate < new Date(timeserie[timeserieRightIndex][mergeKey])
+          ) {
+            timeserieRightIndex--
+          }
+
+          console.log(
+            `%c ${longestTSData[mergeKey]} ${
+              timeserie[timeserieRightIndex][mergeKey]
+            }  || ${timeserieRightIndex} ${to}`,
+            'color: blue'
+          )
+
+          longestTS[longestTSRightIndexBoundary] = mergeData(
+            longestTSData,
+            timeserie[timeserieRightIndex]
+          )
+
+          longestTS.splice(
+            longestTSRightIndexBoundary + 1,
+            0,
+            ...timeserie.slice(timeserieRightIndex + 1, to + 1)
+          )
+
+          timeserieRightIndex--
         }
       }
       if (longestTSRightIndexBoundary === -1) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -135,7 +135,7 @@ const mergeTimeseriesByKey = ({
   }, [])
 
   const longestTS = longestTSMut.slice()
-  const longestTSLastIndex = longestTS.length - 1
+  let longestTSLastIndex = longestTS.length - 1
 
   for (const timeserie of timeseries) {
     if (timeserie === longestTSMut) {
@@ -172,33 +172,41 @@ const mergeTimeseriesByKey = ({
         const timeserieData = timeserie[timeserieRightIndex]
 
         console.log(`${longestTSData[mergeKey]} ${timeserieData[mergeKey]}`)
+
         if (longestTSData[mergeKey] === timeserieData[mergeKey]) {
           longestTS[longestTSRightIndexBoundary] = mergeData(
             longestTSData,
             timeserieData
           )
+
           console.log(
             `%c ${longestTSData[mergeKey]} ${timeserieData[mergeKey]}`,
             'color: red;'
           )
+
           longestTSRightIndexBoundary--
           break
         }
 
         const longestDate = new Date(longestTSData[mergeKey])
         if (longestDate < new Date(timeserieData[mergeKey])) {
-          const to = timeserieRightIndex
+          const timeserieFirstUnfoundIndex = timeserieRightIndex
           timeserieRightIndex--
           while (
+            timeserieRightIndex > 0 &&
             longestDate < new Date(timeserie[timeserieRightIndex][mergeKey])
           ) {
             timeserieRightIndex--
           }
 
+          if (timeserieRightIndex < 0) {
+            break
+          }
+
           console.log(
             `%c ${longestTSData[mergeKey]} ${
               timeserie[timeserieRightIndex][mergeKey]
-            }  || ${timeserieRightIndex} ${to}`,
+            }  || ${timeserieRightIndex} ${timeserieFirstUnfoundIndex}`,
             'color: blue'
           )
 
@@ -210,12 +218,18 @@ const mergeTimeseriesByKey = ({
           longestTS.splice(
             longestTSRightIndexBoundary + 1,
             0,
-            ...timeserie.slice(timeserieRightIndex + 1, to + 1)
+            ...timeserie.slice(
+              timeserieRightIndex + 1,
+              timeserieFirstUnfoundIndex + 1
+            )
           )
+
+          longestTSLastIndex = longestTS.length - 1
 
           timeserieRightIndex--
         }
       }
+
       if (longestTSRightIndexBoundary === -1) {
         break
       }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -130,8 +130,6 @@ const mergeTimeseriesByKey = ({
   mergeData = (longestTSData, timeserieData) =>
     Object.assign({}, longestTSData, timeserieData)
 }) => {
-  console.time('merge')
-
   const longestTSMut = timeseries.reduce((acc, val) => {
     return acc.length > val.length ? acc : val
   }, [])
@@ -156,18 +154,11 @@ const mergeTimeseriesByKey = ({
         const longestTSData = longestTS[longestTSRightIndexBoundary]
         const timeserieData = timeserie[timeserieRightIndex]
 
-        /* console.log(`${longestTSData[mergeKey]} ${timeserieData[mergeKey]}`) */
-
         if (longestTSData[mergeKey] === timeserieData[mergeKey]) {
           longestTS[longestTSRightIndexBoundary] = mergeData(
             longestTSData,
             timeserieData
           )
-
-          /* console.log( */
-          /* `%c ${longestTSData[mergeKey]} ${timeserieData[mergeKey]}`, */
-          /* 'color: red;' */
-          /* ) */
 
           longestTSRightIndexBoundary--
           break
@@ -189,13 +180,6 @@ const mergeTimeseriesByKey = ({
           if (timeserieRightIndex < 0) {
             break
           }
-
-          /* console.log( */
-          /* `%c ${longestTSData[mergeKey]} ${ */
-          /* timeserie[timeserieRightIndex][mergeKey] */
-          /* }  || ${timeserieRightIndex} ${timeserieFirstUnfoundIndex}`, */
-          /* 'color: blue' */
-          /* ) */
 
           longestTS[longestTSRightIndexBoundary] = mergeData(
             longestTSData,
@@ -226,8 +210,6 @@ const mergeTimeseriesByKey = ({
       }
     }
   }
-
-  console.timeEnd('merge')
 
   return longestTS
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -130,6 +130,8 @@ const mergeTimeseriesByKey = ({
   mergeData = (longestTSData, timeserieData) =>
     Object.assign({}, longestTSData, timeserieData)
 }) => {
+  console.time('merge')
+
   const longestTSMut = timeseries.reduce((acc, val) => {
     return acc.length > val.length ? acc : val
   }, [])
@@ -149,29 +151,12 @@ const mergeTimeseriesByKey = ({
       continue
     }
 
-    if (mergeKey === 'datetime') {
-      let timeserieMergeCount = 0
-
-      for (
-        ;
-        moment(longestTS[longestTSRightIndexBoundary]['datetime']).isBefore(
-          moment(timeserie[timeserieRightIndex]['datetime'])
-        ) && timeserieRightIndex > -1;
-        timeserieRightIndex--
-      ) {
-        timeserieMergeCount++
-      }
-      if (timeserieMergeCount > 0) {
-        longestTS.push(...timeserie.slice(-timeserieMergeCount))
-      }
-    }
-
     for (; timeserieRightIndex > -1; timeserieRightIndex--) {
       for (; longestTSRightIndexBoundary > -1; longestTSRightIndexBoundary--) {
         const longestTSData = longestTS[longestTSRightIndexBoundary]
         const timeserieData = timeserie[timeserieRightIndex]
 
-        console.log(`${longestTSData[mergeKey]} ${timeserieData[mergeKey]}`)
+        /* console.log(`${longestTSData[mergeKey]} ${timeserieData[mergeKey]}`) */
 
         if (longestTSData[mergeKey] === timeserieData[mergeKey]) {
           longestTS[longestTSRightIndexBoundary] = mergeData(
@@ -179,10 +164,10 @@ const mergeTimeseriesByKey = ({
             timeserieData
           )
 
-          console.log(
-            `%c ${longestTSData[mergeKey]} ${timeserieData[mergeKey]}`,
-            'color: red;'
-          )
+          /* console.log( */
+          /* `%c ${longestTSData[mergeKey]} ${timeserieData[mergeKey]}`, */
+          /* 'color: red;' */
+          /* ) */
 
           longestTSRightIndexBoundary--
           break
@@ -191,7 +176,9 @@ const mergeTimeseriesByKey = ({
         const longestDate = new Date(longestTSData[mergeKey])
         if (longestDate < new Date(timeserieData[mergeKey])) {
           const timeserieFirstUnfoundIndex = timeserieRightIndex
+
           timeserieRightIndex--
+
           while (
             timeserieRightIndex > 0 &&
             longestDate < new Date(timeserie[timeserieRightIndex][mergeKey])
@@ -203,12 +190,12 @@ const mergeTimeseriesByKey = ({
             break
           }
 
-          console.log(
-            `%c ${longestTSData[mergeKey]} ${
-              timeserie[timeserieRightIndex][mergeKey]
-            }  || ${timeserieRightIndex} ${timeserieFirstUnfoundIndex}`,
-            'color: blue'
-          )
+          /* console.log( */
+          /* `%c ${longestTSData[mergeKey]} ${ */
+          /* timeserie[timeserieRightIndex][mergeKey] */
+          /* }  || ${timeserieRightIndex} ${timeserieFirstUnfoundIndex}`, */
+          /* 'color: blue' */
+          /* ) */
 
           longestTS[longestTSRightIndexBoundary] = mergeData(
             longestTSData,
@@ -227,6 +214,10 @@ const mergeTimeseriesByKey = ({
           longestTSLastIndex = longestTS.length - 1
 
           timeserieRightIndex--
+
+          if (timeserieRightIndex < 0) {
+            break
+          }
         }
       }
 
@@ -235,6 +226,8 @@ const mergeTimeseriesByKey = ({
       }
     }
   }
+
+  console.timeEnd('merge')
 
   return longestTS
 }

--- a/src/utils/utils.spec.js
+++ b/src/utils/utils.spec.js
@@ -364,6 +364,41 @@ describe('mergeTimeseriesByKey', () => {
     expect(expected).toEqual(goodMerge)
   })
 
+  it('should merge 3 timeseries when large one has gaps', () => {
+    const goodMerge = [
+      {
+        value2: 23,
+        value5: 51,
+        value6: 61,
+        datetime: '2018-08-20T00:00:00Z'
+      },
+      {
+        value5: 52,
+        value6: 62,
+        datetime: '2018-09-20T00:00:00Z'
+      },
+      {
+        value5: 53,
+        datetime: '2018-10-20T00:00:00Z'
+      },
+      {
+        value6: 63,
+        datetime: '2018-11-20T00:00:00Z'
+      },
+      {
+        value6: 64,
+        datetime: '2018-12-20T00:00:00Z'
+      }
+    ]
+
+    const expected = mergeTimeseriesByKey({
+      timeseries: [ts5, ts6, ts2],
+      key: 'datetime'
+    })
+
+    expect(expected).toEqual(goodMerge)
+  })
+
   it('should merge 2 timeseries leaving the unfound datetime', () => {
     const goodMerged = [
       {

--- a/src/utils/utils.spec.js
+++ b/src/utils/utils.spec.js
@@ -203,6 +203,25 @@ describe('mergeTimeseriesByKey', () => {
     }
   ]
 
+  const ts6 = [
+    {
+      value6: 61,
+      datetime: '2018-08-20T00:00:00Z'
+    },
+    {
+      value6: 62,
+      datetime: '2018-09-20T00:00:00Z'
+    },
+    {
+      value6: 63,
+      datetime: '2018-11-20T00:00:00Z'
+    },
+    {
+      value6: 64,
+      datetime: '2018-12-20T00:00:00Z'
+    }
+  ]
+
   it('should merge correctly and skip empty TS', () => {
     const goodMerged = [
       {
@@ -310,6 +329,39 @@ describe('mergeTimeseriesByKey', () => {
       key: 'datetime'
     })
     expect(expected).toEqual(goodMerged)
+  })
+  it('should merge 2 timeseries when large one has gaps', () => {
+    const goodMerge = [
+      {
+        value5: 51,
+        value6: 61,
+        datetime: '2018-08-20T00:00:00Z'
+      },
+      {
+        value5: 52,
+        value6: 62,
+        datetime: '2018-09-20T00:00:00Z'
+      },
+      {
+        value5: 53,
+        datetime: '2018-10-20T00:00:00Z'
+      },
+      {
+        value6: 63,
+        datetime: '2018-11-20T00:00:00Z'
+      },
+      {
+        value6: 64,
+        datetime: '2018-12-20T00:00:00Z'
+      }
+    ]
+
+    const expected = mergeTimeseriesByKey({
+      timeseries: [ts5, ts6],
+      key: 'datetime'
+    })
+
+    expect(expected).toEqual(goodMerge)
   })
 
   it('should merge 2 timeseries leaving the unfound datetime', () => {


### PR DESCRIPTION
### Summary
Increasing the speed of the algorithm in general **(2x speed increase)** and handling _**"largest timeserie with gaps"**_ case.

### Largest timeserie with gaps
**NOTE:** Merging is happening from `right to left`.

Before this PR, the algorithm was assuming that the `LongestTS` has no missing data. Because of that, `LongestTS` check-cursor was first to move to the left in order to find a match for the current (unmoved) `SmallTS` check-cursor.

_Case example:_
LongestTS = `(1) (2) (3) (4) (5) !__  __! (8) (9) (10)`
SmallTS = .........................`(4) (5) (6) (7) (8) (9)`

In this example, matching will start from the `LongestTS (10)` and `SmallTS (9)`. As described above, `LongestTS` check-cursor will move to the left until it finds matching data. Next move to the left lead to the successful check, which results in the merge. After one more successful merge, we get to the point where the algorithm compare `LongestTS (5)` and `SmallTS (7)`.  It's a failed equality check and the `LongestTS` check-cursor will be moved all the way to the left. After last failed check algorithm stops working and yields the result -> `(1) (2) (3) (4) (5) !__  __! (8+8) (9+9) (10)`. Only `(8)` and `(9)` were merged. All this is because of the data gap in the `LongestTS` which results in missing data.

Now the additional check happens. When the data is not equal, algorithm checks if the `LongestTS (5).datetime` is before `SmallTS (7).datetime`, if it's true, then LongestTS have gaps of missing data, that will be filled by moving `SmallTS` check-cursor to the left first. After finding `SmallTS (5)` it will be merged into `LongestTS (5)` and `SmallTS (6)` `SmallTS (7)` will be placed in the `LongestTS` according gap.
