### PR TITLE
fix/trends-explore-price-picker

### DIFF
--- a/src/pages/Trends/TrendsExplorePage.js
+++ b/src/pages/Trends/TrendsExplorePage.js
@@ -79,19 +79,8 @@ export class TrendsExplorePage extends Component {
     }
   }
 
-  static getDerivedStateFromProps (nextProps, { asset }) {
-    const { detectedAsset } = nextProps
-
-    let resultAsset = asset
-
-    if (detectedAsset && asset !== 'ethereum' && asset !== 'bitcoin') {
-      resultAsset = 'bitcoin'
-    }
-
-    return {
-      ...mapQSToState(nextProps),
-      asset: resultAsset
-    }
+  static getDerivedStateFromProps (nextProps, prevState) {
+    return { ...mapQSToState(nextProps) }
   }
 
   render () {

--- a/src/pages/Trends/TrendsExplorePage.js
+++ b/src/pages/Trends/TrendsExplorePage.js
@@ -28,6 +28,25 @@ const getCustomInterval = timeframe => {
   return '1d'
 }
 
+const defaultPrices = {
+  options: ['bitcoin', 'ethereum'],
+  labels: ['BTC/USD', 'ETH/USD']
+}
+
+const getPriceOptions = asset => {
+  const { options, labels } = defaultPrices
+  if (!asset) {
+    return [options, labels]
+  }
+
+  const { slug, ticker } = asset
+  if (ticker === 'BTC' || ticker === 'ETH') {
+    return [options, labels]
+  }
+
+  return [[...options, slug], [...labels, `${ticker}/USD`]]
+}
+
 export class TrendsExplorePage extends Component {
   state = {
     timeRange: '3m',
@@ -67,6 +86,8 @@ export class TrendsExplorePage extends Component {
   render () {
     const { word, hasPremium, detectedAsset } = this.props
     const { timeRange, asset = '' } = this.state
+    const [priceOptions, priceLabels] = getPriceOptions(detectedAsset)
+
     const topic = window.decodeURIComponent(word)
     return (
       <div className={styles.TrendsExplorePage}>
@@ -93,16 +114,8 @@ export class TrendsExplorePage extends Component {
             />
             <Panel className={styles.pricePair}>
               <Selector
-                options={
-                  detectedAsset
-                    ? ['bitcoin', 'ethereum', detectedAsset.slug]
-                    : ['bitcoin', 'ethereum']
-                }
-                nameOptions={
-                  detectedAsset
-                    ? ['BTC/USD', 'ETH/USD', `${detectedAsset.ticker}/USD`]
-                    : ['BTC/USD', 'ETH/USD']
-                }
+                options={priceOptions}
+                nameOptions={priceLabels}
                 onSelectOption={this.handleSelectAsset}
                 defaultSelected={asset}
               />

--- a/src/pages/Trends/TrendsExplorePage.js
+++ b/src/pages/Trends/TrendsExplorePage.js
@@ -79,8 +79,19 @@ export class TrendsExplorePage extends Component {
     }
   }
 
-  static getDerivedStateFromProps (nextProps, prevState) {
-    return { ...mapQSToState(nextProps) }
+  static getDerivedStateFromProps (nextProps, { asset }) {
+    const { detectedAsset } = nextProps
+
+    let resultAsset = asset
+
+    if (detectedAsset && asset !== 'ethereum' && asset !== 'bitcoin') {
+      resultAsset = 'bitcoin'
+    }
+
+    return {
+      ...mapQSToState(nextProps),
+      asset: resultAsset
+    }
   }
 
   render () {


### PR DESCRIPTION
#### Summary
Handling case when the detected asset is either `eth` (ethereum) or `btc` (bitcoin).

#### Screenshots
![image](https://user-images.githubusercontent.com/25135650/55019444-f8c17f80-5005-11e9-8540-c87b05b81959.png)
