### PR TITLE
Hotfix/gainers losers table

### DIFF
--- a/src/ducks/GainersAndLosers/GainersAndLosersTable.js
+++ b/src/ducks/GainersAndLosers/GainersAndLosersTable.js
@@ -39,6 +39,12 @@ const GainersLosersTable = ({
     noDataText={isError && 'Error fetching data'}
     data={topSocialGainersLosers}
     columns={getColumns({ timeWindow })}
+    defaultSorted={[
+      {
+        id: 'project',
+        desc: true
+      }
+    ]}
   />
 )
 

--- a/src/ducks/GainersAndLosers/GainersAndLosersTable.js
+++ b/src/ducks/GainersAndLosers/GainersAndLosersTable.js
@@ -41,7 +41,7 @@ const GainersLosersTable = ({
     columns={getColumns({ timeWindow })}
     defaultSorted={[
       {
-        id: 'project',
+        id: 'change',
         desc: true
       }
     ]}

--- a/src/ducks/GainersAndLosers/gainers-and-losers-table-columns.js
+++ b/src/ducks/GainersAndLosers/gainers-and-losers-table-columns.js
@@ -35,7 +35,7 @@ const getColumns = ({ timeWindow }) => [
     maxWidth: 100,
     accessor: 'change',
     Cell: ({ value }) =>
-      value ? <PercentChanges changes={value} /> : 'No data'
+      value ? <PercentChanges changes={value * 100} /> : 'No data'
   },
   {
     Header: '',

--- a/src/ducks/GainersAndLosers/gainers-and-losers-table-columns.js
+++ b/src/ducks/GainersAndLosers/gainers-and-losers-table-columns.js
@@ -17,6 +17,8 @@ const getColumns = ({ timeWindow }) => [
       name,
       coinmarketcapId
     }),
+    sortMethod: (previous, next) =>
+      previous.name.toLowerCase() <= next.name.toLowerCase() ? 1 : -1,
     Cell: ({ value }) => (
       <Link
         className={styles.wrapper}


### PR DESCRIPTION
**Related card**
https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/cffeb6e3eaf254588cb68a9a?card=San-4336

![pr](https://user-images.githubusercontent.com/47984484/56340561-e0412100-61cf-11e9-92b9-fefdab56fdb5.png)

Tasks done here:

1) Fix sorting by project name on click header
2) Default sorted by percentage change (previously no default sorting was implemented, ordering was dependent on query result)