### PR TITLE
fix/empty-category-after-midnight

### DIFF
--- a/src/components/TotalMarketcapWidget/GetTotalMarketcap.js
+++ b/src/components/TotalMarketcapWidget/GetTotalMarketcap.js
@@ -7,6 +7,7 @@ import {
 } from './TotalMarketcapGQL'
 import TotalMarketcapWidget from './TotalMarketcapWidget'
 import { getTimeIntervalFromToday, MONTH } from '../../utils/dates'
+import { normalizeStats } from '../Watchlists/WatchlistCard'
 
 const getMarketcapQuery = (type, projects) => {
   const { from, to } = getTimeIntervalFromToday(-3, MONTH)
@@ -14,7 +15,7 @@ const getMarketcapQuery = (type, projects) => {
   const slugsQueryTotal = graphql(totalMarketcapGQL, {
     props: ({ data: { historyPrice = [] } }) => ({
       historyPrices: {
-        TOTAL_MARKET: historyPrice
+        TOTAL_MARKET: normalizeStats(historyPrice)
       }
     }),
     options: () => ({
@@ -34,7 +35,7 @@ const getMarketcapQuery = (type, projects) => {
     props: ({ data: { historyPrice = [] }, ownProps: { historyPrices } }) => ({
       historyPrices: {
         ...historyPrices,
-        TOTAL_LIST_MARKET: historyPrice
+        TOTAL_LIST_MARKET: normalizeStats(historyPrice)
       }
     }),
     options: () => ({
@@ -69,7 +70,7 @@ const getMarketcapQuery = (type, projects) => {
     }) => ({
       historyPrices: {
         ...historyPrices,
-        TOTAL_LIST_MARKET: projectsListHistoryStats
+        TOTAL_LIST_MARKET: normalizeStats(projectsListHistoryStats)
       }
     }),
     options: () => ({

--- a/src/components/Watchlists/WatchlistCard.js
+++ b/src/components/Watchlists/WatchlistCard.js
@@ -61,6 +61,14 @@ WatchlistCard.defaultProps = {
   stats: []
 }
 
+export const normalizeStats = arr => {
+  const { length } = arr
+  const isNotEmpty = length > 0
+  const lastEl = isNotEmpty ? arr[length - 1] : {}
+
+  return lastEl.marketcap === 0 && lastEl.volume === 0 ? arr.slice(0, -1) : arr
+}
+
 const enhance = compose(
   graphql(projectsListHistoryStatsGQL, {
     options: ({ slugs = [] }) => ({
@@ -71,7 +79,7 @@ const enhance = compose(
     }),
     skip: ({ slugs }) => !slugs.length,
     props: ({ data: { projectsListHistoryStats = [], loading, error } }) => ({
-      stats: projectsListHistoryStats,
+      stats: normalizeStats(projectsListHistoryStats),
       isLoading: loading,
       isError: error
     })
@@ -85,7 +93,7 @@ const enhance = compose(
     }),
     skip: ({ slug }) => !slug,
     props: ({ data: { historyPrice = [], loading, error } }) => ({
-      stats: historyPrice,
+      stats: normalizeStats(historyPrice),
       isLoading: loading,
       isError: error
     })


### PR DESCRIPTION
**Summary**
[favro card](https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/cffeb6e3eaf254588cb68a9a?card=San-4953)

Choosed that way, because backend can give zero after midnight for several minutes in last item even if we changed `to` to correct UTC hour