### PR TITLE
Enhance/detailed page connects with signal

### DIFF
--- a/src/components/ProjectChart/ProjectChartFooter.js
+++ b/src/components/ProjectChart/ProjectChartFooter.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import cx from 'classnames'
 import { Popup, Icon, Label, Loader, Message } from 'semantic-ui-react'
 import AlertMessage from './../../components/AlertMessage'
+import ShowIf from './../../components/ShowIf'
 import help from './../../assets/help.json'
 import LinkToSocialTool from './LinkToSocialTool'
 import SignalMasterModalForm from './../../ducks/Signals/SignalMasterModalForm'
@@ -108,7 +109,7 @@ const ProjectChartFooter = ({
           </ToggleBtn>
         )}
         <br />
-        {
+        <ShowIf beta>
           <SignalMasterModalForm
             metaFormSettings={{
               target: {
@@ -122,7 +123,7 @@ const ProjectChartFooter = ({
             }}
             label='New Price Signal'
           />
-        }
+        </ShowIf>
       </FilterCategory>
       <FilterCategory name='Development'>
         <ToggleBtn

--- a/src/components/ProjectChart/ProjectChartFooter.js
+++ b/src/components/ProjectChart/ProjectChartFooter.js
@@ -108,8 +108,21 @@ const ProjectChartFooter = ({
           </ToggleBtn>
         )}
         <br />
-        {// TODO: Partysun. Upgrade when modal with accept it
-          false && <SignalMasterModalForm label='New Price Signal' />}
+        {
+          <SignalMasterModalForm
+            metaFormSettings={{
+              target: {
+                isDisabled: true,
+                value: { value: props.project.slug, label: props.project.slug }
+              },
+              metric: {
+                value: { label: 'Price', value: 'price' },
+                isDisabled: true
+              }
+            }}
+            label='New Price Signal'
+          />
+        }
       </FilterCategory>
       <FilterCategory name='Development'>
         <ToggleBtn

--- a/src/components/ShowIf/ShowIf.js
+++ b/src/components/ShowIf/ShowIf.js
@@ -1,0 +1,34 @@
+import React, { Fragment } from 'react'
+import { connect } from 'react-redux'
+import { checkHasPremium, checkIsLoggedIn } from './../../pages/UserSelectors'
+
+const ShowIf = ({
+  beta,
+  loggedIn,
+  premium,
+  isBeta,
+  isLoggedIn,
+  isPremium,
+  children
+}) => {
+  if (beta && isBeta) {
+    return <Fragment>{children}</Fragment>
+  }
+  if (premium && isPremium) {
+    return <Fragment>{children}</Fragment>
+  }
+  if (loggedIn && isLoggedIn) {
+    return <Fragment>{children}</Fragment>
+  }
+  return ''
+}
+
+const mapStateToProps = (state, props) => {
+  return {
+    isBeta: props.beta !== void 0 ? state.rootUi.isBetaModeEnabled : undefined,
+    isPremium: props.premium !== void 0 ? checkHasPremium(state) : undefined,
+    isLoggedIn: props.loggedIn !== void 0 ? checkIsLoggedIn(state) : undefined
+  }
+}
+
+export default connect(mapStateToProps)(ShowIf)

--- a/src/components/ShowIf/ShowIf.spec.js
+++ b/src/components/ShowIf/ShowIf.spec.js
@@ -1,0 +1,53 @@
+/* eslint-env jest */
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+import toJson from 'enzyme-to-json'
+import ShowIf from './ShowIf'
+import configureStore from 'redux-mock-store'
+
+const AnyComponent = () => 'Check'
+
+describe('ShowIf', () => {
+  const mockStore = configureStore([])
+  let store
+
+  beforeEach(() => {
+    const initialState = {
+      user: {
+        data: {
+          sanBalance: 400
+        }
+      },
+      rootUi: { isBetaModeEnabled: true }
+    }
+    store = mockStore(initialState)
+  })
+
+  const getWrapper = store =>
+    mount(
+      <ShowIf beta store={store}>
+        <AnyComponent />
+      </ShowIf>
+    )
+
+  it('it should render if beta', () => {
+    const wrapper = getWrapper(store)
+    expect(wrapper.find(AnyComponent).exists()).toBeTruthy()
+  })
+
+  it('it should render empty if is not beta', () => {
+    store = mockStore({ rootUi: { isBetaModeEnabled: false } })
+    const wrapper = getWrapper(store)
+    expect(wrapper.find(AnyComponent).exists()).toBeFalsy()
+  })
+
+  it('it should render if loggedIn', () => {
+    store = mockStore({ user: { token: 'any' } })
+    const wrapper = mount(
+      <ShowIf loggedIn store={store}>
+        <AnyComponent />
+      </ShowIf>
+    )
+    expect(wrapper.find(AnyComponent).exists()).toBeTruthy()
+  })
+})

--- a/src/components/ShowIf/index.js
+++ b/src/components/ShowIf/index.js
@@ -1,0 +1,2 @@
+import ShowIf from './ShowIf'
+export default ShowIf

--- a/src/components/formik-santiment-ui/FormikSelect.js
+++ b/src/components/formik-santiment-ui/FormikSelect.js
@@ -17,7 +17,6 @@ const FormikSelect = ({
         <Select
           placeholder={placeholder}
           options={options}
-          disabled={disabled}
           onChange={value => {
             form.setFieldValue(name, value)
             form.setFieldTouched(name, true)

--- a/src/ducks/Signals/GetSignals.js
+++ b/src/ducks/Signals/GetSignals.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { checkIsLoggedIn } from './../../pages/UserSelectors'
 import { TRIGGERS_QUERY } from './SignalsGQL'
 
-const POLLING_INTERVAL = 5000
+const POLLING_INTERVAL = 25000
 
 const GetSignals = ({ render, ...props }) => render({ ...props })
 
@@ -24,8 +24,8 @@ export default compose(
     name: 'Signals',
     skip: ({ isLoggedIn }) => !isLoggedIn,
     options: () => ({
-      // pollInterval: POLLING_INTERVAL,
-      // context: { isRetriable: true }
+      pollInterval: POLLING_INTERVAL,
+      context: { isRetriable: true }
     }),
     props: ({ Signals }) => {
       const { currentUser, loading, error } = Signals

--- a/src/ducks/Signals/SignalMaster.js
+++ b/src/ducks/Signals/SignalMaster.js
@@ -49,6 +49,7 @@ export class SignalMaster extends React.PureComponent {
         {step === STEPS.SETTINGS && (
           <TriggerForm
             settings={formProps}
+            metaFormSettings={this.props.metaFormSettings}
             onSettingsChange={this.handleSettingsChange}
           />
         )}

--- a/src/ducks/Signals/SignalMasterModalForm.js
+++ b/src/ducks/Signals/SignalMasterModalForm.js
@@ -3,7 +3,7 @@ import { Modal, Button, Icon } from '@santiment-network/ui'
 import SignalMaster from './SignalMaster'
 import styles from './SignalMasterModalForm.module.scss'
 
-const SignalMasterModalForm = ({ label = 'New signal' }) => (
+const SignalMasterModalForm = ({ label = 'New signal', metaFormSettings }) => (
   <Modal
     trigger={
       <Button className={styles.newSignal}>
@@ -14,7 +14,12 @@ const SignalMasterModalForm = ({ label = 'New signal' }) => (
     showDefaultActions={false}
     title='Create signal'
   >
-    {({ closeModal }) => <SignalMaster onCreated={closeModal} />}
+    {({ closeModal }) => (
+      <SignalMaster
+        onCreated={closeModal}
+        metaFormSettings={metaFormSettings}
+      />
+    )}
   </Modal>
 )
 

--- a/src/ducks/Signals/TriggerForm.js
+++ b/src/ducks/Signals/TriggerForm.js
@@ -87,10 +87,10 @@ const defaultValues = {
     cooldown: '24h',
     percentThreshold: 5,
     target: { value: 'santiment', label: 'santiment' },
-    metric: { label: 'Price', value: 'price' },
     timeWindow: 24,
     timeWindowUnit: { label: 'hours', value: 'h' },
     type: { value: 'price_percent_change', label: 'Moving up %' },
+    metric: { label: 'Price', value: 'price' },
     isRepeating: true,
     channels: ['telegram']
   },
@@ -197,6 +197,18 @@ const validate = values => {
   return errors
 }
 
+const DEFAULT_META_FORM_SETTINGS = {
+  target: {
+    isDisabled: false
+  },
+  type: {
+    isDisabled: false
+  },
+  metric: {
+    isDisabled: false
+  }
+}
+
 const propTypes = {
   onSettingsChange: PropTypes.func.isRequired,
   isTelegramConnected: PropTypes.bool.isRequired
@@ -207,8 +219,10 @@ export const TriggerForm = ({
   getSignalBacktestingPoints,
   data: { allProjects = [] },
   isTelegramConnected = false,
-  settings = INITIAL_VALUES
+  settings = INITIAL_VALUES,
+  metaFormSettings
 }) => {
+  metaFormSettings = { ...DEFAULT_META_FORM_SETTINGS, ...metaFormSettings }
   const [initialValues, setInitialValues] = useState(settings)
 
   useEffect(() => {
@@ -275,6 +289,8 @@ export const TriggerForm = ({
                   <label>Asset</label>
                   <FormikSelect
                     name='target'
+                    isDisabled={metaFormSettings.target.isDisabled}
+                    defaultValue={metaFormSettings.target.value}
                     placeholder='Pick an asset'
                     options={allProjects.map(asset => ({
                       label: asset.slug,
@@ -292,6 +308,8 @@ export const TriggerForm = ({
                   <FormikSelect
                     name='metric'
                     isClearable={false}
+                    isDisabled={metaFormSettings.metric.isDisabled}
+                    defaultValue={metaFormSettings.metric.value}
                     isSearchable
                     placeholder='Choose a metric'
                     options={METRICS}
@@ -308,6 +326,8 @@ export const TriggerForm = ({
                       name='type'
                       isClearable={false}
                       isSearchable
+                      isDisabled={metaFormSettings.type.isDisabled}
+                      defaultValue={metaFormSettings.type.value}
                       placeholder='Choose a type'
                       options={TYPES[values.metric.value]}
                       isOptionDisabled={option => !option.value}

--- a/src/ducks/Signals/TriggerForm.js
+++ b/src/ducks/Signals/TriggerForm.js
@@ -125,7 +125,7 @@ const defaultValues = {
   }
 }
 
-const INITIAL_VALUES = defaultValues['price_percent_change']
+const DEFAULT_FORM_SETTINGS = defaultValues['price_percent_change']
 
 const getTypeByMetric = metric => {
   if (metric.value === 'price') {
@@ -197,7 +197,7 @@ const validate = values => {
   return errors
 }
 
-const DEFAULT_META_FORM_SETTINGS = {
+const DEFAULT_FORM_META_SETTINGS = {
   target: {
     isDisabled: false
   },
@@ -219,10 +219,22 @@ export const TriggerForm = ({
   getSignalBacktestingPoints,
   data: { allProjects = [] },
   isTelegramConnected = false,
-  settings = INITIAL_VALUES,
+  settings = DEFAULT_FORM_SETTINGS,
   metaFormSettings
 }) => {
-  metaFormSettings = { ...DEFAULT_META_FORM_SETTINGS, ...metaFormSettings }
+  metaFormSettings = { ...DEFAULT_FORM_META_SETTINGS, ...metaFormSettings }
+  settings = {
+    ...settings,
+    target: metaFormSettings.target.value
+      ? metaFormSettings.target.value
+      : settings.target,
+    metric: metaFormSettings.metric.value
+      ? metaFormSettings.metric.value
+      : settings.metric,
+    type: metaFormSettings.type.value
+      ? metaFormSettings.type.value
+      : settings.type
+  }
   const [initialValues, setInitialValues] = useState(settings)
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13539,15 +13539,15 @@ react@^16.7.0:
     prop-types "^15.6.2"
     scheduler "^0.13.5"
 
-react@^16.8.4:
-  version "16.8.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.4.tgz#fdf7bd9ae53f03a9c4cd1a371432c206be1c4768"
-  integrity sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==
+react@^16.8.5:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.5"
+    scheduler "^0.13.6"
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -14496,10 +14496,10 @@ scheduler@^0.13.5:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-scheduler@^0.13.5:
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.5.tgz#b7226625167041298af3b98088a9dbbf6d7733a8"
-  integrity sha512-K98vjkQX9OIt/riLhp6F+XtDPtMQhqNcf045vsh+pcuvHq+PHy1xCrH3pq1P40m6yR46lpVvVhKdEOtnimuUJw==
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Now you can create a signal from any project detailed page.
The signal form had default values and make them inactive.
Such creation signal button will show only if Beta mode enabled.

![Screenshot 2019-03-30 at 14 45 27](https://user-images.githubusercontent.com/522287/55275681-8ea52500-52fa-11e9-9181-4bf0f91fa435.png)

![Screenshot 2019-03-30 at 14 45 40](https://user-images.githubusercontent.com/522287/55275680-8ea52500-52fa-11e9-8f30-2215db9b5917.png)