### PR TITLE
hotfix/trends-table-table-click

### DIFF
--- a/src/components/Trends/TrendsTable/TrendsTable.js
+++ b/src/components/Trends/TrendsTable/TrendsTable.js
@@ -51,8 +51,10 @@ const getTrGroupProps = (_, rowInfo) => {
       let node = target
       while (node && node !== currentTarget) {
         if (
-          node.classList.contains(styles.action) ||
-          node.classList.contains(styles.checkbox)
+          node.classList &&
+          (node.classList.contains(styles.tooltip) ||
+            node.classList.contains(styles.action) ||
+            node.classList.contains(styles.checkbox))
         ) {
           return
         }
@@ -143,7 +145,7 @@ class TrendsTable extends PureComponent {
                 passOpenStateAs='isActive'
                 trigger={insightsTrigger}
               >
-                <Panel>
+                <Panel className={styles.insights}>
                   {insights.map((insight, i) => (
                     <InsightCardSmall
                       key={i}

--- a/src/components/Trends/TrendsTable/TrendsTable.js
+++ b/src/components/Trends/TrendsTable/TrendsTable.js
@@ -145,7 +145,7 @@ class TrendsTable extends PureComponent {
                 passOpenStateAs='isActive'
                 trigger={insightsTrigger}
               >
-                <Panel className={styles.insights}>
+                <Panel>
                   {insights.map((insight, i) => (
                     <InsightCardSmall
                       key={i}


### PR DESCRIPTION
#### Summary
Fixing the issue with redirection to `trends/explore` after clicking on the tooltip like connected insights.