### PR TITLE
feature/date-formatter

### DIFF
--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -184,8 +184,7 @@ export const dateDifferenceInWords = ({
  * @param {Date} date - Date object to get formats from
  *
  * @description
- * Formatting is based on the "Unicode Date Field Symbol Table"
- * https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
+ * Format tokens are similar to the "moment.js"
    *
    * @example
    * // Getting formats for current date

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -91,7 +91,7 @@ const FormatToTimestamp = {
  * // Getting past interval
  * // Current date: 16th April 2019
  * // Target: 9 days prior to current date
- * // getTimeIntervalFromToday(-9, 'd')
+ *  getTimeIntervalFromToday(-9, 'd')
  */
 export const getTimeIntervalFromToday = (amount, dateFormat) => {
   const from = new Date()
@@ -179,17 +179,32 @@ export const dateDifferenceInWords = ({
   return getUnitFormattedString(result, resultFormat)
 }
 
+/**
+ *
+ * @param {Date} date - Date object to get formats from
+ *
+ * @description
+ * Formatting is based on the "Unicode Date Field Symbol Table"
+ * https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
+   *
+   * @example
+   * // Getting formats for current date
+   * const {EEEE, D, MMMM, YYYY} = getDateFormats(new Date())
+   * console.log(`${EEEE}, ${D} ${MMMM} ${YYYY}`)
+   * //=> "Wednesday, 17 April 2019"
+
+ */
 export const getDateFormats = date => {
   const month = date.getMonth()
   const M = month + 1
   const D = date.getDate()
-  const d = date.getDay()
+  const E = date.getDay()
 
   return {
     D,
     DD: D < 10 ? `0${D}` : D,
-    ddd: WEEK_DAY_NAMES[d],
-    dddd: SHORT_WEEK_DAY_NAMES[d],
+    EEE: SHORT_WEEK_DAY_NAMES[E],
+    EEEE: WEEK_DAY_NAMES[E],
     M,
     MM: M < 10 ? `0${M}` : M,
     MMM: SHORT_MONTH_NAMES[month],

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -188,8 +188,8 @@ export const dateDifferenceInWords = ({
    *
    * @example
    * // Getting formats for current date
-   * const {EEEE, D, MMMM, YYYY} = getDateFormats(new Date())
-   * console.log(`${EEEE}, ${D} ${MMMM} ${YYYY}`)
+   * const {dddd, D, MMMM, YYYY} = getDateFormats(new Date())
+   * console.log(`${dddd}, ${D} ${MMMM} ${YYYY}`)
    * //=> "Wednesday, 17 April 2019"
 
  */

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -12,6 +12,47 @@ export const DAY = 'd'
 export const MONTH = 'm'
 export const YEAR = 'y'
 
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December'
+]
+const SHORT_MONTH_NAMES = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec'
+]
+
+const WEEK_DAY_NAMES = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday'
+]
+
+const SHORT_WEEK_DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
 const DateFormat = {
   [MONTH]: ['getMonth', 'setMonth'],
   [DAY]: ['getDate', 'setDate']
@@ -124,4 +165,23 @@ export const dateDifferenceInWords = ({
   }
 
   return getUnitFormattedString(result, resultFormat)
+}
+
+export const getDateFormats = date => {
+  const month = date.getMonth()
+  const M = month + 1
+  const D = date.getDate()
+  const d = date.getDay()
+
+  return {
+    D,
+    DD: D < 10 ? `0${D}` : D,
+    ddd: WEEK_DAY_NAMES[d],
+    dddd: SHORT_WEEK_DAY_NAMES[d],
+    M,
+    MM: M < 10 ? `0${M}` : M,
+    MMM: SHORT_MONTH_NAMES[month],
+    MMMM: MONTH_NAMES[month],
+    YYYY: date.getFullYear()
+  }
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -197,13 +197,13 @@ export const getDateFormats = date => {
   const month = date.getMonth()
   const M = month + 1
   const D = date.getDate()
-  const E = date.getDay()
+  const d = date.getDay()
 
   return {
     D,
     DD: D < 10 ? `0${D}` : D,
-    EEE: SHORT_WEEK_DAY_NAMES[E],
-    EEEE: WEEK_DAY_NAMES[E],
+    ddd: SHORT_WEEK_DAY_NAMES[d],
+    dddd: WEEK_DAY_NAMES[d],
     M,
     MM: M < 10 ? `0${M}` : M,
     MMM: SHORT_MONTH_NAMES[month],

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -83,6 +83,16 @@ const FormatToTimestamp = {
   [DAY]: ONE_DAY_IN_MS
 }
 
+/**
+ * @param {number} amount - Amount of days/months to add or substract
+ * @param {'d'|'m'} dateFormat - Modifier
+ *
+ * @example
+ * // Getting past interval
+ * // Current date: 16th April 2019
+ * // Target: 9 days prior to current date
+ * // getTimeIntervalFromToday(-9, 'd')
+ */
 export const getTimeIntervalFromToday = (amount, dateFormat) => {
   const from = new Date()
   const to = new Date()
@@ -91,7 +101,9 @@ export const getTimeIntervalFromToday = (amount, dateFormat) => {
   to.setHours(24, 0, 0, 0)
   from.setHours(0, 0, 0, 0)
 
-  from[set](from[get]() + amount)
+  const target = amount < 0 ? from : to
+
+  target[set](from[get]() + amount)
 
   return {
     from,


### PR DESCRIPTION
#### Summary
Santiment alternative to the [`moment().format()`](https://momentjs.com/docs/#/displaying/format/) method -> `getDateFormats`

#### Benchmarks
[Benchmark](https://jsperf.com/custom-date-format/1) of the current implementation. On average, this implementation is `33x` faster than `moment.js` and `date-fns`
![image](https://user-images.githubusercontent.com/25135650/56280719-76634180-6113-11e9-947a-4408d71fd975.png)
