### PR TITLE
hotfix/percent escaped in url

### DIFF
--- a/src/pages/Insights/utils.js
+++ b/src/pages/Insights/utils.js
@@ -50,8 +50,10 @@ export const getInsightIdFromSEOLink = link =>
 
 export const getSEOLinkFromIdAndTitle = (id, title) =>
   encodeURIComponent(
-    `${title
-      .toLowerCase()
-      .split(' ')
-      .join('-')}-${id}`
+    encodeURIComponent(
+      `${title
+        .toLowerCase()
+        .split(' ')
+        .join('-')}-${id}`
+    )
   )

--- a/src/pages/Insights/utils.spec.js
+++ b/src/pages/Insights/utils.spec.js
@@ -5,12 +5,12 @@ const insights = {
   small: {
     id: 0,
     title: 'How are you?',
-    seo: 'how-are-you%3F-0'
+    seo: 'how-are-you%253F-0'
   },
   strange: {
     id: 1,
     title: 'ThIS -- a., &&lre you?-0',
-    seo: 'this----a.%2C-%26%26lre-you%3F-0-1'
+    seo: 'this----a.%252C-%2526%2526lre-you%253F-0-1'
   }
 }
 


### PR DESCRIPTION
fix for bug from Wihelm.
Context: when in insight title we have percent (%) - seolink for insight gives 404, but by id its open nice.
Example:
https://app.santiment.net/insights/read/craig-wright-registers-copyright-for-bitcoin-whitepaper%2C-bsv-pumps-over-70%-417 . Using this link gives a 400 bad error page.

here's how you can read it instead https://app.santiment.net/insights/read/417

in react-router, in Link decoding occurs and it removes encode percents ([more about that](decoding occurs)).

I decided to encode link 2 times, but maybe it's not the best solution
example of link with percent, that encode two times: http://localhost:3000/insights/read/one%2C-insight-100%25-466