### PR TITLE
fix/insight-seo-link-case

### DIFF
--- a/src/pages/Insights/utils.js
+++ b/src/pages/Insights/utils.js
@@ -48,7 +48,9 @@ export const getInsightIdFromSEOLink = link =>
   +link.slice(link.lastIndexOf('-') + 1)
 
 export const getSEOLinkFromIdAndTitle = (id, title) =>
-  `${title
-    .toLowerCase()
-    .split(' ')
-    .join('-')}-${id}`
+  encodeURIComponent(
+    `${title
+      .toLowerCase()
+      .split(' ')
+      .join('-')}-${id}`
+  )

--- a/src/pages/Insights/utils.spec.js
+++ b/src/pages/Insights/utils.spec.js
@@ -5,12 +5,12 @@ const insights = {
   small: {
     id: 0,
     title: 'How are you?',
-    seo: 'how-are-you?-0'
+    seo: 'how-are-you%3F-0'
   },
   strange: {
     id: 1,
     title: 'ThIS -- a., &&lre you?-0',
-    seo: 'this----a.,-&&lre-you?-0-1'
+    seo: 'this----a.%2C-%26%26lre-you%3F-0-1'
   }
 }
 


### PR DESCRIPTION
#### Summary
Enchoding insights `title` when creating SEO-link.
Solving the issue described in this [card](https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/9ff267872fcd8b7925f1d7c7?card=San-4518).