### PR TITLE
enhance/trends-table

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.8",
     "@fortawesome/free-solid-svg-icons": "^5.5.0",
     "@fortawesome/react-fontawesome": "^0.1.3",
-    "@santiment-network/ui": "^0.4.70",
+    "@santiment-network/ui": "^0.4.72",
     "@trainline/react-skeletor": "^1.0.2",
     "animate-components": "^1.4.8",
     "apollo-cache-inmemory": "^1.1.2",

--- a/src/components/ExplanationTooltip/ExplanationTooltip.js
+++ b/src/components/ExplanationTooltip/ExplanationTooltip.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Tooltip } from '@santiment-network/ui'
+import styles from './ExplanationTooltip.module.scss'
+
+const ExplanationTooltip = ({ text, children, ...props }) => (
+  <Tooltip
+    {...props}
+    className={styles.wrapper}
+    closeTimeout={0}
+    trigger={children}
+  >
+    {text}
+  </Tooltip>
+)
+
+export default ExplanationTooltip

--- a/src/components/ExplanationTooltip/ExplanationTooltip.module.scss
+++ b/src/components/ExplanationTooltip/ExplanationTooltip.module.scss
@@ -1,0 +1,9 @@
+@import '~@santiment-network/ui/variables.scss';
+
+.wrapper {
+  background: $fiord;
+  padding: 3px 12px;
+  color: $white;
+  border-radius: $border-radius;
+  font-size: 12px;
+}

--- a/src/components/Trends/TrendsTable/TrendsTable.js
+++ b/src/components/Trends/TrendsTable/TrendsTable.js
@@ -11,7 +11,7 @@ import {
   Panel,
   Icon,
   Tooltip,
-  Button
+  Button,
 } from '@santiment-network/ui'
 import { store } from '../../../index'
 import ValueChange from '../../../components/ValueChange/ValueChange'
@@ -24,20 +24,20 @@ const columns = [
     Header: '#',
     accessor: 'index',
     width: 35,
-    headerClassName: styles.headerIndex
+    headerClassName: styles.headerIndex,
   },
   {
     Header: 'Word',
-    accessor: 'word'
+    accessor: 'word',
   },
   {
-    Header: 'Hyped score',
-    accessor: 'score'
+    Header: 'Hype score',
+    accessor: 'score',
   },
   {
     Header: 'Social volume',
-    accessor: 'volume'
-  }
+    accessor: 'volume',
+  },
 ]
 
 const NumberCircle = ({ className, ...props }) => (
@@ -70,7 +70,7 @@ const getTrGroupProps = (_, rowInfo) => {
         node = node.parentNode
       }
       store.dispatch(push(`/labs/trends/explore/${rowInfo.original.rawWord}`))
-    }
+    },
   }
 }
 
@@ -80,7 +80,7 @@ class TrendsTable extends PureComponent {
     selectable: true,
     selectedTrends: new Set(),
     trendConnections: [],
-    connectedTrends: {}
+    connectedTrends: {},
   }
 
   getActionButtons = () => {
@@ -91,12 +91,12 @@ class TrendsTable extends PureComponent {
             connectedTrends,
             connectTrends,
             clearConnectedTrends,
-            allTrends
+            allTrends,
           } = this.props
           const trendConnections = connectedTrends[rawWord.toUpperCase()]
           const visibleConnectionsLength = trendConnections
             ? trendConnections.filter(word => allTrends.has(word.toLowerCase()))
-              .length
+                .length
             : 0
 
           const hasConnections = visibleConnectionsLength > 0
@@ -106,7 +106,7 @@ class TrendsTable extends PureComponent {
                 <span
                   className={cx(
                     styles.action__icon,
-                    !hasConnections && styles.action__icon_disabled
+                    !hasConnections && styles.action__icon_disabled,
                   )}
                 >
                   <Icon
@@ -126,7 +126,7 @@ class TrendsTable extends PureComponent {
           )
         },
         width: 42,
-        className: styles.action
+        className: styles.action,
       },
       {
         Cell: ({ original: { rawWord } }) => {
@@ -172,7 +172,7 @@ class TrendsTable extends PureComponent {
           )
         },
         width: 42,
-        className: styles.action
+        className: styles.action,
       },
       {
         Cell: ({ original: { rawWord } }) => {
@@ -199,12 +199,12 @@ class TrendsTable extends PureComponent {
           )
         },
         width: 42,
-        className: styles.action
-      }
+        className: styles.action,
+      },
     ]
   }
 
-  render () {
+  render() {
     const {
       small,
       trendWords,
@@ -217,7 +217,7 @@ class TrendsTable extends PureComponent {
       username,
       selectTrend,
       selectedTrends,
-      trendConnections
+      trendConnections,
     } = this.props
 
     const tableData = trendWords.map((word, index) => {
@@ -232,7 +232,7 @@ class TrendsTable extends PureComponent {
                 isActive={isWordSelected}
                 className={cx(
                   styles.checkbox,
-                  isWordSelected && styles.checkbox_active
+                  isWordSelected && styles.checkbox_active,
                 )}
                 onClick={() => selectTrend(word)}
               />
@@ -246,7 +246,7 @@ class TrendsTable extends PureComponent {
           <Link
             className={cx(
               styles.word,
-              trendConnections.includes(word.toUpperCase()) && styles.connected
+              trendConnections.includes(word.toUpperCase()) && styles.connected,
             )}
             to={`/labs/trends/explore/${word}`}
           >
@@ -263,7 +263,7 @@ class TrendsTable extends PureComponent {
           <>
             {newVolume} <ValueChange change={newVolume - oldVolume} />
           </>
-        )
+        ),
       }
     })
 
@@ -297,13 +297,13 @@ class TrendsTable extends PureComponent {
 const mapStateToProps = ({
   hypedTrends: { scoreChange, volumeChange, TrendToInsights },
   user: {
-    data: { username }
-  }
+    data: { username },
+  },
 }) => ({
   scoreChange,
   volumeChange,
   TrendToInsights,
-  username
+  username,
 })
 
 export default connect(mapStateToProps)(TrendsTable)

--- a/src/components/Trends/TrendsTable/TrendsTable.js
+++ b/src/components/Trends/TrendsTable/TrendsTable.js
@@ -54,27 +54,6 @@ class TrendsTable extends PureComponent {
     return [
       {
         Cell: ({ original: { rawWord } }) => {
-          return (
-            <Tooltip
-              closeTimeout={50}
-              position='left'
-              className={styles.tooltip}
-              trigger={
-                <Icon
-                  className={cx(styles.action__icon, styles.action__icon_cloud)}
-                  type='cloud-big'
-                />
-              }
-            >
-              <WordCloud className={styles.wordCloud} word={rawWord} />
-            </Tooltip>
-          )
-        },
-        width: 40,
-        className: styles.action
-      },
-      {
-        Cell: ({ original: { rawWord } }) => {
           const {
             connectedTrends,
             connectTrends,
@@ -146,6 +125,27 @@ class TrendsTable extends PureComponent {
             </>
           ) : (
             icon
+          )
+        },
+        width: 40,
+        className: styles.action
+      },
+      {
+        Cell: ({ original: { rawWord } }) => {
+          return (
+            <Tooltip
+              closeTimeout={50}
+              position='left'
+              className={styles.tooltip}
+              trigger={
+                <Icon
+                  className={cx(styles.action__icon, styles.action__icon_cloud)}
+                  type='cloud-big'
+                />
+              }
+            >
+              <WordCloud className={styles.wordCloud} word={rawWord} />
+            </Tooltip>
           )
         },
         width: 40,

--- a/src/components/Trends/TrendsTable/TrendsTable.js
+++ b/src/components/Trends/TrendsTable/TrendsTable.js
@@ -11,12 +11,13 @@ import {
   Panel,
   Icon,
   Tooltip,
-  Button,
+  Button
 } from '@santiment-network/ui'
 import { store } from '../../../index'
 import ValueChange from '../../../components/ValueChange/ValueChange'
 import WordCloud from '../../../components/WordCloud/WordCloud'
 import InsightCardSmall from '../../../components/Insight/InsightCardSmall'
+import ExplanationTooltip from '../../../components/ExplanationTooltip/ExplanationTooltip'
 import styles from './TrendsTable.module.scss'
 
 const columns = [
@@ -24,36 +25,24 @@ const columns = [
     Header: '#',
     accessor: 'index',
     width: 35,
-    headerClassName: styles.headerIndex,
+    headerClassName: styles.headerIndex
   },
   {
     Header: 'Word',
-    accessor: 'word',
+    accessor: 'word'
   },
   {
     Header: 'Hype score',
-    accessor: 'score',
+    accessor: 'score'
   },
   {
     Header: 'Social volume',
-    accessor: 'volume',
-  },
+    accessor: 'volume'
+  }
 ]
 
 const NumberCircle = ({ className, ...props }) => (
   <div {...props} className={cx(className, styles.insights__number)} />
-)
-
-const Explanation = ({ text, children, ...props }) => (
-  <Tooltip
-    offsetY={5}
-    {...props}
-    className={styles.explanation}
-    closeTimeout={0}
-    trigger={children}
-  >
-    {text}
-  </Tooltip>
 )
 
 const getTrGroupProps = (_, rowInfo) => {
@@ -70,7 +59,7 @@ const getTrGroupProps = (_, rowInfo) => {
         node = node.parentNode
       }
       store.dispatch(push(`/labs/trends/explore/${rowInfo.original.rawWord}`))
-    },
+    }
   }
 }
 
@@ -80,7 +69,7 @@ class TrendsTable extends PureComponent {
     selectable: true,
     selectedTrends: new Set(),
     trendConnections: [],
-    connectedTrends: {},
+    connectedTrends: {}
   }
 
   getActionButtons = () => {
@@ -91,22 +80,22 @@ class TrendsTable extends PureComponent {
             connectedTrends,
             connectTrends,
             clearConnectedTrends,
-            allTrends,
+            allTrends
           } = this.props
           const trendConnections = connectedTrends[rawWord.toUpperCase()]
           const visibleConnectionsLength = trendConnections
             ? trendConnections.filter(word => allTrends.has(word.toLowerCase()))
-                .length
+              .length
             : 0
 
           const hasConnections = visibleConnectionsLength > 0
           return (
             <>
-              <Explanation text='Connected trends'>
+              <ExplanationTooltip text='Connected trends' offsetY={5}>
                 <span
                   className={cx(
                     styles.action__icon,
-                    !hasConnections && styles.action__icon_disabled,
+                    !hasConnections && styles.action__icon_disabled
                   )}
                 >
                   <Icon
@@ -118,7 +107,7 @@ class TrendsTable extends PureComponent {
                     onMouseLeave={clearConnectedTrends}
                   />
                 </span>
-              </Explanation>
+              </ExplanationTooltip>
               {hasConnections && (
                 <NumberCircle>{visibleConnectionsLength}</NumberCircle>
               )}
@@ -126,7 +115,7 @@ class TrendsTable extends PureComponent {
           )
         },
         width: 42,
-        className: styles.action,
+        className: styles.action
       },
       {
         Cell: ({ original: { rawWord } }) => {
@@ -134,12 +123,12 @@ class TrendsTable extends PureComponent {
 
           const insightsTrigger = (
             <Button variant='flat' className={styles.tooltip__trigger}>
-              <Explanation text='Connected insights'>
+              <ExplanationTooltip text='Connected insights' offsetY={5}>
                 <Icon
                   className={cx(!insights && styles.action__icon_disabled)}
                   type='insight'
                 />
-              </Explanation>
+              </ExplanationTooltip>
             </Button>
           )
 
@@ -172,7 +161,7 @@ class TrendsTable extends PureComponent {
           )
         },
         width: 42,
-        className: styles.action,
+        className: styles.action
       },
       {
         Cell: ({ original: { rawWord } }) => {
@@ -185,12 +174,12 @@ class TrendsTable extends PureComponent {
               passOpenStateAs='isActive'
               trigger={
                 <Button variant='flat' className={styles.tooltip__trigger}>
-                  <Explanation text='Social context' offsetY={7}>
+                  <ExplanationTooltip text='Social context' offsetY={7}>
                     <Icon
                       className={styles.action__icon_cloud}
                       type='cloud-big'
                     />
-                  </Explanation>
+                  </ExplanationTooltip>
                 </Button>
               }
             >
@@ -199,12 +188,12 @@ class TrendsTable extends PureComponent {
           )
         },
         width: 42,
-        className: styles.action,
-      },
+        className: styles.action
+      }
     ]
   }
 
-  render() {
+  render () {
     const {
       small,
       trendWords,
@@ -217,7 +206,7 @@ class TrendsTable extends PureComponent {
       username,
       selectTrend,
       selectedTrends,
-      trendConnections,
+      trendConnections
     } = this.props
 
     const tableData = trendWords.map((word, index) => {
@@ -232,7 +221,7 @@ class TrendsTable extends PureComponent {
                 isActive={isWordSelected}
                 className={cx(
                   styles.checkbox,
-                  isWordSelected && styles.checkbox_active,
+                  isWordSelected && styles.checkbox_active
                 )}
                 onClick={() => selectTrend(word)}
               />
@@ -246,7 +235,7 @@ class TrendsTable extends PureComponent {
           <Link
             className={cx(
               styles.word,
-              trendConnections.includes(word.toUpperCase()) && styles.connected,
+              trendConnections.includes(word.toUpperCase()) && styles.connected
             )}
             to={`/labs/trends/explore/${word}`}
           >
@@ -263,7 +252,7 @@ class TrendsTable extends PureComponent {
           <>
             {newVolume} <ValueChange change={newVolume - oldVolume} />
           </>
-        ),
+        )
       }
     })
 
@@ -297,13 +286,13 @@ class TrendsTable extends PureComponent {
 const mapStateToProps = ({
   hypedTrends: { scoreChange, volumeChange, TrendToInsights },
   user: {
-    data: { username },
-  },
+    data: { username }
+  }
 }) => ({
   scoreChange,
   volumeChange,
   TrendToInsights,
-  username,
+  username
 })
 
 export default connect(mapStateToProps)(TrendsTable)

--- a/src/components/Trends/TrendsTable/TrendsTable.js
+++ b/src/components/Trends/TrendsTable/TrendsTable.js
@@ -3,14 +3,17 @@ import Table from 'react-table'
 import cx from 'classnames'
 import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
+import { push } from 'react-router-redux'
 import {
   Label,
   Checkbox,
   PanelWithHeader,
   Panel,
   Icon,
-  Tooltip
+  Tooltip,
+  Button
 } from '@santiment-network/ui'
+import { store } from '../../../index'
 import ValueChange from '../../../components/ValueChange/ValueChange'
 import WordCloud from '../../../components/WordCloud/WordCloud'
 import InsightCardSmall from '../../../components/Insight/InsightCardSmall'
@@ -37,9 +40,39 @@ const columns = [
   }
 ]
 
-const NumberCircle = props => (
-  <div {...props} className={styles.insights__number} />
+const NumberCircle = ({ className, ...props }) => (
+  <div {...props} className={cx(className, styles.insights__number)} />
 )
+
+const Explanation = ({ text, children, ...props }) => (
+  <Tooltip
+    offsetY={5}
+    {...props}
+    className={styles.explanation}
+    closeTimeout={0}
+    trigger={children}
+  >
+    {text}
+  </Tooltip>
+)
+
+const getTrGroupProps = (_, rowInfo) => {
+  return {
+    onClick: ({ target, currentTarget }) => {
+      let node = target
+      while (node && node !== currentTarget) {
+        if (
+          node.classList.contains(styles.action) ||
+          node.classList.contains(styles.checkbox)
+        ) {
+          return
+        }
+        node = node.parentNode
+      }
+      store.dispatch(push(`/labs/trends/explore/${rowInfo.original.rawWord}`))
+    }
+  }
+}
 
 class TrendsTable extends PureComponent {
   static defaultProps = {
@@ -69,47 +102,56 @@ class TrendsTable extends PureComponent {
           const hasConnections = visibleConnectionsLength > 0
           return (
             <>
-              <Icon
-                className={cx(
-                  styles.action__icon,
-                  !hasConnections && styles.action__icon_disabled
-                )}
-                type='connection-big'
-                onMouseEnter={() => {
-                  connectTrends(rawWord)
-                }}
-                onMouseLeave={clearConnectedTrends}
-              />
+              <Explanation text='Connected trends'>
+                <span
+                  className={cx(
+                    styles.action__icon,
+                    !hasConnections && styles.action__icon_disabled
+                  )}
+                >
+                  <Icon
+                    type='connection-big'
+                    className={styles.icon}
+                    onMouseEnter={() => {
+                      connectTrends(rawWord)
+                    }}
+                    onMouseLeave={clearConnectedTrends}
+                  />
+                </span>
+              </Explanation>
               {hasConnections && (
                 <NumberCircle>{visibleConnectionsLength}</NumberCircle>
               )}
             </>
           )
         },
-        width: 40,
+        width: 42,
         className: styles.action
       },
       {
         Cell: ({ original: { rawWord } }) => {
           const insights = this.props.TrendToInsights[rawWord.toUpperCase()]
 
-          const icon = (
-            <Icon
-              className={cx(
-                styles.action__icon,
-                !insights && styles.action__icon_disabled
-              )}
-              type='insight'
-            />
+          const insightsTrigger = (
+            <Button variant='flat' className={styles.tooltip__trigger}>
+              <Explanation text='Connected insights'>
+                <Icon
+                  className={cx(!insights && styles.action__icon_disabled)}
+                  type='insight'
+                />
+              </Explanation>
+            </Button>
           )
 
           return insights && insights.length > 0 ? (
             <>
               <Tooltip
-                closeTimeout={50}
+                closeTimeout={200}
                 position='bottom'
                 className={styles.tooltip}
-                trigger={icon}
+                on='click'
+                passOpenStateAs='isActive'
+                trigger={insightsTrigger}
               >
                 <Panel>
                   {insights.map((insight, i) => (
@@ -121,34 +163,42 @@ class TrendsTable extends PureComponent {
                   ))}
                 </Panel>
               </Tooltip>
-              <NumberCircle>{insights.length}</NumberCircle>
+              <NumberCircle className={styles.insights__number_btn}>
+                {insights.length}
+              </NumberCircle>
             </>
           ) : (
-            icon
+            insightsTrigger
           )
         },
-        width: 40,
+        width: 42,
         className: styles.action
       },
       {
         Cell: ({ original: { rawWord } }) => {
           return (
             <Tooltip
-              closeTimeout={50}
+              on='click'
+              closeTimeout={200}
               position='left'
               className={styles.tooltip}
+              passOpenStateAs='isActive'
               trigger={
-                <Icon
-                  className={cx(styles.action__icon, styles.action__icon_cloud)}
-                  type='cloud-big'
-                />
+                <Button variant='flat' className={styles.tooltip__trigger}>
+                  <Explanation text='Social context' offsetY={7}>
+                    <Icon
+                      className={styles.action__icon_cloud}
+                      type='cloud-big'
+                    />
+                  </Explanation>
+                </Button>
               }
             >
               <WordCloud className={styles.wordCloud} word={rawWord} />
             </Tooltip>
           )
         },
-        width: 40,
+        width: 42,
         className: styles.action
       }
     ]
@@ -237,6 +287,7 @@ class TrendsTable extends PureComponent {
           showPagination={false}
           defaultPageSize={10}
           minRows={10}
+          getTrGroupProps={getTrGroupProps}
         />
       </PanelWithHeader>
     )

--- a/src/components/Trends/TrendsTable/TrendsTable.module.scss
+++ b/src/components/Trends/TrendsTable/TrendsTable.module.scss
@@ -37,10 +37,6 @@
       fill: var(--jungle-green);
     }
 
-    &_cloud {
-      visibility: hidden;
-    }
-
     &_disabled {
       pointer-events: none;
       fill: var(--mystic);
@@ -84,10 +80,6 @@
             color: var(--jungle-green);
           }
 
-          .action__icon_cloud {
-            visibility: visible;
-          }
-
           .checkbox {
             display: inline-flex;
 
@@ -112,12 +104,13 @@
 }
 
 .wordCloud {
-  width: 400px;
   height: 320px;
+  width: 100%;
 }
 
 .tooltip {
   z-index: 10;
+  width: 400px;
 }
 
 .insights {
@@ -133,8 +126,10 @@
     font-size: 12px !important;
     right: -7px;
     top: -5px;
+    padding-top: 1px;
     width: 14px;
     text-align: center;
+    pointer-events: none;
   }
 }
 

--- a/src/components/Trends/TrendsTable/TrendsTable.module.scss
+++ b/src/components/Trends/TrendsTable/TrendsTable.module.scss
@@ -22,10 +22,7 @@
 }
 
 .action {
-  /* text-align: right; */
   text-align: center;
-
-  /* margin-right: 10px; */
   position: relative;
   overflow: visible !important;
 

--- a/src/components/Trends/TrendsTable/TrendsTable.module.scss
+++ b/src/components/Trends/TrendsTable/TrendsTable.module.scss
@@ -1,5 +1,3 @@
-@import '~@santiment-network/ui/variables.scss';
-
 .header {
   padding: 13px 23px;
 }
@@ -120,6 +118,7 @@
 
   &__trigger {
     background: transparent;
+    padding: 6px 7px;
   }
 }
 
@@ -168,14 +167,6 @@
       display: none;
     }
   }
-}
-
-.explanation {
-  background: $fiord;
-  padding: 3px 12px;
-  color: $white;
-  border-radius: $border-radius;
-  font-size: 12px;
 }
 
 .icon {

--- a/src/components/Trends/TrendsTable/TrendsTable.module.scss
+++ b/src/components/Trends/TrendsTable/TrendsTable.module.scss
@@ -1,3 +1,5 @@
+@import '~@santiment-network/ui/variables.scss';
+
 .header {
   padding: 13px 23px;
 }
@@ -20,8 +22,10 @@
 }
 
 .action {
-  text-align: right;
-  margin-right: 10px;
+  /* text-align: right; */
+  text-align: center;
+
+  /* margin-right: 10px; */
   position: relative;
   overflow: visible !important;
 
@@ -69,7 +73,8 @@
     }
 
     .rt-tr-group {
-      padding: 20px 23px;
+      padding: 0 10px 0 23px;
+      height: 60px;
 
       &:hover {
         background: var(--athens);
@@ -96,6 +101,10 @@
       border: none !important;
     }
 
+    .rt-tr {
+      align-items: center;
+    }
+
     .rt-tr:hover {
       background: initial !important;
       transition: initial;
@@ -111,6 +120,10 @@
 .tooltip {
   z-index: 10;
   width: 400px;
+
+  &__trigger {
+    background: transparent;
+  }
 }
 
 .insights {
@@ -124,12 +137,17 @@
     background: var(--porcelain);
     color: var(--waterloo);
     font-size: 12px !important;
-    right: -7px;
+    right: 3px;
     top: -5px;
     padding-top: 1px;
     width: 14px;
     text-align: center;
     pointer-events: none;
+
+    &_btn {
+      top: 0;
+      left: 23px;
+    }
   }
 }
 
@@ -153,4 +171,16 @@
       display: none;
     }
   }
+}
+
+.explanation {
+  background: $fiord;
+  padding: 3px 12px;
+  color: $white;
+  border-radius: $border-radius;
+  font-size: 12px;
+}
+
+.icon {
+  vertical-align: middle;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,10 +1466,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@santiment-network/ui@^0.4.70":
-  version "0.4.70"
-  resolved "https://registry.yarnpkg.com/@santiment-network/ui/-/ui-0.4.70.tgz#c47638b0166b5a8681c41eec20aa6028a4429700"
-  integrity sha512-gejGLT4Mv62GlHDSTlU5E5OT6b8J9En21GQfUpgTMYxN7tlooVYOPfqMiV0kfti8v/TYExz75+BFOySsBaPm9w==
+"@santiment-network/ui@^0.4.72":
+  version "0.4.72"
+  resolved "https://registry.yarnpkg.com/@santiment-network/ui/-/ui-0.4.72.tgz#7ff0ab83bd0523f9fdf7ceab7c595f00e960bf84"
+  integrity sha512-ABr/CZZLYIgCcyu5WjQSC563IAqwvwWoT6LBgH+TL8neUJrw91yUkeMtNXD534jRSZPXOJ/c9j700PGAOz5nZA==
 
 "@semantic-ui-react/event-stack@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
#### Summary
- Explanation tooltips for the action buttons;
- Action buttons now trigger tooltip by `click`;
- `Hyped score` renamed to the `Hype score`
- By clicking on the table row, the user will be lead to the `/labs/trends/explore/:trend` page;

#### Screenshots
![image](https://user-images.githubusercontent.com/25135650/56213169-34c78d80-6064-11e9-936e-19829db8162d.png)
