### PR TITLE
fix/connected-insights-cache

### DIFF
--- a/src/pages/Trends/connectedWordsEpic.js
+++ b/src/pages/Trends/connectedWordsEpic.js
@@ -97,6 +97,7 @@ export const connectedWordsEpic = (action$, store, { client }) =>
       insightQueries.push(
         client.query({
           query: ALL_INSIGHTS_BY_TAG_QUERY,
+          fetchPolicy: 'no-cache',
           variables: {
             tag: getInsightTrendTagByDate(
               new Date(Date.now() - oneDayTimestamp * i)


### PR DESCRIPTION
#### Summary
Trend insights fetch policy changed in order to fetch up-to-date insights during app lifetime