### PR TITLE
Redirect to /assets on mobile instead of dashboard

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -319,7 +319,11 @@ export const App = ({
           path='/login'
           render={props => <LoginPage isDesktop={isDesktop} {...props} />}
         />
-        <Redirect from='/' to='/dashboard' />
+        {isDesktop ? (
+          <Redirect from='/' to='/dashboard' />
+        ) : (
+          <Redirect from='/' to='/assets' />
+        )}
       </Switch>
     </ErrorBoundary>
     <NotificationStack />

--- a/src/components/MobileNavbar/MobileNavbar.js
+++ b/src/components/MobileNavbar/MobileNavbar.js
@@ -10,12 +10,13 @@ import styles from './MobileNavbar.module.scss'
 import * as actions from './../../actions/types'
 
 const NAVBAR_LINKS = [
-  {
-    link: '/trends',
-    label: 'Trends',
-    linkTo: '/labs/trends',
-    iconType: 'fire'
-  },
+  // TODO: until we don't have mobile good view
+  // {
+  // link: '/trends',
+  // label: 'Trends',
+  // linkTo: '/labs/trends',
+  // iconType: 'fire'
+  // },
   {
     link: '/assets',
     label: 'Assets',


### PR DESCRIPTION
  Remove trends link from mobile, until we don't have good mobile UI

![image](https://user-images.githubusercontent.com/522287/56034097-f9108900-5d2e-11e9-813a-ee6ce2864b87.png)
