### PR TITLE
hotfix/empty-category

### DIFF
--- a/src/ducks/SANCharts/ChartPage.module.scss
+++ b/src/ducks/SANCharts/ChartPage.module.scss
@@ -1,7 +1,3 @@
-:global(#root) {
-  height: auto;
-}
-
 .settings {
   display: flex;
   padding: 10px;


### PR DESCRIPTION
this bug because[ parent has height: 0 ](https://github.com/bvaughn/react-virtualized/blob/master/docs/usingAutoSizer.md#why-is-my-autosizer-setting-a-height-of-0)
