### PR TITLE
fix/transaction-volume

### DIFF
--- a/src/components/MobileMetricCard/MobileMetricCard.js
+++ b/src/components/MobileMetricCard/MobileMetricCard.js
@@ -4,7 +4,7 @@ import { formatNumber } from '../../utils/formatting'
 import PercentChanges from '../PercentChanges'
 import styles from './MobileMetricCard.module.scss'
 
-const MobileMetricCard = ({ name, value, label, changes }) => {
+const MobileMetricCard = ({ name, value, label, changes, measure = '' }) => {
   return (
     <article className={styles.metric}>
       <div>
@@ -12,7 +12,9 @@ const MobileMetricCard = ({ name, value, label, changes }) => {
         <Label accent='waterloo'>({label})</Label>
       </div>
       <div className={styles.right}>
-        <span>{formatNumber(value)}</span>
+        <span>
+          {formatNumber(value)} {measure}
+        </span>
         <PercentChanges changes={changes} />
       </div>
     </article>

--- a/src/pages/Detailed/MobileDetailedPage.js
+++ b/src/pages/Detailed/MobileDetailedPage.js
@@ -227,8 +227,8 @@ const enhance = compose(
     options: ({ match }) => {
       const to = new Date()
       const from = new Date()
-      to.setHours(to.getHours() - 1, 0, 0)
-      from.setHours(from.getHours() - 48, 0, 0)
+      to.setHours(to.getHours() - 1, 0, 0, 0)
+      from.setHours(from.getHours() - 48, 0, 0, 0)
       const { slug } = match.params
       return {
         variables: {

--- a/src/pages/Detailed/MobileDetailedPage.js
+++ b/src/pages/Detailed/MobileDetailedPage.js
@@ -230,8 +230,8 @@ const enhance = compose(
     options: ({ match }) => {
       const to = new Date()
       const from = new Date()
-      to.setHours(to.getHours() - 1, 0, 0, 0)
-      from.setHours(from.getHours() - 48, 0, 0, 0)
+      to.setUTCHours(to.getUTCHours() - 1, 0, 0, 0)
+      from.setUTCHours(from.getUTCHours() - 48, 0, 0, 0)
       const { slug } = match.params
       return {
         variables: {

--- a/src/pages/Detailed/MobileDetailedPage.js
+++ b/src/pages/Detailed/MobileDetailedPage.js
@@ -38,11 +38,13 @@ const MobileDetailedPage = props => {
 
   let transactionVolumeInfo
   const { transactionVolume } = props
-  if (transactionVolume && transactionVolume.length === 2) {
-    const [
-      { transactionVolume: yesterdayTransactionVolume },
-      { transactionVolume: todayTransactionVolume }
-    ] = transactionVolume
+  if (transactionVolume && transactionVolume.length === 48) {
+    const yesterdayTransactionVolume = transactionVolume
+      .slice(0, 24)
+      .reduce((acc, { transactionVolume }) => acc + transactionVolume, 0)
+    const todayTransactionVolume = transactionVolume
+      .slice(-24)
+      .reduce((acc, { transactionVolume }) => acc + transactionVolume, 0)
     const TVDiff = calcPercentageChange(
       yesterdayTransactionVolume,
       todayTransactionVolume
@@ -223,9 +225,19 @@ const enhance = compose(
   }),
   graphql(TRANSACTION_VOLUME_QUERY, {
     options: ({ match }) => {
-      const { from, to } = getTimeIntervalFromToday(-1, DAY)
+      const to = new Date()
+      const from = new Date()
+      to.setHours(to.getHours() - 1, 0, 0)
+      from.setHours(from.getHours() - 48, 0, 0)
       const { slug } = match.params
-      return { variables: { slug, from, to, interval: '1d' } }
+      return {
+        variables: {
+          slug,
+          from: from.toISOString(),
+          to: to.toISOString(),
+          interval: '1h'
+        }
+      }
     },
     props: ({ data: { transactionVolume = [] } }) => ({ transactionVolume })
   }),

--- a/src/pages/Detailed/MobileDetailedPage.js
+++ b/src/pages/Detailed/MobileDetailedPage.js
@@ -166,7 +166,10 @@ const MobileDetailedPage = props => {
                           <MobileMetricCard {...devActivityInfo} />
                         )}
                         {transactionVolumeInfo && (
-                          <MobileMetricCard {...transactionVolumeInfo} />
+                          <MobileMetricCard
+                            {...transactionVolumeInfo}
+                            measure={ticker}
+                          />
                         )}
                         <ShowIf beta>
                           {props.news && props.news.length > 0 && (


### PR DESCRIPTION
**Summary**
Changed graphql request with interval = "1h"
combined 24 hours before comparing 24h changes
Added ticker for TV metric

So, for non-premium users it won't be show

**Screenshots**
non-premium:
![image](https://user-images.githubusercontent.com/24521041/59025475-f0cf5880-885c-11e9-9be7-6cfdd41bd80a.png)

premium:
![image](https://user-images.githubusercontent.com/24521041/59025440-d5fce400-885c-11e9-8e43-783b662f4b8e.png)


Added ticker for TV metric:
![image](https://user-images.githubusercontent.com/24521041/59163407-8262f280-8b09-11e9-9952-27afab1b5b30.png)
