### PR TITLE
enhance/unfound-insight-redirect

### DIFF
--- a/src/pages/Insights/InsightPage.js
+++ b/src/pages/Insights/InsightPage.js
@@ -30,7 +30,11 @@ const InsightPage = ({
   },
   ...rest
 }) => {
-  if (!data || data.loading || !data.insight) return null
+  if (!data || data.error) {
+    return <Redirect to='/insights' />
+  }
+
+  if (data.loading || !data.insight) return null
 
   if (isInsightADraftByDifferentUser(data.insight, userId)) {
     return <Redirect to='/insights' />


### PR DESCRIPTION
#### Summary
Redirecting to `/insights` if the requested insight was not found by using such link as `/insights/read/:id` (or any other reading link)