### PR TITLE
feature/insights-anon-redirect

### DIFF
--- a/src/pages/Insights/index.js
+++ b/src/pages/Insights/index.js
@@ -23,8 +23,16 @@ const LoadableInsightPage = Loadable({
   loading: () => <PageLoader />
 })
 
+const LoadableUnAuthPage = Loadable({
+  loader: () => import('./InsightUnAuthPage'),
+  loading: () => <PageLoader />
+})
+
 const PageHub = ({ location: { pathname }, isLoggedIn }) => {
   window.scrollTo(0, 0)
+  const normalizedPathname = pathname.endsWith('/')
+    ? pathname.slice(0, -1)
+    : pathname
 
   return (
     <div style={{ width: '100%' }} className={cx('page', styles.wrapper)}>
@@ -32,6 +40,11 @@ const PageHub = ({ location: { pathname }, isLoggedIn }) => {
         <title>Insights</title>
       </Helmet>
       <Switch>
+        {!isLoggedIn &&
+          (normalizedPathname !== baseLocation &&
+            !normalizedPathname.startsWith('/insights/read/')) && (
+          <Route component={LoadableUnAuthPage} />
+        )}
         <Route
           exact
           path={`${baseLocation}/read/:id`}


### PR DESCRIPTION
#### Summary
Showing user a 'Create account' page if he is trying to access any insight route, but `/insights` and `/insights/read/:insight`

#### Screenshots
![image](https://user-images.githubusercontent.com/25135650/54923716-dfdc9f80-4f1b-11e9-8786-e64e11b6774f.png)
