### PR TITLE
enhance/chart-share-iframe

### DIFF
--- a/src/ducks/SANCharts/ChartSettings.js
+++ b/src/ducks/SANCharts/ChartSettings.js
@@ -31,7 +31,11 @@ const ChartSettings = ({
         defaultSelectedIndexes={hasNightMode && ['Night mode']}
         onSelect={onNightModeSelect}
       />
-      <ShareModalTrigger shareLink={generateShareLink(disabledMetrics)} />
+      <ShareModalTrigger
+        shareLink={`<iframe frameborder="0" height="340" src="${generateShareLink(
+          disabledMetrics
+        )}"></iframe>`}
+      />
     </div>
   )
 }


### PR DESCRIPTION
#### Summary
Sharing the `iframe` by default on the `/chart` page.
#### Screenshots
![image](https://user-images.githubusercontent.com/25135650/58095453-b4082e00-7bdb-11e9-9a3c-dbe56262c4f1.png)
