### PR TITLE
enhance/chart-metrics

### DIFF
--- a/src/ducks/GetTimeSeries/GetTimeSeries.spec.js
+++ b/src/ducks/GetTimeSeries/GetTimeSeries.spec.js
@@ -15,7 +15,7 @@ describe('GetTimeSeries', () => {
   beforeEach(() => {
     const initialState = {
       timeseries: {
-        price: {
+        historyPrice: {
           isLoading: false,
           isError: false,
           items: []
@@ -28,7 +28,7 @@ describe('GetTimeSeries', () => {
   const getWrapper = store =>
     mount(
       <GetTimeSeries
-        price={{
+        historyPrice={{
           timeRange: '6m',
           slug: 'santiment',
           interval: '1d'

--- a/src/ducks/GetTimeSeries/__snapshots__/GetTimeSeries.spec.js.snap
+++ b/src/ducks/GetTimeSeries/__snapshots__/GetTimeSeries.spec.js.snap
@@ -12,7 +12,7 @@ Array [
         "to": "2018-12-10",
         "transform": "movingAverage",
       },
-      "price": Object {
+      "historyPrice": Object {
         "interval": "1d",
         "slug": "santiment",
         "timeRange": "6m",

--- a/src/ducks/GetTimeSeries/__snapshots__/epics.spec.js.snap
+++ b/src/ducks/GetTimeSeries/__snapshots__/epics.spec.js.snap
@@ -17,7 +17,7 @@ Array [
         "isLoading": false,
       },
       "errorMetrics": Object {},
-      "price": Object {
+      "historyPrice": Object {
         "isEmpty": false,
         "isError": undefined,
         "isLoading": false,
@@ -27,9 +27,9 @@ Array [
           "formatter": [Function],
           "title": "devActivity",
         },
-        "price": Object {
+        "historyPrice": Object {
           "formatter": [Function],
-          "title": "price",
+          "title": "historyPrice",
         },
       },
       "timeseries": Array [
@@ -160,7 +160,7 @@ Array [
         ],
       },
       "errorMetrics": Object {},
-      "price": Object {
+      "historyPrice": Object {
         "isEmpty": false,
         "isError": undefined,
         "isLoading": false,
@@ -235,9 +235,9 @@ Array [
           "formatter": [Function],
           "title": "devActivity",
         },
-        "price": Object {
+        "historyPrice": Object {
           "formatter": [Function],
-          "title": "price",
+          "title": "historyPrice",
         },
       },
     },

--- a/src/ducks/GetTimeSeries/epics.spec.js
+++ b/src/ducks/GetTimeSeries/epics.spec.js
@@ -20,7 +20,7 @@ const createClient = link => {
 }
 
 const mockedData = {
-  price: [0, 1, 2, 3, 4, 5, 6, 7, 8].map(index => ({
+  historyPrice: [0, 1, 2, 3, 4, 5, 6, 7, 8].map(index => ({
     priceBtc: Math.round(100),
     priceUsd: Math.round(100),
     volume: Math.round(100),
@@ -39,7 +39,7 @@ const mockedDevActivity = {
 const link = mockSingleLink(
   {
     request: {
-      query: getMetricQUERY('price'),
+      query: getMetricQUERY('historyPrice'),
       variables: {
         slug: 'santiment',
         interval: '1d',
@@ -77,7 +77,7 @@ const link = mockSingleLink(
   },
   {
     request: {
-      query: getMetricQUERY('price'),
+      query: getMetricQUERY('historyPrice'),
       variables: {
         slug: 'santiment',
         interval: '1d',
@@ -109,7 +109,7 @@ describe('Fetch timeseries', () => {
     const action$ = ActionsObservable.of({
       type: actions.TIMESERIES_FETCH,
       payload: {
-        price: {
+        historyPrice: {
           from: '2018-12-01',
           to: '2018-12-10',
           slug: 'santiment',
@@ -128,7 +128,7 @@ describe('Fetch timeseries', () => {
     const action$ = ActionsObservable.of({
       type: actions.TIMESERIES_FETCH,
       payload: {
-        price: {
+        historyPrice: {
           from: '2018-12-01',
           to: '2018-12-10',
           slug: 'santiment',
@@ -156,7 +156,7 @@ describe('Fetch timeseries', () => {
     const action$ = ActionsObservable.of({
       type: actions.TIMESERIES_FETCH,
       payload: {
-        price: {
+        historyPrice: {
           from: '2018-12-01',
           to: '2018-12-10',
           slug: 'santiment',

--- a/src/ducks/GetTimeSeries/epics.spec.js
+++ b/src/ducks/GetTimeSeries/epics.spec.js
@@ -51,7 +51,7 @@ const link = mockSingleLink(
   },
   {
     request: {
-      query: getMetricQUERY('price'),
+      query: getMetricQUERY('historyPrice'),
       variables: {
         slug: 'santiment',
         interval: '1d',

--- a/src/ducks/GetTimeSeries/queries/history_price_query.js
+++ b/src/ducks/GetTimeSeries/queries/history_price_query.js
@@ -7,12 +7,7 @@ export const HISTORY_PRICE_QUERY = gql`
     $to: DateTime
     $interval: String
   ) {
-    price: historyPrice(
-      slug: $slug
-      from: $from
-      to: $to
-      interval: $interval
-    ) {
+    historyPrice(slug: $slug, from: $from, to: $to, interval: $interval) {
       priceBtc
       priceUsd
       volume

--- a/src/ducks/GetTimeSeries/timeseries.js
+++ b/src/ducks/GetTimeSeries/timeseries.js
@@ -17,7 +17,7 @@ import { mergeTimeseriesByKey } from './../../utils/utils'
 import { formatNumber } from './../../utils/formatting'
 
 const TIMESERIES = {
-  price: {
+  historyPrice: {
     query: HISTORY_PRICE_QUERY
   },
   volume: {
@@ -48,7 +48,7 @@ const TIMESERIES = {
   tokenCirculation: {
     query: TOKEN_CIRCULATION_QUERY
   },
-  mvrv: {
+  mvrvRatio: {
     query: MVRV_QUERY
   },
   dailyActiveDeposits: {

--- a/src/ducks/SANCharts/ChartMetrics.js
+++ b/src/ducks/SANCharts/ChartMetrics.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
 import Label from '@santiment-network/ui/Label'
+import { graphql } from 'react-apollo'
 import cx from 'classnames'
+import { PROJECT_METRICS_BY_SLUG_QUERY } from './gql'
 import { Metrics } from './utils'
 import styles from './ChartPage.module.scss'
 
@@ -32,12 +34,18 @@ class ChartMetrics extends Component {
 
   render () {
     const { metrics } = this.state
-    const { disabledMetrics = [] } = this.props
+    const {
+      disabledMetrics = [],
+      data: { project: { availableMetrics = [] } = {} }
+    } = this.props
     const listOfMetrics = this.props.listOfMetrics || Metrics
     return (
       <div className={styles.metrics}>
-        {Object.keys(listOfMetrics).map(metric => {
-          const { color, label } = listOfMetrics[metric]
+        {availableMetrics.map(metric => {
+          const { color, label = metric } = listOfMetrics[metric] || {}
+          if (!color) {
+            debugger
+          }
           return (
             <button
               key={label}
@@ -57,4 +65,6 @@ class ChartMetrics extends Component {
   }
 }
 
-export default ChartMetrics
+export default graphql(PROJECT_METRICS_BY_SLUG_QUERY, {
+  options: ({ slug }) => ({ variables: { slug } })
+})(ChartMetrics)

--- a/src/ducks/SANCharts/ChartMetrics.js
+++ b/src/ducks/SANCharts/ChartMetrics.js
@@ -43,9 +43,6 @@ class ChartMetrics extends Component {
       <div className={styles.metrics}>
         {availableMetrics.map(metric => {
           const { color, label = metric } = listOfMetrics[metric] || {}
-          if (!color) {
-            debugger
-          }
           return (
             <button
               key={label}

--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -27,7 +27,7 @@ class ChartPage extends Component {
   state = {
     timeRange: '6m',
     slug: 'santiment',
-    metrics: ['price'],
+    metrics: ['historyPrice'],
     title: 'Santiment (SAN)',
     interval: '1d',
     ...this.mapQSToState(this.props)
@@ -220,6 +220,7 @@ class ChartPage extends Component {
               />
               {!viewOnly && (
                 <LoadableChartMetrics
+                  slug={slug}
                   onMetricsChange={this.onMetricsChange}
                   defaultActiveMetrics={finalMetrics}
                   disabledMetrics={errors}

--- a/src/ducks/SANCharts/ChartPage.module.scss
+++ b/src/ducks/SANCharts/ChartPage.module.scss
@@ -28,7 +28,6 @@
 }
 
 .btn {
-  border: none;
   background: var(--white);
   outline: none;
   color: var(--waterloo);
@@ -37,11 +36,13 @@
   cursor: pointer;
   margin-right: 8px;
   padding: 6px 12px;
+  border: 1px solid transparent;
 }
 
 .active {
   color: var(--mirage);
   background: var(--athens);
+  border: 1px solid var(--porcelain);
 }
 
 .btn[disabled] {

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -114,7 +114,7 @@ class Charts extends React.Component {
             <Tooltip
               labelFormatter={labelFormatter}
               formatter={(value, name) => {
-                if (name === Metrics.price.label) {
+                if (name === Metrics.historyPrice.label) {
                   return formatNumber(value, { currency: 'USD' })
                 }
                 if (

--- a/src/ducks/SANCharts/gql.js
+++ b/src/ducks/SANCharts/gql.js
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag'
+
+export const PROJECT_METRICS_BY_SLUG_QUERY = gql`
+  query projectBySlug($slug: String!) {
+    project: projectBySlug(slug: $slug) {
+      availableMetrics
+    }
+  }
+`

--- a/src/ducks/SANCharts/utils.js
+++ b/src/ducks/SANCharts/utils.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { YAxis, Bar, Line } from 'recharts'
 
 export const Metrics = {
-  price: {
+  historyPrice: {
     node: Line,
     color: 'jungle-green',
     label: 'Price',
@@ -11,7 +11,6 @@ export const Metrics = {
   },
   volume: {
     node: Bar,
-    color: 'mirage',
     label: 'Volume',
     fill: true,
     dataKey: 'volume'
@@ -56,7 +55,7 @@ export const Metrics = {
     color: 'dodger-blue',
     label: 'Token Circulation'
   },
-  mvrv: {
+  mvrvRatio: {
     node: Line,
     color: 'waterloo',
     label: 'Market Value To Realized Value'
@@ -68,7 +67,6 @@ export const Metrics = {
   },
   networkGrowth: {
     node: Line,
-    color: 'mirage',
     label: 'Network Growth'
   },
   devActivity: {
@@ -87,7 +85,38 @@ export const Metrics = {
     color: 'jungle-green',
     label: 'Daily Active Deposits',
     dataKey: 'activeDeposits'
-  }
+  },
+  ohlc: {},
+  priceVolumeDiff: {},
+  githubActivity: {},
+  aveargeDevActivity: {},
+  averageGithubActivity: {},
+  historyTwitterData: {
+    label: 'Twitter'
+  },
+  twitterData: {}, // NOTE(vanguard): NOT A TIMESERIE
+  socialGainersLosersStatus: {},
+  socialDominance: {},
+  historicalBalance: {},
+  shareOfDeposits: {},
+  tokenTopTransactions: {},
+  realizedValue: {},
+  burnRate: {},
+  averageTokenAgeConsumedInDays: {},
+  nvtRatio: {},
+  ethSpent: {},
+  ethSpentOverTime: {
+    label: 'ETH spent over time'
+  },
+  ethTopTransactions: {},
+  ethBalance: {},
+  usdBalance: {},
+  icos: {},
+  icoPrice: {},
+  initialIco: {},
+  fundsRaisedUsdIcoEndPrice: {},
+  fundsRaisedEthIcoEndPrice: {},
+  fundsRaisedBtcIcoEndPrice: {}
 }
 
 export const getMetricCssVarColor = metric => `var(--${Metrics[metric].color})`

--- a/src/ducks/Signals/SignalPreview.js
+++ b/src/ducks/Signals/SignalPreview.js
@@ -34,7 +34,7 @@ const getTimerangeByType = type =>
 const SignalPreview = ({
   points = [],
   target,
-  initialMetrics = ['price'],
+  initialMetrics = ['historyPrice'],
   type
 }) => {
   const [metrics, setMetrics] = useState(initialMetrics)
@@ -51,22 +51,28 @@ const SignalPreview = ({
         {getTimerangeByType(type.value)}
       </Message>
       <GetTimeSeries
-        price={{
+        historyPrice={{
           timeRange: getTimerangeByType(type.value),
           slug: target,
           interval: '1d'
         }}
-        render={({ price, errorMetrics = {}, isError, errorType, ...rest }) => {
-          if (!price) {
+        render={({
+          historyPrice,
+          errorMetrics = {},
+          isError,
+          errorType,
+          ...rest
+        }) => {
+          if (!historyPrice) {
             return 'Loading...'
           }
           const data = normalizeTimeseries(points)
           const customMetrics = _metrics.map(metric =>
             CHART_SETTINGS[metric] ? CHART_SETTINGS[metric] : metric
           )
-          const _price = normalizeTimeseries(price.items)
+          const _price = normalizeTimeseries(historyPrice.items)
           return (
-            price && (
+            historyPrice && (
               <VisualBacktestChart
                 data={data}
                 price={_price}

--- a/src/pages/Detailed/MobileDetailedPage.js
+++ b/src/pages/Detailed/MobileDetailedPage.js
@@ -142,20 +142,20 @@ const MobileDetailedPage = props => {
                 />
                 {timeRangeBlock}
                 <GetTimeSeries
-                  price={{
+                  historyPrice={{
                     slug,
                     timeRange,
                     interval:
                       timeRange === '1w' || timeRange === '1m' ? '1h' : '1d'
                   }}
-                  render={({ price = {} }) => {
-                    if (price.isLoading) {
+                  render={({ historyPrice = {} }) => {
+                    if (historyPrice.isLoading) {
                       return 'Loading...'
                     }
                     return (
                       <>
                         <MobileAssetChart
-                          data={price.items}
+                          data={historyPrice.items}
                           slug={slug}
                           icoPrice={icoPrice}
                         />

--- a/src/pages/Trends/TrendsExplorePage.js
+++ b/src/pages/Trends/TrendsExplorePage.js
@@ -140,17 +140,17 @@ export class TrendsExplorePage extends Component {
             interval={getCustomInterval(timeRange)}
             render={trends => (
               <GetTimeSeries
-                price={{
+                historyPrice={{
                   timeRange,
                   slug: asset.toLowerCase(),
                   interval: getCustomInterval(timeRange)
                 }}
-                render={({ price = {} }) => (
+                render={({ historyPrice = {} }) => (
                   <Fragment>
                     <div style={{ minHeight: 300 }}>
                       <TrendsReChart
                         asset={asset && capitalizeStr(asset)}
-                        data={price}
+                        data={historyPrice}
                         trends={trends}
                         hasPremium={hasPremium}
                       />


### PR DESCRIPTION
 ### Summary
**Old behaviour**: Displaying all possible metrics and disabling it on the bad query response.
**New behaviour**: Getting available metrics by fetching `Project.availableMetrics` array.

### Breaking change
`GetTimeSeries` `price` metric key changed to the `historyPrice` to comply with a backend naming scheme.