### PR TITLE
Enhance/featured insights styles

### DIFF
--- a/src/components/Insight/InsightCardSmall.js
+++ b/src/components/Insight/InsightCardSmall.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import LikeBtn from '../Like/LikeBtn'
+import MultilineText from '../MultilineText/MultilineText'
 import { getSEOLinkFromIdAndTitle } from '../../pages/Insights/utils'
 import styles from './InsightCardSmall.module.scss'
-import MultilineText from '../MultilineText/MultilineText'
 
 const InsightCard = ({
   className = '',

--- a/src/components/Insight/InsightCardSmall.js
+++ b/src/components/Insight/InsightCardSmall.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import moment from 'moment'
 import LikeBtn from '../Like/LikeBtn'
 import { getSEOLinkFromIdAndTitle } from '../../pages/Insights/utils'
 import styles from './InsightCardSmall.module.scss'
@@ -9,7 +8,7 @@ const InsightCard = ({
   className = '',
   id,
   title,
-  createdAt,
+  user,
   votedAt,
   votes: { totalVotes }
 }) => {
@@ -22,8 +21,8 @@ const InsightCard = ({
         {title}
       </Link>
       <div className={styles.meta}>
-        <div className={styles.date}>
-          {moment(createdAt).format('MMM D, YYYY')}
+        <div className={styles.username} title={user.username}>
+          {user.username}
         </div>
         <LikeBtn small grey liked={!!votedAt} likesNumber={totalVotes} />
       </div>

--- a/src/components/Insight/InsightCardSmall.js
+++ b/src/components/Insight/InsightCardSmall.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import LikeBtn from '../Like/LikeBtn'
 import { getSEOLinkFromIdAndTitle } from '../../pages/Insights/utils'
 import styles from './InsightCardSmall.module.scss'
+import MultilineText from '../MultilineText/MultilineText'
 
 const InsightCard = ({
   className = '',
@@ -18,7 +19,7 @@ const InsightCard = ({
         to={`/insights/read/${getSEOLinkFromIdAndTitle(id, title)}`}
         className={styles.title}
       >
-        {title}
+        <MultilineText id='InsightCardSmall__title' maxLines={2} text={title} />
       </Link>
       <div className={styles.meta}>
         <div className={styles.username} title={user.username}>

--- a/src/components/Insight/InsightCardSmall.js
+++ b/src/components/Insight/InsightCardSmall.js
@@ -22,9 +22,9 @@ const InsightCard = ({
         <MultilineText id='InsightCardSmall__title' maxLines={2} text={title} />
       </Link>
       <div className={styles.meta}>
-        <div className={styles.username} title={user.username}>
+        <Link to={`/insights/users/${user.id}`} className={styles.username}>
           {user.username}
-        </div>
+        </Link>
         <LikeBtn small grey liked={!!votedAt} likesNumber={totalVotes} />
       </div>
     </div>

--- a/src/components/Insight/InsightCardSmall.module.scss
+++ b/src/components/Insight/InsightCardSmall.module.scss
@@ -1,12 +1,18 @@
 .title {
-  display: inline-block;
   font-size: 16px;
   line-height: 24px;
   color: var(--mirage);
   max-width: 100%;
-  overflow-x: hidden;
+  margin-bottom: 6px;
+  overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  word-wrap: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  max-height: 48px;
+
+  /* autoprefixer: ignore next */
+  -webkit-box-orient: vertical;
 
   &:hover {
     color: var(--jungle-green);
@@ -17,9 +23,13 @@
   display: flex;
 }
 
-.date {
+.username {
   width: 100px;
   font-size: 14px;
   line-height: 20px;
   color: var(--waterloo);
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-right: 21px;
 }

--- a/src/components/Insight/InsightCardSmall.module.scss
+++ b/src/components/Insight/InsightCardSmall.module.scss
@@ -5,7 +5,6 @@
   color: var(--mirage);
   max-width: 400px;
   margin-bottom: 6px;
-  word-wrap: break-word;
 
   &:hover {
     color: var(--jungle-green);

--- a/src/components/Insight/InsightCardSmall.module.scss
+++ b/src/components/Insight/InsightCardSmall.module.scss
@@ -1,18 +1,11 @@
 .title {
+  display: inline-block;
   font-size: 16px;
   line-height: 24px;
   color: var(--mirage);
-  max-width: 100%;
+  max-width: 400px;
   margin-bottom: 6px;
-  overflow: hidden;
-  text-overflow: ellipsis;
   word-wrap: break-word;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  max-height: 48px;
-
-  /* autoprefixer: ignore next */
-  -webkit-box-orient: vertical;
 
   &:hover {
     color: var(--jungle-green);
@@ -21,10 +14,11 @@
 
 .meta {
   display: flex;
+  justify-content: space-between;
 }
 
 .username {
-  width: 100px;
+  max-width: 200px;
   font-size: 14px;
   line-height: 20px;
   color: var(--waterloo);

--- a/src/pages/Dashboard/DashboardPage.js
+++ b/src/pages/Dashboard/DashboardPage.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import { Panel, Label, Icon } from '@santiment-network/ui'
+import { Panel, Label } from '@santiment-network/ui'
 import GetHypedTrends from './../../components/Trends/GetHypedTrends'
 import InsightsFeatured from '../../components/Insight/InsightsFeatured'
 import TrendsTable from '../../components/Trends/TrendsTable/TrendsTable'
@@ -12,9 +12,7 @@ import styles from './DashboardPage.module.scss'
 
 const More = ({ link }) => (
   <Link to={link} className={styles.more}>
-    <Label accent='jungle-green'>
-      More <Icon className={styles.pointer} type='pointer-right' />
-    </Label>
+    <Label accent='jungle-green'>More</Label>
   </Link>
 )
 
@@ -23,9 +21,10 @@ const DashboardPage = ({ isLoggedIn }) => (
     {isLoggedIn ? <DashboardPageOnboard /> : <AnonBanner />}
     <div className={styles.column}>
       <div className={styles.column__left}>
-        <h2 className={styles.subtitle}>
-          Emerging trends <More link='/labs/trends/' />
-        </h2>
+        <div className={styles.subtitle}>
+          <h2 className={styles.subtitle__text}>Emerging trends</h2>
+          <More link='/labs/trends/' />
+        </div>
         <GetHypedTrends
           render={({ isLoading, items }) => (
             <TrendsTable
@@ -38,9 +37,10 @@ const DashboardPage = ({ isLoggedIn }) => (
         />
       </div>
       <div className={styles.column__right}>
-        <h2 className={styles.subtitle}>
-          Featured insights <More link='/insights/' />
-        </h2>
+        <div className={styles.subtitle}>
+          <h2 className={styles.subtitle__text}>Featured insights</h2>
+          <More link='/insights/' />
+        </div>
         <div className={styles.insights}>
           <Panel className={styles.insights__panel}>
             <div className={styles.insights__list}>

--- a/src/pages/Dashboard/DashboardPage.module.scss
+++ b/src/pages/Dashboard/DashboardPage.module.scss
@@ -1,5 +1,4 @@
 @import '~@santiment-network/ui/variables.scss';
-@import 'mixins.scss';
 
 .wrapper {
   width: 100%;
@@ -113,8 +112,13 @@
 
   &__panel {
     flex: 1;
-    overflow-y: auto;
+    overflow-y: hidden;
     position: relative;
+
+    &:hover {
+      overflow-y: auto;
+      overflow-y: overlay;
+    }
   }
 
   &__list {

--- a/src/pages/Dashboard/DashboardPage.module.scss
+++ b/src/pages/Dashboard/DashboardPage.module.scss
@@ -124,19 +124,13 @@
   &__list {
     position: absolute;
     width: 100%;
-    padding: 24px;
   }
 
   &__card {
     min-width: 100%;
-    margin-bottom: 15px;
     padding: 16px 23px;
-    border: 1px solid var(--porcelain);
+    border-bottom: 1px solid var(--porcelain);
     border-radius: $border-radius;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
   }
 }
 

--- a/src/pages/Dashboard/DashboardPage.module.scss
+++ b/src/pages/Dashboard/DashboardPage.module.scss
@@ -130,7 +130,6 @@
     min-width: 100%;
     padding: 16px 23px;
     border-bottom: 1px solid var(--porcelain);
-    border-radius: $border-radius;
   }
 }
 

--- a/src/pages/Dashboard/DashboardPage.module.scss
+++ b/src/pages/Dashboard/DashboardPage.module.scss
@@ -68,11 +68,18 @@
 }
 
 .subtitle {
-  font-family: Rubik, sans-serif;
-  font-size: 22px;
-  line-height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 26px;
-  color: var(--mirage);
+
+  &__text {
+    font-family: Rubik, sans-serif;
+    font-size: 22px;
+    line-height: 30px;
+    color: var(--mirage);
+    margin: 0;
+  }
 }
 
 .column {


### PR DESCRIPTION
scrollbar on hover. There is a problem with bias content when scrollbar appear. For webkit- I used to non-standard `overflow: overlay`. In firefox when you hover on the block - cards decrease their widths for some px (depends on scrollbar' width)

![image](https://user-images.githubusercontent.com/24521041/56213542-e36bce00-6064-11e9-9c63-4ffdb7d2619d.png)

