### PR TITLE
feature/time-from-now-util

### DIFF
--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -2,7 +2,7 @@ export const ONE_SECOND_IN_MS = 1000
 export const ONE_MINUTE_IN_MS = ONE_SECOND_IN_MS * 60
 export const ONE_HOUR_IN_MS = ONE_MINUTE_IN_MS * 60
 export const ONE_DAY_IN_MS = ONE_HOUR_IN_MS * 24
-export const ONE_MONTH_IN_MS = ONE_DAY_IN_MS * 29 // Estimate
+export const ONE_MONTH_IN_MS = 2505600000 // Estimate
 export const ONE_YEAR_IN_MS = 31557600000 // Estimate
 
 export const SECOND = 's'
@@ -58,10 +58,10 @@ export const getTimeIntervalFromToday = (amount, dateFormat) => {
   }
 }
 
-const getDiffWithFormat = (diff, format) =>
+const calculateUnitByFormat = (diff, format) =>
   parseInt(diff / FormatToTimestamp[format], 10)
 
-const getFormattedDiffString = (amount, format) => {
+const getUnitFormattedString = (amount, format) => {
   if (format === SECOND && amount < 60) {
     return 'a few seconds ago'
   }
@@ -72,7 +72,11 @@ const getFormattedDiffString = (amount, format) => {
   return `${number}${FormatToString[format]}${plural} ago`
 }
 
-export const getTimeFromTo = (from, to = new Date(), format = YEAR) => {
+export const dateDifferenceInWords = ({
+  from,
+  to = new Date(),
+  format = YEAR
+}) => {
   const diff = to - from
   let resultFormat
 
@@ -103,8 +107,8 @@ export const getTimeFromTo = (from, to = new Date(), format = YEAR) => {
       result = monthDiff
     }
   } else {
-    result = getDiffWithFormat(diff, resultFormat)
+    result = calculateUnitByFormat(diff, resultFormat)
   }
 
-  return getFormattedDiffString(result, resultFormat)
+  return getUnitFormattedString(result, resultFormat)
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -72,6 +72,19 @@ const getUnitFormattedString = (amount, format) => {
   return `${number}${FormatToString[format]}${plural} ago`
 }
 
+/**
+ * @param {Object} args - Arguments
+ * @param {Date} args.from - from
+ * @param {Date} args.to - to
+ * @param {'y'|'m'|'d'|'h'|'min'|'s'} args.format - format in which return the string
+ *
+ * @example
+ * // Getting the difference from: 2nd April 2019
+ * // to: 4th April 2019
+ * dateDifferenceInWords({ from: new Date(2019, 3, 2), to: new Date(2019, 3, 4)})
+ * //=> '2 days ago'
+ *
+ */
 export const dateDifferenceInWords = ({
   from,
   to = new Date(),

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,9 +1,42 @@
+export const ONE_SECOND_IN_MS = 1000
+export const ONE_MINUTE_IN_MS = ONE_SECOND_IN_MS * 60
+export const ONE_HOUR_IN_MS = ONE_MINUTE_IN_MS * 60
+export const ONE_DAY_IN_MS = ONE_HOUR_IN_MS * 24
+
+export const SECOND = 's'
+export const MINUTE = 'min'
+export const HOUR = 'h'
+export const DAY = 'd'
+export const MONTH = 'm'
+export const YEAR = 'y'
+
 const DateFormat = {
-  m: ['getMonth', 'setMonth'],
-  d: ['getDate', 'setDate']
+  [MONTH]: ['getMonth', 'setMonth'],
+  [DAY]: ['getDate', 'setDate']
 }
 
+const FormatToIndex = {
+  [SECOND]: 0,
+  [MINUTE]: 1,
+  [HOUR]: 2,
+  [DAY]: 3,
+  [MONTH]: 4,
+  [YEAR]: 5
+}
+
+const FormatToString = {
+  [SECOND]: 'second',
+  [MINUTE]: 'minute',
+  [HOUR]: 'hour',
+  [DAY]: 'day',
+  [MONTH]: 'month',
+  [YEAR]: 'year'
+}
+
+const IndexToFormat = [SECOND, MINUTE, HOUR, DAY, MONTH, YEAR]
+
 export const getTimeIntervalFromToday = (amount, dateFormat) => {
+  ddd
   const from = new Date()
   const to = new Date()
   const [get, set] = DateFormat[dateFormat]
@@ -19,52 +52,36 @@ export const getTimeIntervalFromToday = (amount, dateFormat) => {
   }
 }
 
-const ONE_SECOND = 1000
-const ONE_MINUTE = ONE_SECOND * 60
-const ONE_HOUR = ONE_MINUTE * 60
-const ONE_DAY = ONE_HOUR * 24
-
-export const timeDifference = ({ from, to = Date.now() }) => {
+export const timeDifference = (from, to) => {
   const diff = to - from
   const result = []
 
-  const seconds = parseInt(diff / ONE_SECOND, 10)
+  const seconds = parseInt(diff / ONE_SECOND_IN_MS, 10)
   result.push(seconds)
 
   if (seconds < 60) return result
 
-  const minutes = parseInt(diff / ONE_MINUTE, 10)
+  const minutes = parseInt(diff / ONE_MINUTE_IN_MS, 10)
   result.push(minutes)
 
   if (minutes < 60) return result
 
-  const hours = parseInt(diff / ONE_HOUR, 10)
+  const hours = parseInt(diff / ONE_HOUR_IN_MS, 10)
   result.push(hours)
 
   if (hours < 24) return result
 
-  const days = parseInt(diff / ONE_DAY, 10)
+  const days = parseInt(diff / ONE_DAY_IN_MS, 10)
   result.push(days)
 
   return result
 }
 
-const FormatToIndex = {
-  s: 0,
-  min: 1,
-  h: 2,
-  d: 3,
-  m: 4,
-  y: 5
-}
-
-const IndexToFormat = ['s', 'min', 'h', 'd', 'm', 'y']
-
 const _getTimeFromTo = (from, to = new Date(), format = 'y') => {
-  if (format === 'y') {
+  if (format === YEAR) {
     return to.getFullYear() - from.getFullYear()
   }
-  if (format === 'm') {
+  if (format === MONTH) {
     let months = to.getMonth() - from.getMonth()
     if (months < 0) {
       months += 12
@@ -72,20 +89,11 @@ const _getTimeFromTo = (from, to = new Date(), format = 'y') => {
     return months
   }
 
-  return timeDifference({ from, to })[FormatToIndex[format]]
-}
-
-const FormatToString = {
-  s: 'second',
-  min: 'minute',
-  h: 'hour',
-  d: 'day',
-  m: 'month',
-  y: 'year'
+  return timeDifference(from, to)[FormatToIndex[format]]
 }
 
 const getFormattedDiffString = (amount, format) => {
-  if (format === 's' && amount < 60) {
+  if (format === SECOND && amount < 60) {
     return 'a few seconds ago'
   }
 
@@ -94,7 +102,7 @@ const getFormattedDiffString = (amount, format) => {
   let plural = ''
 
   if (amount === 1) {
-    article = format === 'h' ? 'an ' : 'a '
+    article = format === HOUR ? 'an ' : 'a '
   } else {
     plural = 's'
     number = amount + ' '
@@ -103,7 +111,7 @@ const getFormattedDiffString = (amount, format) => {
   return `${article}${number}${FormatToString[format]}${plural} ago`
 }
 
-export const getTimeFromTo = (from, to = new Date(), format = 'y') => {
+export const getTimeFromTo = (from, to = new Date(), format = YEAR) => {
   let index = FormatToIndex[format]
   let result
 

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -36,7 +36,6 @@ const FormatToString = {
 const IndexToFormat = [SECOND, MINUTE, HOUR, DAY, MONTH, YEAR]
 
 export const getTimeIntervalFromToday = (amount, dateFormat) => {
-  ddd
   const from = new Date()
   const to = new Date()
   const [get, set] = DateFormat[dateFormat]
@@ -78,15 +77,15 @@ export const timeDifference = (from, to) => {
 }
 
 const _getTimeFromTo = (from, to = new Date(), format = 'y') => {
-  if (format === YEAR) {
-    return to.getFullYear() - from.getFullYear()
+  const yearDiff = to.getFullYear() - from.getFullYear()
+  const monthDiff = to.getMonth() - from.getMonth() + yearDiff * 12
+
+  if (format === YEAR && monthDiff > 11) {
+    return yearDiff
   }
+
   if (format === MONTH) {
-    let months = to.getMonth() - from.getMonth()
-    if (months < 0) {
-      months += 12
-    }
-    return months
+    return monthDiff
   }
 
   return timeDifference(from, to)[FormatToIndex[format]]

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -3,7 +3,7 @@ export const ONE_MINUTE_IN_MS = ONE_SECOND_IN_MS * 60
 export const ONE_HOUR_IN_MS = ONE_MINUTE_IN_MS * 60
 export const ONE_DAY_IN_MS = ONE_HOUR_IN_MS * 24
 export const ONE_MONTH_IN_MS = ONE_DAY_IN_MS * 29 // Estimate
-export const ONE_YEAR_IN_MS = 31557600000 - ONE_MONTH_IN_MS // Estimate
+export const ONE_YEAR_IN_MS = 31557600000 // Estimate
 
 export const SECOND = 's'
 export const MINUTE = 'min'
@@ -35,7 +35,12 @@ const FormatToString = {
   [YEAR]: 'year'
 }
 
-const IndexToFormat = [SECOND, MINUTE, HOUR, DAY, MONTH, YEAR]
+const FormatToTimestamp = {
+  [SECOND]: ONE_SECOND_IN_MS,
+  [MINUTE]: ONE_MINUTE_IN_MS,
+  [HOUR]: ONE_HOUR_IN_MS,
+  [DAY]: ONE_DAY_IN_MS
+}
 
 export const getTimeIntervalFromToday = (amount, dateFormat) => {
   const from = new Date()
@@ -53,61 +58,9 @@ export const getTimeIntervalFromToday = (amount, dateFormat) => {
   }
 }
 
-export const timeDifference = (from, to) => {
-  const diff = to - from
-  const result = []
-
-  const seconds = parseInt(diff / ONE_SECOND_IN_MS, 10)
-  result.push(seconds)
-
-  if (seconds < 60) return result
-
-  const minutes = parseInt(diff / ONE_MINUTE_IN_MS, 10)
-  result.push(minutes)
-
-  if (minutes < 60) return result
-
-  const hours = parseInt(diff / ONE_HOUR_IN_MS, 10)
-  result.push(hours)
-
-  if (hours < 24) return result
-
-  const days = parseInt(diff / ONE_DAY_IN_MS, 10)
-  result.push(days)
-
-  return result
-}
-
-const FormatToTimestamp = {
-  [SECOND]: ONE_SECOND_IN_MS,
-  [MINUTE]: ONE_MINUTE_IN_MS,
-  [HOUR]: ONE_HOUR_IN_MS,
-  [DAY]: ONE_DAY_IN_MS
-}
-
 const getDiffWithFormat = (diff, format) =>
   parseInt(diff / FormatToTimestamp[format], 10)
 
-const _getTimeFromTo = (from, to = new Date(), format = YEAR) => {
-  const isFormatYear = format === YEAR
-  if (isFormatYear || format === MONTH) {
-    const yearDiff = to.getFullYear() - from.getFullYear()
-    const monthDiff = to.getMonth() - from.getMonth() + yearDiff * 12
-
-    if (isFormatYear && monthDiff > 11) {
-      return yearDiff
-    }
-
-    const dayDiff = getDiffWithFormat(to - from, DAY)
-
-    if (format === MONTH && dayDiff > 28) {
-      return monthDiff
-    }
-  }
-
-  /* return timeDifference(from, to)[FormatToIndex[format]] */
-  return getDiffWithFormat(to - from, format)
-}
 const getFormattedDiffString = (amount, format) => {
   if (format === SECOND && amount < 60) {
     return 'a few seconds ago'
@@ -120,19 +73,6 @@ const getFormattedDiffString = (amount, format) => {
 }
 
 export const getTimeFromTo = (from, to = new Date(), format = YEAR) => {
-  let index = FormatToIndex[format]
-  let result
-
-  while (index > -1) {
-    result = _getTimeFromTo(from, to, IndexToFormat[index])
-    if (result) break
-    index--
-  }
-
-  return getFormattedDiffString(result, IndexToFormat[index])
-}
-
-export const new_getTimeFromTo = (from, to = new Date(), format = YEAR) => {
   const diff = to - from
   let resultFormat
 
@@ -153,16 +93,18 @@ export const new_getTimeFromTo = (from, to = new Date(), format = YEAR) => {
     FormatToIndex[format] < FormatToIndex[resultFormat] ? format : resultFormat
 
   let result
-  if (resultFormat === YEAR) {
-    result = to.getFullYear() - from.getFullYear()
-  } else if (resultFormat === MONTH) {
-    result =
-      to.getMonth() -
-      from.getMonth() +
-      (to.getFullYear() - from.getFullYear()) * 12
+  if (resultFormat === YEAR || resultFormat === MONTH) {
+    const yearDiff = to.getFullYear() - from.getFullYear()
+    const monthDiff = to.getMonth() - from.getMonth() + yearDiff * 12
+    if (monthDiff > 11 && format === YEAR) {
+      resultFormat = YEAR
+      result = yearDiff
+    } else {
+      result = monthDiff
+    }
   } else {
     result = getDiffWithFormat(diff, resultFormat)
   }
-  /* return timeDifference(from, to)[FormatToIndex[format]] */
+
   return getFormattedDiffString(result, resultFormat)
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -18,3 +18,100 @@ export const getTimeIntervalFromToday = (amount, dateFormat) => {
     to
   }
 }
+
+const ONE_SECOND = 1000
+const ONE_MINUTE = ONE_SECOND * 60
+const ONE_HOUR = ONE_MINUTE * 60
+const ONE_DAY = ONE_HOUR * 24
+
+export const timeDifference = ({ from, to = Date.now() }) => {
+  const diff = to - from
+  const result = []
+
+  const seconds = parseInt(diff / ONE_SECOND, 10)
+  result.push(seconds)
+
+  if (seconds < 60) return result
+
+  const minutes = parseInt(diff / ONE_MINUTE, 10)
+  result.push(minutes)
+
+  if (minutes < 60) return result
+
+  const hours = parseInt(diff / ONE_HOUR, 10)
+  result.push(hours)
+
+  if (hours < 24) return result
+
+  const days = parseInt(diff / ONE_DAY, 10)
+  result.push(days)
+
+  return result
+}
+
+const FormatToIndex = {
+  s: 0,
+  min: 1,
+  h: 2,
+  d: 3,
+  m: 4,
+  y: 5
+}
+
+const IndexToFormat = ['s', 'min', 'h', 'd', 'm', 'y']
+
+const _getTimeFromTo = (from, to = new Date(), format = 'y') => {
+  if (format === 'y') {
+    return to.getFullYear() - from.getFullYear()
+  }
+  if (format === 'm') {
+    let months = to.getMonth() - from.getMonth()
+    if (months < 0) {
+      months += 12
+    }
+    return months
+  }
+
+  return timeDifference({ from, to })[FormatToIndex[format]]
+}
+
+const FormatToString = {
+  s: 'second',
+  min: 'minute',
+  h: 'hour',
+  d: 'day',
+  m: 'month',
+  y: 'year'
+}
+
+const getFormattedDiffString = (amount, format) => {
+  if (format === 's' && amount < 60) {
+    return 'a few seconds ago'
+  }
+
+  let article = ''
+  let number = ''
+  let plural = ''
+
+  if (amount === 1) {
+    article = format === 'h' ? 'an ' : 'a '
+  } else {
+    plural = 's'
+    number = amount + ' '
+  }
+
+  return `${article}${number}${FormatToString[format]}${plural} ago`
+}
+
+export const getTimeFromTo = (from, to = new Date(), format = 'y') => {
+  let index = FormatToIndex[format]
+  let result
+
+  while (index > -1) {
+    result = _getTimeFromTo(from, to, IndexToFormat[index])
+    if (result) break
+    index--
+  }
+
+  return getFormattedDiffString(result, IndexToFormat[index])
+}

--- a/src/utils/dates.spec.js
+++ b/src/utils/dates.spec.js
@@ -1,0 +1,120 @@
+/* eslint-env jest */
+import { getTimeFromTo } from './dates'
+
+const TO = new Date('2019-04-08T08:05:50.038Z')
+
+describe('getTimeFromTo', () => {
+  describe('specified format', () => {
+    it('should return seconds string', () => {
+      const FROM = new Date('2019-04-08T08:05:40.038Z')
+      expect(getTimeFromTo(FROM, TO, 's')).toEqual('a few seconds ago')
+    })
+
+    it('should return minute string', () => {
+      const FROM = new Date('2019-04-08T08:04:50.038Z')
+      expect(getTimeFromTo(FROM, TO, 'min')).toEqual('a minute ago')
+    })
+
+    it('should return minutes (plural) string', () => {
+      const FROM = new Date('2019-04-08T08:03:50.038Z')
+      expect(getTimeFromTo(FROM, TO, 'min')).toEqual('2 minutes ago')
+    })
+
+    it('should return hour string', () => {
+      const FROM = new Date('2019-04-08T07:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO, 'h')).toEqual('an hour ago')
+    })
+
+    it('should return hours (plural) string', () => {
+      const FROM = new Date('2019-04-08T06:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO, 'h')).toEqual('2 hours ago')
+    })
+
+    it('should return day string', () => {
+      const FROM = new Date('2019-04-07T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO, 'd')).toEqual('a day ago')
+    })
+
+    it('should return days (plural) string', () => {
+      const FROM = new Date('2019-04-06T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO, 'd')).toEqual('2 days ago')
+    })
+
+    it('should return month string', () => {
+      const FROM = new Date('2019-03-08T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO, 'm')).toEqual('a month ago')
+    })
+
+    it('should return months (plural) string', () => {
+      const FROM = new Date('2019-02-08T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO, 'm')).toEqual('2 months ago')
+    })
+
+    it('should return year string', () => {
+      const FROM = new Date('2018-04-08T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO, 'y')).toEqual('a year ago')
+    })
+
+    it('should return months (plural) string', () => {
+      const FROM = new Date('2017-04-08T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO, 'y')).toEqual('2 years ago')
+    })
+  })
+
+  describe('auto format', () => {
+    it('should return seconds string', () => {
+      const FROM = new Date('2019-04-08T08:05:40.038Z')
+      expect(getTimeFromTo(FROM, TO)).toEqual('a few seconds ago')
+    })
+
+    it('should return minute string', () => {
+      const FROM = new Date('2019-04-08T08:04:50.038Z')
+      expect(getTimeFromTo(FROM, TO)).toEqual('a minute ago')
+    })
+
+    it('should return minutes (plural) string', () => {
+      const FROM = new Date('2019-04-08T08:03:50.038Z')
+      expect(getTimeFromTo(FROM, TO)).toEqual('2 minutes ago')
+    })
+
+    it('should return hour string', () => {
+      const FROM = new Date('2019-04-08T07:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO)).toEqual('an hour ago')
+    })
+
+    it('should return hours (plural) string', () => {
+      const FROM = new Date('2019-04-08T06:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO)).toEqual('2 hours ago')
+    })
+
+    it('should return day string', () => {
+      const FROM = new Date('2019-04-07T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO)).toEqual('a day ago')
+    })
+
+    it('should return days (plural) string', () => {
+      const FROM = new Date('2019-04-06T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO)).toEqual('2 days ago')
+    })
+
+    it('should return month string', () => {
+      const FROM = new Date('2019-03-08T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO)).toEqual('a month ago')
+    })
+
+    it('should return months (plural) string', () => {
+      const FROM = new Date('2019-02-08T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO)).toEqual('2 months ago')
+    })
+
+    it('should return year string', () => {
+      const FROM = new Date('2018-04-08T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO)).toEqual('a year ago')
+    })
+
+    it('should return months (plural) string', () => {
+      const FROM = new Date('2017-04-08T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO)).toEqual('2 years ago')
+    })
+  })
+})

--- a/src/utils/dates.spec.js
+++ b/src/utils/dates.spec.js
@@ -117,4 +117,23 @@ describe('getTimeFromTo', () => {
       expect(getTimeFromTo(FROM, TO)).toEqual('2 years ago')
     })
   })
+
+  describe('special cases', () => {
+    it('should return year difference in months', () => {
+      const FROM = new Date('2018-03-08T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO, 'm')).toEqual('13 months ago')
+    })
+
+    it('should return month difference when year changed but 12 months not passed', () => {
+      const FROM = new Date('2018-12-08T08:05:50.038Z')
+      const TO_SPECIAL = new Date('2019-01-08T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO_SPECIAL, 'm')).toEqual('a month ago')
+    })
+
+    it('should return month difference when year changed but 12 months not passed (auto format)', () => {
+      const FROM = new Date('2018-12-08T08:05:50.038Z')
+      const TO_SPECIAL = new Date('2019-01-08T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO_SPECIAL)).toEqual('a month ago')
+    })
+  })
 })

--- a/src/utils/dates.spec.js
+++ b/src/utils/dates.spec.js
@@ -1,151 +1,157 @@
 /* eslint-env jest */
-import { new_getTimeFromTo } from './dates'
+import { getTimeFromTo } from './dates'
 
 const TO = new Date('2019-04-08T08:05:50.038Z')
 
-describe('new_getTimeFromTo', () => {
+describe('getTimeFromTo', () => {
   describe('specified format', () => {
     it('should return seconds string', () => {
       const FROM = new Date('2019-04-08T08:05:40.038Z')
-      expect(new_getTimeFromTo(FROM, TO, 's')).toEqual('a few seconds ago')
+      expect(getTimeFromTo(FROM, TO, 's')).toEqual('a few seconds ago')
     })
 
     it('should return minute string', () => {
       const FROM = new Date('2019-04-08T08:04:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO, 'min')).toEqual('1 minute ago')
+      expect(getTimeFromTo(FROM, TO, 'min')).toEqual('1 minute ago')
     })
 
     it('should return minutes (plural) string', () => {
       const FROM = new Date('2019-04-08T08:03:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO, 'min')).toEqual('2 minutes ago')
+      expect(getTimeFromTo(FROM, TO, 'min')).toEqual('2 minutes ago')
     })
 
     it('should return hour string', () => {
       const FROM = new Date('2019-04-08T07:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO, 'h')).toEqual('1 hour ago')
+      expect(getTimeFromTo(FROM, TO, 'h')).toEqual('1 hour ago')
     })
 
     it('should return hours (plural) string', () => {
       const FROM = new Date('2019-04-08T06:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO, 'h')).toEqual('2 hours ago')
+      expect(getTimeFromTo(FROM, TO, 'h')).toEqual('2 hours ago')
     })
 
     it('should return day string', () => {
       const FROM = new Date('2019-04-07T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO, 'd')).toEqual('1 day ago')
+      expect(getTimeFromTo(FROM, TO, 'd')).toEqual('1 day ago')
     })
 
     it('should return days (plural) string', () => {
       const FROM = new Date('2019-04-06T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO, 'd')).toEqual('2 days ago')
+      expect(getTimeFromTo(FROM, TO, 'd')).toEqual('2 days ago')
     })
 
     it('should return month string', () => {
       const FROM = new Date('2019-03-08T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO, 'm')).toEqual('1 month ago')
+      expect(getTimeFromTo(FROM, TO, 'm')).toEqual('1 month ago')
     })
 
     it('should return months (plural) string', () => {
       const FROM = new Date('2019-02-08T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO, 'm')).toEqual('2 months ago')
+      expect(getTimeFromTo(FROM, TO, 'm')).toEqual('2 months ago')
     })
 
     it('should return year string', () => {
       const FROM = new Date('2018-04-08T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO, 'y')).toEqual('1 year ago')
+      expect(getTimeFromTo(FROM, TO, 'y')).toEqual('1 year ago')
     })
 
     it('should return years (plural) string', () => {
       const FROM = new Date('2017-04-08T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO, 'y')).toEqual('2 years ago')
+      expect(getTimeFromTo(FROM, TO, 'y')).toEqual('2 years ago')
     })
   })
 
   describe('auto format', () => {
     it('should return seconds string', () => {
       const FROM = new Date('2019-04-08T08:05:40.038Z')
-      expect(new_getTimeFromTo(FROM, TO)).toEqual('a few seconds ago')
+      expect(getTimeFromTo(FROM, TO)).toEqual('a few seconds ago')
     })
 
     it('should return minute string', () => {
       const FROM = new Date('2019-04-08T08:04:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO)).toEqual('1 minute ago')
+      expect(getTimeFromTo(FROM, TO)).toEqual('1 minute ago')
     })
 
     it('should return minutes (plural) string', () => {
       const FROM = new Date('2019-04-08T08:03:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO)).toEqual('2 minutes ago')
+      expect(getTimeFromTo(FROM, TO)).toEqual('2 minutes ago')
     })
 
     it('should return hour string', () => {
       const FROM = new Date('2019-04-08T07:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO)).toEqual('1 hour ago')
+      expect(getTimeFromTo(FROM, TO)).toEqual('1 hour ago')
     })
 
     it('should return hours (plural) string', () => {
       const FROM = new Date('2019-04-08T06:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO)).toEqual('2 hours ago')
+      expect(getTimeFromTo(FROM, TO)).toEqual('2 hours ago')
     })
 
     it('should return day string', () => {
       const FROM = new Date('2019-04-07T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO)).toEqual('1 day ago')
+      expect(getTimeFromTo(FROM, TO)).toEqual('1 day ago')
     })
 
     it('should return days (plural) string', () => {
       const FROM = new Date('2019-04-06T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO)).toEqual('2 days ago')
+      expect(getTimeFromTo(FROM, TO)).toEqual('2 days ago')
     })
 
     it('should return month string', () => {
       const FROM = new Date('2019-03-08T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO)).toEqual('1 month ago')
+      expect(getTimeFromTo(FROM, TO)).toEqual('1 month ago')
     })
 
     it('should return months (plural) string', () => {
       const FROM = new Date('2019-02-08T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO)).toEqual('2 months ago')
+      expect(getTimeFromTo(FROM, TO)).toEqual('2 months ago')
     })
 
     it('should return year string', () => {
       const FROM = new Date('2018-04-08T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO)).toEqual('1 year ago')
+      expect(getTimeFromTo(FROM, TO)).toEqual('1 year ago')
     })
 
     it('should return years (plural) string', () => {
       const FROM = new Date('2017-04-08T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO)).toEqual('2 years ago')
+      expect(getTimeFromTo(FROM, TO)).toEqual('2 years ago')
     })
   })
 
   describe('special cases', () => {
     it('should return year difference in months', () => {
       const FROM = new Date('2018-03-08T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO, 'm')).toEqual('13 months ago')
+      expect(getTimeFromTo(FROM, TO, 'm')).toEqual('13 months ago')
     })
 
     it('should return days difference when month changed but 30 days not passed', () => {
       const FROM = new Date('2019-03-28T08:05:50.038Z')
       const TO_SPECIAL = new Date('2019-04-08T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO_SPECIAL, 'd')).toEqual('11 days ago')
+      expect(getTimeFromTo(FROM, TO_SPECIAL, 'd')).toEqual('11 days ago')
     })
 
     it('should return days difference when month changed but 30 days not passed (auto format)', () => {
       const FROM = new Date('2019-03-28T08:05:50.038Z')
       const TO_SPECIAL = new Date('2019-04-08T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO_SPECIAL)).toEqual('11 days ago')
+      expect(getTimeFromTo(FROM, TO_SPECIAL)).toEqual('11 days ago')
     })
 
     it('should return month difference when year changed but 12 months not passed', () => {
       const FROM = new Date('2018-12-08T08:05:50.038Z')
       const TO_SPECIAL = new Date('2019-01-08T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO_SPECIAL, 'm')).toEqual('1 month ago')
+      expect(getTimeFromTo(FROM, TO_SPECIAL, 'm')).toEqual('1 month ago')
     })
 
     it('should return month difference when year changed but 12 months not passed (auto format)', () => {
       const FROM = new Date('2018-12-08T08:05:50.038Z')
       const TO_SPECIAL = new Date('2019-01-08T08:05:50.038Z')
-      expect(new_getTimeFromTo(FROM, TO_SPECIAL)).toEqual('1 month ago')
+      expect(getTimeFromTo(FROM, TO_SPECIAL)).toEqual('1 month ago')
+    })
+
+    it('should return 11 month when it close to the 1 year difference', () => {
+      const FROM = new Date('2019-01-08T08:05:50.038Z')
+      const TO_SPECIAL = new Date('2019-12-29T08:05:50.038Z')
+      expect(getTimeFromTo(FROM, TO_SPECIAL)).toEqual('11 months ago')
     })
   })
 })

--- a/src/utils/dates.spec.js
+++ b/src/utils/dates.spec.js
@@ -1,139 +1,151 @@
 /* eslint-env jest */
-import { getTimeFromTo } from './dates'
+import { new_getTimeFromTo } from './dates'
 
 const TO = new Date('2019-04-08T08:05:50.038Z')
 
-describe('getTimeFromTo', () => {
+describe('new_getTimeFromTo', () => {
   describe('specified format', () => {
     it('should return seconds string', () => {
       const FROM = new Date('2019-04-08T08:05:40.038Z')
-      expect(getTimeFromTo(FROM, TO, 's')).toEqual('a few seconds ago')
+      expect(new_getTimeFromTo(FROM, TO, 's')).toEqual('a few seconds ago')
     })
 
     it('should return minute string', () => {
       const FROM = new Date('2019-04-08T08:04:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'min')).toEqual('a minute ago')
+      expect(new_getTimeFromTo(FROM, TO, 'min')).toEqual('1 minute ago')
     })
 
     it('should return minutes (plural) string', () => {
       const FROM = new Date('2019-04-08T08:03:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'min')).toEqual('2 minutes ago')
+      expect(new_getTimeFromTo(FROM, TO, 'min')).toEqual('2 minutes ago')
     })
 
     it('should return hour string', () => {
       const FROM = new Date('2019-04-08T07:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'h')).toEqual('an hour ago')
+      expect(new_getTimeFromTo(FROM, TO, 'h')).toEqual('1 hour ago')
     })
 
     it('should return hours (plural) string', () => {
       const FROM = new Date('2019-04-08T06:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'h')).toEqual('2 hours ago')
+      expect(new_getTimeFromTo(FROM, TO, 'h')).toEqual('2 hours ago')
     })
 
     it('should return day string', () => {
       const FROM = new Date('2019-04-07T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'd')).toEqual('a day ago')
+      expect(new_getTimeFromTo(FROM, TO, 'd')).toEqual('1 day ago')
     })
 
     it('should return days (plural) string', () => {
       const FROM = new Date('2019-04-06T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'd')).toEqual('2 days ago')
+      expect(new_getTimeFromTo(FROM, TO, 'd')).toEqual('2 days ago')
     })
 
     it('should return month string', () => {
       const FROM = new Date('2019-03-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'm')).toEqual('a month ago')
+      expect(new_getTimeFromTo(FROM, TO, 'm')).toEqual('1 month ago')
     })
 
     it('should return months (plural) string', () => {
       const FROM = new Date('2019-02-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'm')).toEqual('2 months ago')
+      expect(new_getTimeFromTo(FROM, TO, 'm')).toEqual('2 months ago')
     })
 
     it('should return year string', () => {
       const FROM = new Date('2018-04-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'y')).toEqual('a year ago')
+      expect(new_getTimeFromTo(FROM, TO, 'y')).toEqual('1 year ago')
     })
 
-    it('should return months (plural) string', () => {
+    it('should return years (plural) string', () => {
       const FROM = new Date('2017-04-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'y')).toEqual('2 years ago')
+      expect(new_getTimeFromTo(FROM, TO, 'y')).toEqual('2 years ago')
     })
   })
 
   describe('auto format', () => {
     it('should return seconds string', () => {
       const FROM = new Date('2019-04-08T08:05:40.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('a few seconds ago')
+      expect(new_getTimeFromTo(FROM, TO)).toEqual('a few seconds ago')
     })
 
     it('should return minute string', () => {
       const FROM = new Date('2019-04-08T08:04:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('a minute ago')
+      expect(new_getTimeFromTo(FROM, TO)).toEqual('1 minute ago')
     })
 
     it('should return minutes (plural) string', () => {
       const FROM = new Date('2019-04-08T08:03:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('2 minutes ago')
+      expect(new_getTimeFromTo(FROM, TO)).toEqual('2 minutes ago')
     })
 
     it('should return hour string', () => {
       const FROM = new Date('2019-04-08T07:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('an hour ago')
+      expect(new_getTimeFromTo(FROM, TO)).toEqual('1 hour ago')
     })
 
     it('should return hours (plural) string', () => {
       const FROM = new Date('2019-04-08T06:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('2 hours ago')
+      expect(new_getTimeFromTo(FROM, TO)).toEqual('2 hours ago')
     })
 
     it('should return day string', () => {
       const FROM = new Date('2019-04-07T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('a day ago')
+      expect(new_getTimeFromTo(FROM, TO)).toEqual('1 day ago')
     })
 
     it('should return days (plural) string', () => {
       const FROM = new Date('2019-04-06T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('2 days ago')
+      expect(new_getTimeFromTo(FROM, TO)).toEqual('2 days ago')
     })
 
     it('should return month string', () => {
       const FROM = new Date('2019-03-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('a month ago')
+      expect(new_getTimeFromTo(FROM, TO)).toEqual('1 month ago')
     })
 
     it('should return months (plural) string', () => {
       const FROM = new Date('2019-02-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('2 months ago')
+      expect(new_getTimeFromTo(FROM, TO)).toEqual('2 months ago')
     })
 
     it('should return year string', () => {
       const FROM = new Date('2018-04-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('a year ago')
+      expect(new_getTimeFromTo(FROM, TO)).toEqual('1 year ago')
     })
 
-    it('should return months (plural) string', () => {
+    it('should return years (plural) string', () => {
       const FROM = new Date('2017-04-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('2 years ago')
+      expect(new_getTimeFromTo(FROM, TO)).toEqual('2 years ago')
     })
   })
 
   describe('special cases', () => {
     it('should return year difference in months', () => {
       const FROM = new Date('2018-03-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'm')).toEqual('13 months ago')
+      expect(new_getTimeFromTo(FROM, TO, 'm')).toEqual('13 months ago')
+    })
+
+    it('should return days difference when month changed but 30 days not passed', () => {
+      const FROM = new Date('2019-03-28T08:05:50.038Z')
+      const TO_SPECIAL = new Date('2019-04-08T08:05:50.038Z')
+      expect(new_getTimeFromTo(FROM, TO_SPECIAL, 'd')).toEqual('11 days ago')
+    })
+
+    it('should return days difference when month changed but 30 days not passed (auto format)', () => {
+      const FROM = new Date('2019-03-28T08:05:50.038Z')
+      const TO_SPECIAL = new Date('2019-04-08T08:05:50.038Z')
+      expect(new_getTimeFromTo(FROM, TO_SPECIAL)).toEqual('11 days ago')
     })
 
     it('should return month difference when year changed but 12 months not passed', () => {
       const FROM = new Date('2018-12-08T08:05:50.038Z')
       const TO_SPECIAL = new Date('2019-01-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO_SPECIAL, 'm')).toEqual('a month ago')
+      expect(new_getTimeFromTo(FROM, TO_SPECIAL, 'm')).toEqual('1 month ago')
     })
 
     it('should return month difference when year changed but 12 months not passed (auto format)', () => {
       const FROM = new Date('2018-12-08T08:05:50.038Z')
       const TO_SPECIAL = new Date('2019-01-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO_SPECIAL)).toEqual('a month ago')
+      expect(new_getTimeFromTo(FROM, TO_SPECIAL)).toEqual('1 month ago')
     })
   })
 })

--- a/src/utils/dates.spec.js
+++ b/src/utils/dates.spec.js
@@ -1,157 +1,211 @@
 /* eslint-env jest */
-import { getTimeFromTo } from './dates'
+import { dateDifferenceInWords } from './dates'
 
 const TO = new Date('2019-04-08T08:05:50.038Z')
 
-describe('getTimeFromTo', () => {
+describe('dateDifferenceInWords', () => {
   describe('specified format', () => {
     it('should return seconds string', () => {
       const FROM = new Date('2019-04-08T08:05:40.038Z')
-      expect(getTimeFromTo(FROM, TO, 's')).toEqual('a few seconds ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO, format: 's' })
+      ).toEqual('a few seconds ago')
     })
 
     it('should return minute string', () => {
       const FROM = new Date('2019-04-08T08:04:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'min')).toEqual('1 minute ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO, format: 'min' })
+      ).toEqual('1 minute ago')
     })
 
     it('should return minutes (plural) string', () => {
       const FROM = new Date('2019-04-08T08:03:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'min')).toEqual('2 minutes ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO, format: 'min' })
+      ).toEqual('2 minutes ago')
     })
 
     it('should return hour string', () => {
       const FROM = new Date('2019-04-08T07:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'h')).toEqual('1 hour ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO, format: 'h' })
+      ).toEqual('1 hour ago')
     })
 
     it('should return hours (plural) string', () => {
       const FROM = new Date('2019-04-08T06:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'h')).toEqual('2 hours ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO, format: 'h' })
+      ).toEqual('2 hours ago')
     })
 
     it('should return day string', () => {
       const FROM = new Date('2019-04-07T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'd')).toEqual('1 day ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO, format: 'd' })
+      ).toEqual('1 day ago')
     })
 
     it('should return days (plural) string', () => {
       const FROM = new Date('2019-04-06T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'd')).toEqual('2 days ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO, format: 'd' })
+      ).toEqual('2 days ago')
     })
 
     it('should return month string', () => {
       const FROM = new Date('2019-03-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'm')).toEqual('1 month ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO, format: 'm' })
+      ).toEqual('1 month ago')
     })
 
     it('should return months (plural) string', () => {
       const FROM = new Date('2019-02-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'm')).toEqual('2 months ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO, format: 'm' })
+      ).toEqual('2 months ago')
     })
 
     it('should return year string', () => {
       const FROM = new Date('2018-04-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'y')).toEqual('1 year ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO, format: 'y' })
+      ).toEqual('1 year ago')
     })
 
     it('should return years (plural) string', () => {
       const FROM = new Date('2017-04-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'y')).toEqual('2 years ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO, format: 'y' })
+      ).toEqual('2 years ago')
     })
   })
 
   describe('auto format', () => {
     it('should return seconds string', () => {
       const FROM = new Date('2019-04-08T08:05:40.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('a few seconds ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO })).toEqual(
+        'a few seconds ago'
+      )
     })
 
     it('should return minute string', () => {
       const FROM = new Date('2019-04-08T08:04:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('1 minute ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO })).toEqual(
+        '1 minute ago'
+      )
     })
 
     it('should return minutes (plural) string', () => {
       const FROM = new Date('2019-04-08T08:03:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('2 minutes ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO })).toEqual(
+        '2 minutes ago'
+      )
     })
 
     it('should return hour string', () => {
       const FROM = new Date('2019-04-08T07:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('1 hour ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO })).toEqual(
+        '1 hour ago'
+      )
     })
 
     it('should return hours (plural) string', () => {
       const FROM = new Date('2019-04-08T06:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('2 hours ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO })).toEqual(
+        '2 hours ago'
+      )
     })
 
     it('should return day string', () => {
       const FROM = new Date('2019-04-07T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('1 day ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO })).toEqual('1 day ago')
     })
 
     it('should return days (plural) string', () => {
       const FROM = new Date('2019-04-06T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('2 days ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO })).toEqual(
+        '2 days ago'
+      )
     })
 
     it('should return month string', () => {
       const FROM = new Date('2019-03-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('1 month ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO })).toEqual(
+        '1 month ago'
+      )
     })
 
     it('should return months (plural) string', () => {
       const FROM = new Date('2019-02-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('2 months ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO })).toEqual(
+        '2 months ago'
+      )
     })
 
     it('should return year string', () => {
       const FROM = new Date('2018-04-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('1 year ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO })).toEqual(
+        '1 year ago'
+      )
     })
 
     it('should return years (plural) string', () => {
       const FROM = new Date('2017-04-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO)).toEqual('2 years ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO })).toEqual(
+        '2 years ago'
+      )
     })
   })
 
   describe('special cases', () => {
     it('should return year difference in months', () => {
       const FROM = new Date('2018-03-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO, 'm')).toEqual('13 months ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO, format: 'm' })
+      ).toEqual('13 months ago')
     })
 
     it('should return days difference when month changed but 30 days not passed', () => {
       const FROM = new Date('2019-03-28T08:05:50.038Z')
       const TO_SPECIAL = new Date('2019-04-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO_SPECIAL, 'd')).toEqual('11 days ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO_SPECIAL, format: 'd' })
+      ).toEqual('11 days ago')
     })
 
     it('should return days difference when month changed but 30 days not passed (auto format)', () => {
       const FROM = new Date('2019-03-28T08:05:50.038Z')
       const TO_SPECIAL = new Date('2019-04-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO_SPECIAL)).toEqual('11 days ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO_SPECIAL })).toEqual(
+        '11 days ago'
+      )
     })
 
     it('should return month difference when year changed but 12 months not passed', () => {
       const FROM = new Date('2018-12-08T08:05:50.038Z')
       const TO_SPECIAL = new Date('2019-01-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO_SPECIAL, 'm')).toEqual('1 month ago')
+      expect(
+        dateDifferenceInWords({ from: FROM, to: TO_SPECIAL, format: 'm' })
+      ).toEqual('1 month ago')
     })
 
     it('should return month difference when year changed but 12 months not passed (auto format)', () => {
       const FROM = new Date('2018-12-08T08:05:50.038Z')
       const TO_SPECIAL = new Date('2019-01-08T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO_SPECIAL)).toEqual('1 month ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO_SPECIAL })).toEqual(
+        '1 month ago'
+      )
     })
 
     it('should return 11 month when it close to the 1 year difference', () => {
       const FROM = new Date('2019-01-08T08:05:50.038Z')
       const TO_SPECIAL = new Date('2019-12-29T08:05:50.038Z')
-      expect(getTimeFromTo(FROM, TO_SPECIAL)).toEqual('11 months ago')
+      expect(dateDifferenceInWords({ from: FROM, to: TO_SPECIAL })).toEqual(
+        '11 months ago'
+      )
     })
   })
 })


### PR DESCRIPTION
#### Summary
Santiment alternative to the [`moment().fromNow()`](https://momentjs.com/docs/#/displaying/fromnow/) method.

#### Benchmarks
[Benchmark](https://jsperf.com/time-from-now) of the current implementation. On average, this implementation is `18x` faster than `moment` and `2x` faster than `date-fns`
![image](https://user-images.githubusercontent.com/25135650/55723854-bb4fef80-5a12-11e9-8727-fb23351aae5d.png)

