### PR TITLE
fix/search

### DIFF
--- a/src/components/Search/SearchProjects.js
+++ b/src/components/Search/SearchProjects.js
@@ -15,6 +15,8 @@ const SearchProjects = ({ data: { allProjects = [] }, ...props }) => {
       predicate={searchTerm => {
         const upperCaseSearchTerm = searchTerm.toUpperCase()
         return ({ ticker, name }) =>
+          name.toUpperCase() === upperCaseSearchTerm ||
+          ticker.toUpperCase() === upperCaseSearchTerm ||
           name.toUpperCase().includes(upperCaseSearchTerm) ||
           ticker.toUpperCase().includes(upperCaseSearchTerm)
       }}


### PR DESCRIPTION
[favro card](https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/cffeb6e3eaf254588cb68a9a?card=San-4954)

my suggest, that search didn't work for `TRON`, because we used only `includes()` method and the first 5 projects includes this substring. TRON project also is searching, but didn't include in first five ones

we can't test it on stage, because set of projects isn't the same as on prod