### PR TITLE
fix/insights-tab

### DIFF
--- a/src/components/Insight/InsightsTrends.js
+++ b/src/components/Insight/InsightsTrends.js
@@ -31,13 +31,12 @@ export const getPast3DaysInsightsByTrendTag = () =>
         }
       },
       props: ({
-        data: { allInsightsByTag = [] },
-        ownProps: { allInsightsByTag: ownInsights = [] }
-      }) => {
-        return {
-          allInsightsByTag: allInsightsByTag.concat(ownInsights)
-        }
-      }
+        data: { allInsightsByTag = [], loading },
+        ownProps: { allInsightsByTag: ownInsights = [], isLoadingInsights }
+      }) => ({
+        isLoadingInsights: loading || isLoadingInsights,
+        allInsightsByTag: allInsightsByTag.concat(ownInsights)
+      })
     })
   )
 

--- a/src/components/Trends/Explore/TrendsExploreAdditionalInfo.js
+++ b/src/components/Trends/Explore/TrendsExploreAdditionalInfo.js
@@ -12,7 +12,14 @@ import styles from './TrendsExploreAdditionalInfo.module.scss'
 const NEWS_INDEX = 'News'
 const INSIGHTS_INDEX = 'Insights'
 
-const TrendsExploreAdditionalInfo = ({ news, allInsightsByTag, word }) => {
+const TrendsExploreAdditionalInfo = ({
+  news,
+  allInsightsByTag,
+  word,
+  isLoadingInsights,
+  isLoadingNews
+}) => {
+  if (isLoadingInsights || isLoadingNews) return null
   const modifiedWord = word.toUpperCase()
   const insights = allInsightsByTag.filter(({ tags }) =>
     tags.some(({ name }) => name === modifiedWord)
@@ -71,7 +78,10 @@ const enhance = compose(
         variables: { from, to, tag, size: 6 }
       }
     },
-    props: ({ data: { news = [] } }) => ({ news: news.reverse() })
+    props: ({ data: { news = [], loading } }) => ({
+      news: news.reverse(),
+      isLoadingNews: loading
+    })
   })
 )
 

--- a/src/pages/Detailed/MobileDetailedPage.js
+++ b/src/pages/Detailed/MobileDetailedPage.js
@@ -154,7 +154,7 @@ const MobileDetailedPage = props => {
                         {transactionVolumeInfo && (
                           <MobileMetricCard {...transactionVolumeInfo} />
                         )}
-                        {props.news && (
+                        {props.news && props.news.length > 0 && (
                           <>
                             <h3 className={styles.news__heading}>News</h3>
                             <NewsSmall data={props.news} />


### PR DESCRIPTION
was problem with showing heading when empty news:
![image](https://user-images.githubusercontent.com/24521041/57929152-354d8100-78bb-11e9-873d-62f35e9b9100.png)

and sometimes was problem with logic for insights & news tabs (content was from insights tab, but on ui - active tab was "News")
![image](https://user-images.githubusercontent.com/24521041/57929243-6ded5a80-78bb-11e9-8ad3-78d432892567.png)
