### PR TITLE
fix/digest-toggle

### DIFF
--- a/src/pages/Account/SettingsNotifications.js
+++ b/src/pages/Account/SettingsNotifications.js
@@ -73,12 +73,14 @@ const SettingsNotifications = ({
         <Selector
           options={['DAILY', 'WEEKLY', 'OFF']}
           nameOptions={['Daily', 'Weekly', 'Off']}
-          onSelectOption={subscription => {
-            changeDigestType(subscription)
+          onSelectOption={subscription =>
             mutateDigestType({ variables: { subscription } })
-              .then(onDigestChangeSuccess)
+              .then(() => {
+                changeDigestType(subscription)
+                onDigestChangeSuccess()
+              })
               .catch(onDigestChangeError)
-          }}
+          }
           defaultSelected={digestType}
         />
       </Settings.Row>

--- a/src/pages/Account/SettingsNotifications.js
+++ b/src/pages/Account/SettingsNotifications.js
@@ -33,7 +33,8 @@ const SettingsNotifications = ({
   toggleEmailNotification,
   toggleTelegramNotification,
   digestType,
-  changeDigestType
+  changeDigestType,
+  mutateDigestType
 }) => {
   return (
     <Settings id='notifications' header='Notifications'>
@@ -72,11 +73,12 @@ const SettingsNotifications = ({
         <Selector
           options={['DAILY', 'WEEKLY', 'OFF']}
           nameOptions={['Daily', 'Weekly', 'Off']}
-          onSelectOption={subscription =>
-            changeDigestType({ variables: { subscription } })
+          onSelectOption={subscription => {
+            changeDigestType(subscription)
+            mutateDigestType({ variables: { subscription } })
               .then(onDigestChangeSuccess)
               .catch(onDigestChangeError)
-          }
+          }}
           defaultSelected={digestType}
         />
       </Settings.Row>
@@ -112,6 +114,11 @@ const mapDispatchToProps = dispatch => ({
     dispatch({
       type: actions.SETTINGS_TOGGLE_NOTIFICATION_CHANNEL,
       payload: { signalNotifyTelegram }
+    }),
+  changeDigestType: type =>
+    dispatch({
+      type: actions.USER_DIGEST_CHANGE,
+      payload: type
     })
 })
 
@@ -120,7 +127,7 @@ const enhance = compose(
     mapStateToProps,
     mapDispatchToProps
   ),
-  graphql(NEWSLETTER_SUBSCRIPTION_MUTATION, { name: 'changeDigestType' })
+  graphql(NEWSLETTER_SUBSCRIPTION_MUTATION, { name: 'mutateDigestType' })
 )
 
 export default enhance(SettingsNotifications)


### PR DESCRIPTION
#### Summary
Preserving the state of the `Digest` setting after reload.

#### Related Favro card
https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/cffeb6e3eaf254588cb68a9a?card=San-4840