### PR TITLE
fix/facebook-share

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ms": "^2.1.1",
     "nprogress": "^0.2.0",
     "outliers": "^0.0.3",
-    "query-string": "^5.0.1",
+    "query-string": "^6.5.0",
     "raven-for-redux": "^1.1.1",
     "raven-js": "^3.20.1",
     "react": "^16.8.6",

--- a/src/components/Share/SharePanel.js
+++ b/src/components/Share/SharePanel.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Input, Panel, Icon, Button } from '@santiment-network/ui'
+import { Button, Icon, Input, Panel } from '@santiment-network/ui'
 import ShareComposition from './ShareComposition'
 import ShareCopyBtn from './ShareCopyBtn.js'
 import styles from './SharePanel.module.scss'
@@ -66,8 +66,8 @@ const SharePanel = ({
           />
           <ShareCopyBtn shareLink={shareLink} />
         </div>
-        {extraShare.map(({ value, label }) => (
-          <div className={styles.link}>
+        {extraShare.map(({ value, label }, idx) => (
+          <div className={styles.link} key={idx}>
             <Input
               className={styles.link__input}
               readOnly

--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -3,7 +3,6 @@ import * as qs from 'query-string'
 import Loadable from 'react-loadable'
 import GetTimeSeries from '../../ducks/GetTimeSeries/GetTimeSeries'
 import { ERRORS } from '../GetTimeSeries/reducers'
-import { mapQSToState } from './../../utils/utils'
 import Charts from './Charts'
 
 const LoadableChartSettings = Loadable({
@@ -17,13 +16,16 @@ const LoadableChartMetrics = Loadable({
 })
 
 class ChartPage extends Component {
+  mapQSToState = ({ location: { search } }) =>
+    qs.parse(search, { arrayFormat: 'comma' })
+
   state = {
     timeRange: '6m',
     slug: 'santiment',
     metrics: ['price'],
     title: 'Santiment (SAN)',
     interval: '1d',
-    ...mapQSToState(this.props)
+    ...this.mapQSToState(this.props)
   }
 
   onZoom = (leftZoomIndex, rightZoomIndex, leftZoomDate, rightZoomDate) => {
@@ -63,7 +65,7 @@ class ChartPage extends Component {
     )
   }
 
-  mapStateToQS = props => '?' + qs.stringify(props, { arrayFormat: 'bracket' })
+  mapStateToQS = props => '?' + qs.stringify(props, { arrayFormat: 'comma' })
 
   updateSearchQuery () {
     this.props.history.replace({
@@ -101,7 +103,7 @@ class ChartPage extends Component {
     }
 
     return `${origin}${pathname}?${qs.stringify(settings, {
-      arrayFormat: 'bracket'
+      arrayFormat: 'comma'
     })}`
   }
 
@@ -109,23 +111,15 @@ class ChartPage extends Component {
     const {
       timeRange,
       slug,
-      metrics: metricsOriginal,
+      metrics,
       from,
       to,
       interval,
       viewOnly,
       title,
       zoom,
-      nightMode,
-      ...restState
+      nightMode
     } = this.state
-
-    const modifiedMetrics = []
-    for (let [key, value] of Object.entries(restState)) {
-      if (key.match(/metrics\[\d+]$/) !== null) modifiedMetrics.push(value)
-    }
-    const metrics =
-      modifiedMetrics.length > 0 ? modifiedMetrics : metricsOriginal
 
     const requestedMetrics = metrics.reduce((acc, metric) => {
       acc = {

--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -109,15 +109,24 @@ class ChartPage extends Component {
     const {
       timeRange,
       slug,
-      metrics,
+      metrics: metricsOriginal,
       from,
       to,
       interval,
       viewOnly,
       title,
       zoom,
-      nightMode
+      nightMode,
+      ...restState
     } = this.state
+
+    const modifiedMetrics = []
+    for (let [key, value] of Object.entries(restState)) {
+      if (key.match(/metrics\[\d+]$/) !== null) modifiedMetrics.push(value)
+    }
+    const metrics =
+      modifiedMetrics.length > 0 ? modifiedMetrics : metricsOriginal
+
     const requestedMetrics = metrics.reduce((acc, metric) => {
       acc = {
         ...acc,


### PR DESCRIPTION
[Favro card](https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/cffeb6e3eaf254588cb68a9a?card=San-5006)

Problem happened because `metrics` array was missed and metrics returned as separate arrays (on screenshot `metrics` include `price` by default):
![image](https://user-images.githubusercontent.com/24521041/58707365-5fc03380-83bd-11e9-9ff4-f04883eec43d.png)


Result:
![image](https://user-images.githubusercontent.com/24521041/58707430-9bf39400-83bd-11e9-9959-1cba6348f431.png)
