### PR TITLE
enhance/trends-displayed-time

### DIFF
--- a/src/components/Trends/TrendsTable/TrendsTables.js
+++ b/src/components/Trends/TrendsTable/TrendsTables.js
@@ -14,7 +14,10 @@ class TrendsTables extends PureComponent {
             .slice(0, -1)
             .map((trend, index) => (
               <TrendsTable
-                header={`Compiled ${moment(trend.datetime).fromNow()}`}
+                header={`${moment(Date.now()).diff(
+                  new Date(trend.datetime),
+                  'hours'
+                )} hours ago`}
                 notSelected
                 key={index}
                 className={styles.table}


### PR DESCRIPTION
#### Summary
A better way to display when trends were compiled.

#### Screenshots
![image](https://user-images.githubusercontent.com/25135650/55682319-98520c80-593a-11e9-9fe9-0c36902095a1.png)
