### PR TITLE
enhance/connected-trends

### DIFF
--- a/src/components/TagSelector.js
+++ b/src/components/TagSelector.js
@@ -11,7 +11,27 @@ class TagSelect extends Component {
   }
 
   state = {
-    tags: this.props.defaultTags.filter(noTrendTagsFilter)
+    tags: [],
+    defaultTagsLoaded: false
+  }
+
+  static getDerivedStateFromProps (
+    { defaultTags, onChange },
+    { tags, defaultTagsLoaded }
+  ) {
+    if (defaultTagsLoaded || defaultTags.length === 0) {
+      return null
+    }
+
+    const newTags = [...new Set(tags.concat(defaultTags))].filter(
+      noTrendTagsFilter
+    )
+
+    onChange(newTags)
+    return {
+      tags: newTags,
+      defaultTagsLoaded: true
+    }
   }
 
   onChange = tags => {

--- a/src/components/Trends/TrendsTable/TrendsTable.js
+++ b/src/components/Trends/TrendsTable/TrendsTable.js
@@ -43,6 +43,7 @@ const NumberCircle = props => (
 
 class TrendsTable extends PureComponent {
   static defaultProps = {
+    trendWords: [],
     selectable: true,
     selectedTrends: new Set(),
     trendConnections: [],
@@ -156,7 +157,7 @@ class TrendsTable extends PureComponent {
   render () {
     const {
       small,
-      trend,
+      trendWords,
       scoreChange,
       volumeChange,
       header,
@@ -169,7 +170,7 @@ class TrendsTable extends PureComponent {
       trendConnections
     } = this.props
 
-    const tableData = trend.map((word, index) => {
+    const tableData = trendWords.map((word, index) => {
       const [oldScore = 0, newScore = 0] = scoreChange[word] || []
       const [oldVolume = 0, newVolume = 0] = volumeChange[word] || []
       const isWordSelected = selectedTrends.has(word)

--- a/src/components/Trends/TrendsTable/TrendsTable.js
+++ b/src/components/Trends/TrendsTable/TrendsTable.js
@@ -81,10 +81,12 @@ class TrendsTable extends PureComponent {
             allTrends
           } = this.props
           const trendConnections = connectedTrends[rawWord.toUpperCase()]
-          const hasConnections =
-            trendConnections &&
-            trendConnections.filter(word => allTrends.has(word.toLowerCase()))
-              .length > 0
+          const visibleConnectionsLength = trendConnections
+            ? trendConnections.filter(word => allTrends.has(word.toLowerCase()))
+              .length
+            : 0
+
+          const hasConnections = visibleConnectionsLength > 0
           return (
             <>
               <Icon
@@ -99,7 +101,7 @@ class TrendsTable extends PureComponent {
                 onMouseLeave={clearConnectedTrends}
               />
               {hasConnections && (
-                <NumberCircle>{trendConnections.length}</NumberCircle>
+                <NumberCircle>{visibleConnectionsLength}</NumberCircle>
               )}
             </>
           )

--- a/src/components/Trends/TrendsTable/TrendsTable.js
+++ b/src/components/Trends/TrendsTable/TrendsTable.js
@@ -28,7 +28,7 @@ const columns = [
     accessor: 'word'
   },
   {
-    Header: 'Trending score',
+    Header: 'Hyped score',
     accessor: 'score'
   },
   {

--- a/src/components/Trends/TrendsTable/TrendsTable.js
+++ b/src/components/Trends/TrendsTable/TrendsTable.js
@@ -78,12 +78,12 @@ class TrendsTable extends PureComponent {
             connectedTrends,
             connectTrends,
             clearConnectedTrends,
-            trend
+            allTrends
           } = this.props
           const trendConnections = connectedTrends[rawWord.toUpperCase()]
           const hasConnections =
             trendConnections &&
-            trendConnections.filter(word => trend.includes(word.toLowerCase()))
+            trendConnections.filter(word => allTrends.has(word.toLowerCase()))
               .length > 0
           return (
             <>

--- a/src/components/Trends/TrendsTable/TrendsTable.js
+++ b/src/components/Trends/TrendsTable/TrendsTable.js
@@ -44,7 +44,9 @@ const NumberCircle = props => (
 class TrendsTable extends PureComponent {
   static defaultProps = {
     selectable: true,
-    selectedTrends: new Set()
+    selectedTrends: new Set(),
+    trendConnections: [],
+    connectedTrends: {}
   }
 
   getActionButtons = () => {
@@ -75,10 +77,14 @@ class TrendsTable extends PureComponent {
           const {
             connectedTrends,
             connectTrends,
-            clearConnectedTrends
+            clearConnectedTrends,
+            trend
           } = this.props
           const trendConnections = connectedTrends[rawWord.toUpperCase()]
-          const hasConnections = trendConnections && trendConnections.length > 0
+          const hasConnections =
+            trendConnections &&
+            trendConnections.filter(word => trend.includes(word.toLowerCase()))
+              .length > 0
           return (
             <>
               <Icon
@@ -148,7 +154,7 @@ class TrendsTable extends PureComponent {
   render () {
     const {
       small,
-      trend: { topWords = [] },
+      trend,
       scoreChange,
       volumeChange,
       header,
@@ -161,7 +167,7 @@ class TrendsTable extends PureComponent {
       trendConnections
     } = this.props
 
-    const tableData = topWords.map(({ word }, index) => {
+    const tableData = trend.map((word, index) => {
       const [oldScore = 0, newScore = 0] = scoreChange[word] || []
       const [oldVolume = 0, newVolume = 0] = volumeChange[word] || []
       const isWordSelected = selectedTrends.has(word)

--- a/src/components/Trends/TrendsTable/TrendsTable.js
+++ b/src/components/Trends/TrendsTable/TrendsTable.js
@@ -47,27 +47,6 @@ class TrendsTable extends PureComponent {
     selectedTrends: new Set()
   }
 
-  state = {
-    connectedTrends: []
-  }
-
-  connectTrends (word) {
-    const { connectedTrends } = this.props
-    const trendConnections = connectedTrends[word.toUpperCase()]
-
-    if (trendConnections && trendConnections.length > 0) {
-      this.setState({
-        connectedTrends: trendConnections
-      })
-    }
-  }
-
-  clearConnectedTrends = () => {
-    this.setState({
-      connectedTrends: []
-    })
-  }
-
   getActionButtons = () => {
     return [
       {
@@ -93,9 +72,12 @@ class TrendsTable extends PureComponent {
       },
       {
         Cell: ({ original: { rawWord } }) => {
-          const trendConnections = this.props.connectedTrends[
-            rawWord.toUpperCase()
-          ]
+          const {
+            connectedTrends,
+            connectTrends,
+            clearConnectedTrends
+          } = this.props
+          const trendConnections = connectedTrends[rawWord.toUpperCase()]
           const hasConnections = trendConnections && trendConnections.length > 0
           return (
             <>
@@ -106,9 +88,9 @@ class TrendsTable extends PureComponent {
                 )}
                 type='connection-big'
                 onMouseEnter={() => {
-                  this.connectTrends(rawWord)
+                  connectTrends(rawWord)
                 }}
-                onMouseLeave={this.clearConnectedTrends}
+                onMouseLeave={clearConnectedTrends}
               />
               {hasConnections && (
                 <NumberCircle>{trendConnections.length}</NumberCircle>
@@ -175,9 +157,9 @@ class TrendsTable extends PureComponent {
       isLoggedIn,
       username,
       selectTrend,
-      selectedTrends
+      selectedTrends,
+      trendConnections
     } = this.props
-    const { connectedTrends } = this.state
 
     const tableData = topWords.map(({ word }, index) => {
       const [oldScore = 0, newScore = 0] = scoreChange[word] || []
@@ -205,7 +187,7 @@ class TrendsTable extends PureComponent {
           <Link
             className={cx(
               styles.word,
-              connectedTrends.includes(word.toUpperCase()) && styles.connected
+              trendConnections.includes(word.toUpperCase()) && styles.connected
             )}
             to={`/labs/trends/explore/${word}`}
           >
@@ -253,14 +235,13 @@ class TrendsTable extends PureComponent {
 }
 
 const mapStateToProps = ({
-  hypedTrends: { scoreChange, volumeChange, connectedTrends, TrendToInsights },
+  hypedTrends: { scoreChange, volumeChange, TrendToInsights },
   user: {
     data: { username }
   }
 }) => ({
   scoreChange,
   volumeChange,
-  connectedTrends,
   TrendToInsights,
   username
 })

--- a/src/components/Trends/TrendsTable/TrendsTables.js
+++ b/src/components/Trends/TrendsTable/TrendsTables.js
@@ -63,11 +63,12 @@ class TrendsTables extends PureComponent {
       connectedTrends
     } = this.props
 
+    const { length } = trends
+
     return (
       <div className={styles.tables}>
         {trends.length > 1 &&
-          trends.slice(0, -1).map(trend => {
-            const { datetime } = trend
+          trends.slice(0, -1).map(({ datetime, topWords }) => {
             return (
               <TrendsTable
                 key={datetime}
@@ -77,7 +78,7 @@ class TrendsTables extends PureComponent {
                 })}
                 small
                 className={styles.table}
-                trend={trend}
+                trend={topWords.map(({ word }) => word)}
                 isLoggedIn={isLoggedIn}
                 selectTrend={this.selectTrend}
                 selectedTrends={selected}
@@ -91,7 +92,11 @@ class TrendsTables extends PureComponent {
         <TrendsTable
           className={styles.table}
           isLoading={isLoading}
-          trend={trends.length > 0 ? trends[trends.length - 1] : {}}
+          trend={
+            length > 0
+              ? trends[length - 1].topWords.map(({ word }) => word)
+              : []
+          }
           header='Last trends'
           selectable={selectable}
           isLoggedIn={isLoggedIn || true}

--- a/src/components/Trends/TrendsTable/TrendsTables.js
+++ b/src/components/Trends/TrendsTable/TrendsTables.js
@@ -7,11 +7,13 @@ import styles from './TrendsTables.module.scss'
 
 class TrendsTables extends PureComponent {
   static defaultProps = {
-    selectedTrends: new Set()
+    selectedTrends: new Set(),
+    connectedTrends: {}
   }
 
   state = {
-    selected: this.props.selectedTrends
+    selected: this.props.selectedTrends,
+    trendConnections: []
   }
 
   componentWillUnmount () {
@@ -34,9 +36,32 @@ class TrendsTables extends PureComponent {
     this.setState({ selected })
   }
 
+  connectTrends = word => {
+    const { connectedTrends } = this.props
+    const trendConnections = connectedTrends[word.toUpperCase()]
+
+    if (trendConnections && trendConnections.length > 0) {
+      this.setState({
+        trendConnections
+      })
+    }
+  }
+
+  clearConnectedTrends = () => {
+    this.setState({
+      trendConnections: []
+    })
+  }
+
   render () {
-    const { selected } = this.state
-    const { trends, isLoading, selectable, isLoggedIn } = this.props
+    const { selected, trendConnections } = this.state
+    const {
+      trends,
+      isLoading,
+      selectable,
+      isLoggedIn,
+      connectedTrends
+    } = this.props
 
     return (
       <div className={styles.tables}>
@@ -56,6 +81,10 @@ class TrendsTables extends PureComponent {
                 isLoggedIn={isLoggedIn}
                 selectTrend={this.selectTrend}
                 selectedTrends={selected}
+                connectedTrends={connectedTrends}
+                trendConnections={trendConnections}
+                connectTrends={this.connectTrends}
+                clearConnectedTrends={this.clearConnectedTrends}
               />
             )
           })}
@@ -68,6 +97,10 @@ class TrendsTables extends PureComponent {
           isLoggedIn={isLoggedIn || true}
           selectTrend={this.selectTrend}
           selectedTrends={selected}
+          connectedTrends={connectedTrends}
+          trendConnections={trendConnections}
+          connectTrends={this.connectTrends}
+          clearConnectedTrends={this.clearConnectedTrends}
         />
       </div>
     )
@@ -75,10 +108,11 @@ class TrendsTables extends PureComponent {
 }
 
 const mapStateToProps = ({
-  hypedTrends: { selectedTrends },
+  hypedTrends: { selectedTrends, connectedTrends },
   user: { token }
 }) => ({
   selectedTrends,
+  connectedTrends,
   isLoggedIn: !!token
 })
 

--- a/src/components/Trends/TrendsTable/TrendsTables.js
+++ b/src/components/Trends/TrendsTable/TrendsTables.js
@@ -13,7 +13,23 @@ class TrendsTables extends PureComponent {
 
   state = {
     selected: this.props.selectedTrends,
-    trendConnections: []
+    trendConnections: [],
+    allTrends: []
+  }
+
+  static getDerivedStateFromProps ({ trends }, { allTrends }) {
+    if (allTrends.length > 0) {
+      return null
+    }
+
+    return {
+      allTrends: new Set(
+        trends.reduce(
+          (acc, { topWords }) => acc.concat(topWords.map(({ word }) => word)),
+          []
+        )
+      )
+    }
   }
 
   componentWillUnmount () {
@@ -54,7 +70,7 @@ class TrendsTables extends PureComponent {
   }
 
   render () {
-    const { selected, trendConnections } = this.state
+    const { selected, trendConnections, allTrends } = this.state
     const {
       trends,
       isLoading,
@@ -106,6 +122,7 @@ class TrendsTables extends PureComponent {
           trendConnections={trendConnections}
           connectTrends={this.connectTrends}
           clearConnectedTrends={this.clearConnectedTrends}
+          allTrends={allTrends}
         />
       </div>
     )

--- a/src/components/Trends/TrendsTable/TrendsTables.js
+++ b/src/components/Trends/TrendsTable/TrendsTables.js
@@ -22,13 +22,20 @@ class TrendsTables extends PureComponent {
       return null
     }
 
+    const newAllTrends = []
+    const ownTrends = trends.map(({ datetime, topWords }) => {
+      const words = topWords.map(({ word }) => word)
+      newAllTrends.push(...words)
+
+      return {
+        datetime,
+        words
+      }
+    })
+
     return {
-      allTrends: new Set(
-        trends.reduce(
-          (acc, { topWords }) => acc.concat(topWords.map(({ word }) => word)),
-          []
-        )
-      )
+      allTrends: new Set(newAllTrends),
+      trends: ownTrends
     }
   }
 
@@ -70,21 +77,15 @@ class TrendsTables extends PureComponent {
   }
 
   render () {
-    const { selected, trendConnections, allTrends } = this.state
-    const {
-      trends,
-      isLoading,
-      selectable,
-      isLoggedIn,
-      connectedTrends
-    } = this.props
+    const { selected, trendConnections, allTrends, trends } = this.state
+    const { isLoading, selectable, isLoggedIn, connectedTrends } = this.props
 
     const { length } = trends
 
     return (
       <div className={styles.tables}>
-        {trends.length > 1 &&
-          trends.slice(0, -1).map(({ datetime, topWords }) => {
+        {length > 1 &&
+          trends.slice(0, -1).map(({ datetime, words }) => {
             return (
               <TrendsTable
                 key={datetime}
@@ -94,7 +95,7 @@ class TrendsTables extends PureComponent {
                 })}
                 small
                 className={styles.table}
-                trend={topWords.map(({ word }) => word)}
+                trendWords={words}
                 isLoggedIn={isLoggedIn}
                 selectTrend={this.selectTrend}
                 selectedTrends={selected}
@@ -108,11 +109,7 @@ class TrendsTables extends PureComponent {
         <TrendsTable
           className={styles.table}
           isLoading={isLoading}
-          trend={
-            length > 0
-              ? trends[length - 1].topWords.map(({ word }) => word)
-              : []
-          }
+          trendWords={length > 0 ? trends[length - 1].words : undefined}
           header='Last trends'
           selectable={selectable}
           isLoggedIn={isLoggedIn || true}

--- a/src/pages/Dashboard/DashboardPage.js
+++ b/src/pages/Dashboard/DashboardPage.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { Panel, Label, Icon } from '@santiment-network/ui'
 import GetHypedTrends from './../../components/Trends/GetHypedTrends'
 import InsightsFeatured from '../../components/Insight/InsightsFeatured'
-import TrendsTable from '../../components/Trends/TrendsTable/TrendsTable'
+import TrendsTables from '../../components/Trends/TrendsTable/TrendsTables'
 import FeaturedWatchlists from '../../components/Watchlists/FeaturedWatchlist'
 import DashboardPageSubscription from './DashboardPageSubscription'
 import DashboardPageOnboard from './DashboardPageOnboard'
@@ -28,9 +28,8 @@ const DashboardPage = ({ isLoggedIn }) => (
         </h2>
         <GetHypedTrends
           render={({ isLoading, items }) => (
-            <TrendsTable
-              header='Last trends'
-              trend={items.length > 0 ? items[items.length - 1] : {}}
+            <TrendsTables
+              trends={items.slice(-1)}
               isLoading={isLoading}
               selectable={false}
             />

--- a/src/pages/Trends/connectedWordsEpic.js
+++ b/src/pages/Trends/connectedWordsEpic.js
@@ -87,159 +87,162 @@ export const connectedWordsOptimizationEpic = action$ =>
     })
 
 export const connectedWordsEpic = (action$, store, { client }) =>
-  Observable.concat(
+  Observable.combineLatest(
     action$.ofType(TRENDS_HYPED_FETCH_SUCCESS),
-    action$.ofType(TRENDS_CONNECTED_WORDS_OPTIMIZATION_SUCCESS)
-  )
-    .take(1)
-    .switchMap(({ payload: { items } }) => {
-      const insightQueries = []
-      for (let i = 0; i < 3; i++) {
-        insightQueries.push(
-          client.query({
-            query: ALL_INSIGHTS_BY_TAG_QUERY,
-            variables: {
-              tag: getInsightTrendTagByDate(
-                new Date(Date.now() - oneDayTimestamp * i)
-              )
-            }
-          })
-        )
-      }
+    action$.ofType(TRENDS_CONNECTED_WORDS_OPTIMIZATION_SUCCESS).take(1)
+  ).switchMap(([{ payload: { items } }]) => {
+    const insightQueries = []
+    for (let i = 0; i < 3; i++) {
+      insightQueries.push(
+        client.query({
+          query: ALL_INSIGHTS_BY_TAG_QUERY,
+          variables: {
+            tag: getInsightTrendTagByDate(
+              new Date(Date.now() - oneDayTimestamp * i)
+            )
+          }
+        })
+      )
+    }
 
-      const trendingWords = [
-        ...new Set(
-          items.reduce((acc, { topWords }) => {
-            return acc.concat(topWords.map(({ word }) => word.toUpperCase()))
-          }, [])
-        )
-      ]
+    const trendingWords = [
+      ...new Set(
+        items.reduce((acc, { topWords }) => {
+          return acc.concat(topWords.map(({ word }) => word.toUpperCase()))
+        }, [])
+      )
+    ]
 
-      const TrendToTag = {}
-      const TrendToInsights = {}
-      const TagToTrend = {}
+    const TrendToTag = {}
+    const TrendToInsights = {}
+    const TagToTrend = {}
 
-      return Observable.forkJoin(...insightQueries)
-        .flatMap(result => {
-          const tagsGraph = {}
+    return Observable.forkJoin(...insightQueries)
+      .flatMap(result => {
+        const tagsGraph = {}
 
-          // [START] Looping over requests
-          for (const {
+        // [START] Looping over requests
+        const { length: resultLength } = result
+        for (let i = 0; i < resultLength; i++) {
+          const {
             data: { allInsightsByTag }
-          } of result) {
-            if (allInsightsByTag.length < 1) continue
+          } = result[i]
 
-            let lastConnectedInsight
-            // [START] Looping over request's insights
-            for (const { tags, ...insight } of allInsightsByTag) {
-              const filteredTags = tags
-                .filter(({ name }) => !name.endsWith('-trending-words'))
-                .map(({ name }) => name.toUpperCase())
-              const { length: filteredTagsLength } = filteredTags
+          if (allInsightsByTag.length < 1) continue
 
-              if (filteredTagsLength < 1) continue
-              // [START] Looping over insight's tags
-              for (let i = 0; i < filteredTagsLength; i++) {
-                const tag = filteredTags[i]
-                const connectedTags = filteredTags.slice(0, i)
-                const rightOffset = i - (filteredTagsLength - 1)
+          let lastConnectedInsight
+          // [START] Looping over request's insights
+          const { length: insightsLength } = allInsightsByTag
+          for (let y = 0; y < insightsLength; y++) {
+            const { tags, ...insight } = allInsightsByTag[y]
+            const filteredTags = tags
+              .filter(({ name }) => !name.endsWith('-trending-words'))
+              .map(({ name }) => name.toUpperCase())
+            const { length: filteredTagsLength } = filteredTags
 
-                if (rightOffset !== 0) {
-                  connectedTags.push(...filteredTags.slice(rightOffset))
-                }
+            if (filteredTagsLength < 1) continue
+            // [START] Looping over insight's tags
+            for (let z = 0; z < filteredTagsLength; z++) {
+              const tag = filteredTags[z]
+              const connectedTags = filteredTags.slice(0, z)
+              const rightOffset = z - (filteredTagsLength - 1)
 
-                const tagConnections = tagsGraph[tag]
-
-                if (tagConnections) {
-                  tagConnections.push(...connectedTags)
-                  tagsGraph[tag] = [...new Set(tagConnections)]
-
-                  const trendInsights = TrendToInsights[tag]
-                  if (
-                    trendInsights &&
-                    lastConnectedInsight !== insight &&
-                    insight.readyState !== 'draft'
-                  ) {
-                    trendInsights.push(insight)
-                    lastConnectedInsight = insight
-                  }
-                } else {
-                  tagsGraph[tag] = connectedTags
-                  lastConnectedInsight = insight
-                  if (insight.readyState !== 'draft') {
-                    TrendToInsights[tag] = [insight]
-                  }
-
-                  if (trendingWords.includes(tag)) {
-                    TrendToTag[tag] = tag
-                    TagToTrend[tag] = [tag]
-                  }
-                }
-              } // [END] Looping over insight's tags
-            } // [END] Looping over request's insights
-          } // [END] Looping over requests
-
-          const unmappedTrendingWords = trendingWords.filter(
-            word => !TrendToTag[word]
-          )
-
-          unmappedTrendingWords.forEach(trend => {
-            const foundTicker = mapWordToProjectsTicker(trend)
-            if (foundTicker) {
-              TrendToTag[trend] = foundTicker
-              TrendToInsights[trend] = TrendToInsights[foundTicker]
-
-              const trendSynonyms = TagToTrend[foundTicker]
-              if (trendSynonyms) {
-                trendSynonyms.push(trend)
-              } else {
-                TagToTrend[foundTicker] = [trend]
+              if (rightOffset !== 0) {
+                connectedTags.push(...filteredTags.slice(rightOffset))
               }
-            }
-          })
 
-          const connectedTrends = Object.keys(TrendToTag).reduce(
-            (connectedTrendsAcc, trend) => {
-              const tag = TrendToTag[trend]
               const tagConnections = tagsGraph[tag]
 
               if (tagConnections) {
-                const trendConnections = tagConnections.reduce(
-                  (trendConnectionsAcc, connectedTag) => {
-                    const connectedTrend = TagToTrend[connectedTag]
+                tagConnections.push(...connectedTags)
+                tagsGraph[tag] = [...new Set(tagConnections)]
 
-                    if (connectedTrend) {
-                      trendConnectionsAcc.push(...connectedTrend)
-                    }
-                    return trendConnectionsAcc
-                  },
-                  []
-                )
-
-                const trendSynonyms = TagToTrend[tag]
-                if (trendSynonyms.length > 1) {
-                  // NOTE(vanguard): maybe just to push without checking and filtering? It's okay if one of connected words will be the same as the key
-                  trendConnections.push(
-                    ...trendSynonyms.filter(synonym => synonym !== trend)
-                  )
+                const trendInsights = TrendToInsights[tag]
+                if (
+                  trendInsights &&
+                  lastConnectedInsight !== insight &&
+                  insight.readyState !== 'draft'
+                ) {
+                  trendInsights.push(insight)
+                  lastConnectedInsight = insight
+                }
+              } else {
+                tagsGraph[tag] = connectedTags
+                lastConnectedInsight = insight
+                if (insight.readyState !== 'draft') {
+                  TrendToInsights[tag] = [insight]
                 }
 
-                connectedTrendsAcc[trend] = trendConnections
-              } else if (TagToTrend[tag].length > 1) {
-                connectedTrendsAcc[trend] = TagToTrend[tag].filter(
-                  synonym => synonym !== trend
+                if (trendingWords.includes(tag)) {
+                  TrendToTag[tag] = tag
+                  TagToTrend[tag] = [tag]
+                }
+              }
+            } // [END] Looping over insight's tags
+          } // [END] Looping over request's insights
+        } // [END] Looping over requests
+
+        const unmappedTrendingWords = trendingWords.filter(
+          word => !TrendToTag[word]
+        )
+
+        unmappedTrendingWords.forEach(trend => {
+          const foundTicker = mapWordToProjectsTicker(trend)
+          if (foundTicker) {
+            TrendToTag[trend] = foundTicker
+            TrendToInsights[trend] = TrendToInsights[foundTicker]
+
+            const trendSynonyms = TagToTrend[foundTicker]
+            if (trendSynonyms) {
+              trendSynonyms.push(trend)
+            } else {
+              TagToTrend[foundTicker] = [trend]
+            }
+          }
+        })
+
+        const connectedTrends = Object.keys(TrendToTag).reduce(
+          (connectedTrendsAcc, trend) => {
+            const tag = TrendToTag[trend]
+            const tagConnections = tagsGraph[tag]
+
+            if (tagConnections) {
+              const trendConnections = tagConnections.reduce(
+                (trendConnectionsAcc, connectedTag) => {
+                  const connectedTrend = TagToTrend[connectedTag]
+
+                  if (connectedTrend) {
+                    trendConnectionsAcc.push(...connectedTrend)
+                  }
+                  return trendConnectionsAcc
+                },
+                []
+              )
+
+              const trendSynonyms = TagToTrend[tag]
+              if (trendSynonyms.length > 1) {
+                // NOTE(vanguard): maybe just to push without checking and filtering? It's okay if one of connected words will be the same as the key
+                trendConnections.push(
+                  ...trendSynonyms.filter(synonym => synonym !== trend)
                 )
               }
 
-              return connectedTrendsAcc
-            },
-            {}
-          )
+              connectedTrendsAcc[trend] = trendConnections
+            } else if (TagToTrend[tag].length > 1) {
+              connectedTrendsAcc[trend] = TagToTrend[tag].filter(
+                synonym => synonym !== trend
+              )
+            }
 
-          return Observable.of({
-            type: TRENDS_CONNECTED_WORDS_SUCCESS,
-            payload: { connectedTrends, TrendToInsights, TrendToTag }
-          })
+            return connectedTrendsAcc
+          },
+          {}
+        )
+
+        return Observable.of({
+          type: TRENDS_CONNECTED_WORDS_SUCCESS,
+          payload: { connectedTrends, TrendToInsights, TrendToTag }
         })
-        .catch(handleErrorAndTriggerAction(TRENDS_CONNECTED_WORDS_FAILED))
-    })
+      })
+      .catch(handleErrorAndTriggerAction(TRENDS_CONNECTED_WORDS_FAILED))
+  })

--- a/src/pages/Trends/connectedWordsEpic.js
+++ b/src/pages/Trends/connectedWordsEpic.js
@@ -187,11 +187,11 @@ export const connectedWordsEpic = (action$, store, { client }) =>
             const foundTicker = mapWordToProjectsTicker(trend)
             if (foundTicker) {
               TrendToTag[trend] = foundTicker
+              TrendToInsights[trend] = TrendToInsights[foundTicker]
 
               const trendSynonyms = TagToTrend[foundTicker]
               if (trendSynonyms) {
                 trendSynonyms.push(trend)
-                TrendToInsights[trend] = TrendToInsights[foundTicker]
               } else {
                 TagToTrend[foundTicker] = [trend]
               }

--- a/src/pages/Trends/connectedWordsEpic.spec.js
+++ b/src/pages/Trends/connectedWordsEpic.spec.js
@@ -11,7 +11,8 @@ import {
 import {
   TRENDS_HYPED_FETCH_SUCCESS,
   TRENDS_HYPED_FETCH_TICKERS_SLUGS_SUCCESS,
-  TRENDS_CONNECTED_WORDS_SUCCESS
+  TRENDS_CONNECTED_WORDS_SUCCESS,
+  TRENDS_CONNECTED_WORDS_OPTIMIZATION_SUCCESS
 } from '../../components/Trends/actions'
 import { ALL_INSIGHTS_BY_TAG_QUERY } from '../../components/Insight/insightsGQL'
 
@@ -137,10 +138,15 @@ describe('Connect Trending Words', () => {
   it('should should connect synonyms', async () => {
     const client = await createClient(link)
 
-    const action$ = ActionsObservable.of({
-      type: TRENDS_HYPED_FETCH_SUCCESS,
-      payload: mockedData.trends.synonyms
-    })
+    const action$ = ActionsObservable.from([
+      {
+        type: TRENDS_HYPED_FETCH_SUCCESS,
+        payload: mockedData.trends.synonyms
+      },
+      {
+        type: TRENDS_CONNECTED_WORDS_OPTIMIZATION_SUCCESS
+      }
+    ])
     const epic$ = connectedWordsEpic(action$, mockStore({}), { client })
     const promise = epic$.toPromise()
     const result = await promise
@@ -156,10 +162,15 @@ describe('Connect Trending Words', () => {
   it('should should connect trends', async () => {
     const client = await createClient(link)
 
-    const action$ = ActionsObservable.of({
-      type: TRENDS_HYPED_FETCH_SUCCESS,
-      payload: mockedData.trends.hard
-    })
+    const action$ = ActionsObservable.from([
+      {
+        type: TRENDS_HYPED_FETCH_SUCCESS,
+        payload: mockedData.trends.hard
+      },
+      {
+        type: TRENDS_CONNECTED_WORDS_OPTIMIZATION_SUCCESS
+      }
+    ])
     const epic$ = connectedWordsEpic(action$, mockStore({}), { client })
     const promise = epic$.toPromise()
     const result = await promise


### PR DESCRIPTION
#### Summary
- Fixed bug with mapping insights to a new found trend ticker;
- Highlighting connected trends in neighbor trend tables;
- Connected trends number-label now is relative to the visible trends;
- Fixed the inconsistent behavior of auto-selected tags from trends when writing new insight;
- Keeping `connectedTrends` up-to-date.

#### Screenshots
![image](https://user-images.githubusercontent.com/25135650/56115563-52b1c700-5f6c-11e9-8467-b410c1d638f5.png)
