### PR TITLE
Navigate to projects page when a row from social-movers table is clicked

### DIFF
--- a/src/ducks/GainersAndLosers/GainersAndLosersTable.js
+++ b/src/ducks/GainersAndLosers/GainersAndLosersTable.js
@@ -65,8 +65,7 @@ const withGainersLosers = graphql(TOP_SOCIAL_GAINERS_LOSERS_QUERY, {
             .filter(({ slug }) => ownProps.allProjects[slug])
             .map(project => ({
               ...project,
-              ticker: ownProps.allProjects[project.slug].ticker,
-              name: ownProps.allProjects[project.slug].name
+              ...ownProps.allProjects[project.slug]
             }))
           : []
     }

--- a/src/ducks/GainersAndLosers/GainersLosersPage.js
+++ b/src/ducks/GainersAndLosers/GainersLosersPage.js
@@ -3,7 +3,7 @@ import { graphql } from 'react-apollo'
 import cx from 'classnames'
 import { Selector } from '@santiment-network/ui'
 import GainersLosersTable from './GainersAndLosersTable'
-import { allProjectsGQL } from '../../pages/Projects/allProjectsGQL'
+import { allProjectsForSearchGQL } from '../../pages/Projects/allProjectsGQL'
 import { mapItemsToKeys } from '../../utils/utils'
 import styles from './GainersAndLosersPage.module.scss'
 
@@ -64,7 +64,7 @@ class GainersAndLosersPage extends Component {
   }
 }
 
-const enhance = graphql(allProjectsGQL, {
+const enhance = graphql(allProjectsForSearchGQL, {
   props: ({ data: { allProjects = [], loading, error } }) => ({
     allProjects: !loading
       ? mapItemsToKeys(allProjects, { keyPath: 'slug' })

--- a/src/ducks/GainersAndLosers/gainers-and-losers-table-columns.js
+++ b/src/ducks/GainersAndLosers/gainers-and-losers-table-columns.js
@@ -1,7 +1,9 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import GainersLosersGraph from './GainersLosersGraph'
 import ProjectLabel from '../../components/ProjectLabel'
 import PercentChanges from '../../components/PercentChanges'
+import styles from './GainersAndLosersPage.module.scss'
 
 const getColumns = ({ timeWindow }) => [
   {
@@ -10,11 +12,19 @@ const getColumns = ({ timeWindow }) => [
     sortable: true,
     minWidth: 300,
     maxWidth: 450,
-    accessor: ({ ticker, name }) => ({
+    accessor: ({ ticker, name, coinmarketcapId }) => ({
       ticker,
-      name
+      name,
+      coinmarketcapId
     }),
-    Cell: ({ value }) => <ProjectLabel {...value} />
+    Cell: ({ value }) => (
+      <Link
+        className={styles.wrapper}
+        to={`/projects/${value.coinmarketcapId}`}
+      >
+        <ProjectLabel {...value} />
+      </Link>
+    )
   },
   {
     Header: 'Change',

--- a/src/ducks/GainersAndLosers/gainers-and-losers-table-columns.js
+++ b/src/ducks/GainersAndLosers/gainers-and-losers-table-columns.js
@@ -36,7 +36,7 @@ const getColumns = ({ timeWindow }) => [
       value ? <PercentChanges changes={value} /> : 'No data'
   },
   {
-    Header: 'Graph',
+    Header: '',
     id: 'status',
     minWidth: 320,
     Cell: ({ original }) => (


### PR DESCRIPTION
This PR contains:
  - Functionality to navigate to project page when row is clicked on social movers page
  - Better query that fetches only required data

No changes in UI.