### PR TITLE
feature/mobile-chart-anomaly

### DIFF
--- a/src/components/MobileMetricCard/MobileMetricCard.js
+++ b/src/components/MobileMetricCard/MobileMetricCard.js
@@ -17,7 +17,13 @@ const METRIC_ANOMALIE_QUERY = gql`
     $slug: String!
     $to: DateTime!
   ) {
-    metricAnomaly(from: $from, to: $to, slug: $slug, metric: $metric) {
+    metricAnomaly(
+      from: $from
+      to: $to
+      slug: $slug
+      metric: $metric
+      interval: "8h"
+    ) {
       datetime
       metricValue
     }

--- a/src/components/MobileMetricCard/MobileMetricCard.js
+++ b/src/components/MobileMetricCard/MobileMetricCard.js
@@ -48,7 +48,7 @@ const MobileMetricCard = ({
         <h4 className={styles.anomalies}>
           {anomalies && anomalies.length ? `${anomalies.length} anomalies` : ''}
         </h4>
-        <div className={styles.right}>
+        <div>
           <PercentChanges changes={changes} />
           <Label accent='casper'>, {period}</Label>
         </div>

--- a/src/components/MobileMetricCard/MobileMetricCard.js
+++ b/src/components/MobileMetricCard/MobileMetricCard.js
@@ -1,34 +1,14 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { graphql } from 'react-apollo'
-import gql from 'graphql-tag'
 import cx from 'classnames'
-import { Label } from '@santiment-network/ui'
+import Label from '@santiment-network/ui/Label'
 import { formatNumber } from '../../utils/formatting'
 import PercentChanges from '../PercentChanges'
 import { getTimeIntervalFromToday, DAY } from '../../utils/dates'
+import { METRIC_ANOMALIE_QUERY } from '../../pages/Detailed/DetailedGQL'
 import styles from './MobileMetricCard.module.scss'
 
 const { from: FROM, to: TO } = getTimeIntervalFromToday(-7, DAY)
-
-const METRIC_ANOMALIE_QUERY = gql`
-  query metricAnomaly(
-    $from: DateTime!
-    $metric: AnomaliesMetricsEnum!
-    $slug: String!
-    $to: DateTime!
-  ) {
-    metricAnomaly(
-      from: $from
-      to: $to
-      slug: $slug
-      metric: $metric
-      interval: "8h"
-    ) {
-      datetime
-      metricValue
-    }
-  }
-`
 
 const ANOMALIES_METRICS_ENUM = {
   dailyActiveAddresses: 'DAILY_ACTIVE_ADDRESSES',
@@ -43,20 +23,20 @@ const MobileMetricCard = ({
   changes,
   measure = '',
   data: { metricAnomaly: anomalies } = {},
-  onClick = () => {}
+  onClick,
+  activeMetric
 }) => {
-  const [active, setActive] = useState(false)
-
   const onButtonClick = () => {
-    const newState = !active
-    setActive(newState)
-    onClick(newState && { metric, anomalies })
+    onClick({ metric, anomalies })
   }
 
   return (
     <button
-      className={cx(styles.wrapper, active && styles.active)}
-      onClick={onButtonClick}
+      className={cx(
+        styles.wrapper,
+        activeMetric && activeMetric.metric === metric && styles.active
+      )}
+      onClick={onClick ? onButtonClick : undefined}
     >
       <div className={cx(styles.row, styles.row_top)}>
         <h3 className={styles.metric}>{name}</h3>

--- a/src/components/MobileMetricCard/MobileMetricCard.js
+++ b/src/components/MobileMetricCard/MobileMetricCard.js
@@ -17,18 +17,17 @@ const METRIC_ANOMALIE_QUERY = gql`
     $slug: String!
     $to: DateTime!
   ) {
-    metricAnomaly(
-      from: $from
-      to: $to
-      slug: $slug
-      metric: $metric
-      interval: "8h"
-    ) {
+    metricAnomaly(from: $from, to: $to, slug: $slug, metric: $metric) {
       datetime
       metricValue
     }
   }
 `
+
+const ANOMALIES_METRICS_ENUM = {
+  dailyActiveAddresses: 'DAILY_ACTIVE_ADDRESSES',
+  devActivity: 'DEV_ACTIVITY'
+}
 
 const MobileMetricCard = ({
   metric,
@@ -37,7 +36,7 @@ const MobileMetricCard = ({
   period,
   changes,
   measure = '',
-  anomalies = '',
+  data: { metricAnomaly: anomalies } = {},
   onClick = () => {}
 }) => {
   const [active, setActive] = useState(false)
@@ -61,8 +60,7 @@ const MobileMetricCard = ({
       </div>
       <div className={styles.row}>
         <h4 className={styles.anomalies}>
-          {/* {anomalies && `${anomalies} anomalies`} */}
-          25 anomalies
+          {anomalies && anomalies.length ? `${anomalies.length} anomalies` : ''}
         </h4>
         <div className={styles.right}>
           <PercentChanges changes={changes} />
@@ -78,7 +76,7 @@ export default graphql(METRIC_ANOMALIE_QUERY, {
   options: ({ metric, slug }) => {
     return {
       variables: {
-        metric,
+        metric: ANOMALIES_METRICS_ENUM[metric],
         slug,
         from: FROM.toISOString(),
         to: TO.toISOString()

--- a/src/components/MobileMetricCard/MobileMetricCard.js
+++ b/src/components/MobileMetricCard/MobileMetricCard.js
@@ -1,23 +1,37 @@
 import React from 'react'
+import cx from 'classnames'
 import { Label } from '@santiment-network/ui'
 import { formatNumber } from '../../utils/formatting'
 import PercentChanges from '../PercentChanges'
 import styles from './MobileMetricCard.module.scss'
 
-const MobileMetricCard = ({ name, value, label, changes, measure = '' }) => {
+const MobileMetricCard = ({
+  name,
+  value,
+  label,
+  changes,
+  measure = '',
+  anomalies = ''
+}) => {
   return (
-    <article className={styles.metric}>
-      <div>
-        <div>{name}</div>
-        <Label accent='waterloo'>({label})</Label>
-      </div>
-      <div className={styles.right}>
-        <span>
+    <button className={styles.wrapper}>
+      <div className={cx(styles.row, styles.row_top)}>
+        <h3 className={styles.metric}>{name}</h3>
+        <h4 className={styles.value}>
           {formatNumber(value)} {measure}
-        </span>
-        <PercentChanges changes={changes} />
+        </h4>
       </div>
-    </article>
+      <div className={styles.row}>
+        <h4 className={styles.anomalies}>
+          {/* {anomalies && `${anomalies} anomalies`} */}
+          25 anomalies
+        </h4>
+        <div className={styles.right}>
+          <PercentChanges changes={changes} />
+          <Label accent='casper'>, {label}</Label>
+        </div>
+      </div>
+    </button>
   )
 }
 

--- a/src/components/MobileMetricCard/MobileMetricCard.js
+++ b/src/components/MobileMetricCard/MobileMetricCard.js
@@ -22,19 +22,19 @@ const MobileMetricCard = ({
   period,
   changes,
   measure = '',
-  data: { metricAnomaly: anomalies } = {},
+  data: { metricAnomaly: anomalies = [] } = {},
   onClick,
   activeMetric
 }) => {
   const onButtonClick = () => {
-    onClick({ metric, anomalies })
+    onClick({ name: metric, anomalies })
   }
 
   return (
     <button
       className={cx(
         styles.wrapper,
-        activeMetric && activeMetric.metric === metric && styles.active
+        activeMetric && activeMetric.name === metric && styles.active
       )}
       onClick={onClick ? onButtonClick : undefined}
     >

--- a/src/components/MobileMetricCard/MobileMetricCard.module.scss
+++ b/src/components/MobileMetricCard/MobileMetricCard.module.scss
@@ -1,19 +1,35 @@
-@import '~@santiment-network/ui/mixins';
-@import '~@santiment-network/ui/variables';
+@import "~@santiment-network/ui/mixins";
 
-.metric {
-  @include text-normal;
+.wrapper {
+  border: none;
+  background: transparent;
+  outline: none;
+  width: 100%;
+  border-top: 1px solid var(--porcelain);
+  padding: 14px 16px 11px;
 
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 14px 0;
-  border-bottom: 1px solid var(--porcelain);
-  line-height: 20px;
+  &:last-child {
+    border-bottom: 1px solid var(--porcelain);
+  }
 }
 
-.right {
+.row {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  justify-content: space-between;
+
+  &_top {
+    margin: 0 0 2px;
+  }
+}
+
+.metric,
+.value,
+.anomalies {
+  margin: 0;
+
+  @include text("body-3");
+}
+
+.anomalies {
+  color: var(--persimmon);
 }

--- a/src/components/MobileMetricCard/MobileMetricCard.module.scss
+++ b/src/components/MobileMetricCard/MobileMetricCard.module.scss
@@ -13,6 +13,10 @@
   }
 }
 
+.active {
+  background: var(--athens);
+}
+
 .row {
   display: flex;
   justify-content: space-between;

--- a/src/pages/Detailed/DetailedGQL.js
+++ b/src/pages/Detailed/DetailedGQL.js
@@ -281,3 +281,22 @@ export const AllInsightsByTagGQL = gql`
     }
   }
 `
+
+export const METRIC_ANOMALIE_QUERY = gql`
+  query metricAnomaly(
+    $from: DateTime!
+    $metric: AnomaliesMetricsEnum!
+    $slug: String!
+    $to: DateTime!
+  ) {
+    metricAnomaly(
+      from: $from
+      to: $to
+      slug: $slug
+      metric: $metric
+      interval: "8h"
+    ) {
+      datetime
+    }
+  }
+`

--- a/src/pages/Detailed/DetailedGQL.js
+++ b/src/pages/Detailed/DetailedGQL.js
@@ -289,13 +289,7 @@ export const METRIC_ANOMALIE_QUERY = gql`
     $slug: String!
     $to: DateTime!
   ) {
-    metricAnomaly(
-      from: $from
-      to: $to
-      slug: $slug
-      metric: $metric
-      interval: "8h"
-    ) {
+    metricAnomaly(from: $from, to: $to, slug: $slug, metric: $metric) {
       datetime
     }
   }

--- a/src/pages/Detailed/MobileAssetChart.js
+++ b/src/pages/Detailed/MobileAssetChart.js
@@ -7,10 +7,13 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ReferenceLine
+  ReferenceLine,
+  Scatter,
+  Dot
 } from 'recharts'
 import { formatNumber } from './../../utils/formatting'
 import { getDateFormats } from '../../utils/dates'
+import { generateMetricsMarkup } from '../../ducks/SANCharts/utils.js'
 import styles from './MobileAssetChart.module.scss'
 
 //
@@ -25,7 +28,8 @@ const tickFormatter = date => {
   return `${DD} ${MMM} ${YY}`
 }
 
-const MobileAssetChart = ({ data, slug: asset, icoPrice }) => {
+const MobileAssetChart = ({ data, slug: asset, icoPrice, metrics }) => {
+  console.log(data, metrics)
   return (
     <div>
       <ResponsiveContainer width='100%' height={300}>
@@ -63,8 +67,17 @@ const MobileAssetChart = ({ data, slug: asset, icoPrice }) => {
             dot={false}
             strokeWidth={1.5}
             dataKey='priceUsd'
-            stroke={'var(--jungle-green)'}
+            stroke='var(--jungle-green)'
           />
+          {metrics && generateMetricsMarkup(metrics)}
+          {metrics && [
+            <YAxis yAxisId='axis-anomaly' domain={['dataMin', 'auto']} hide />,
+            <Scatter
+              dataKey='metricValue'
+              yAxisId='axis-anomaly'
+              fill='#ff0000'
+            />
+          ]}
           {icoPrice && (
             <ReferenceLine
               yAxisId='axis-price'

--- a/src/pages/Detailed/MobileAssetChart.js
+++ b/src/pages/Detailed/MobileAssetChart.js
@@ -64,13 +64,13 @@ const MobileAssetChart = ({ data, slug: asset, icoPrice, extraMetric }) => {
             dataKey='priceUsd'
             stroke='var(--jungle-green)'
           />
-          {extraMetric && generateMetricsMarkup([extraMetric.metric])}
+          {extraMetric && generateMetricsMarkup([extraMetric.name])}
           {extraMetric &&
             extraMetric.anomalies.map(({ datetime }) => (
               <ReferenceLine
                 key={datetime}
-                yAxisId={`axis-${Metrics[extraMetric.metric].dataKey ||
-                  extraMetric.metric}`}
+                yAxisId={`axis-${Metrics[extraMetric.name].dataKey ||
+                  extraMetric.name}`}
                 x={datetime}
                 stroke='red'
               />

--- a/src/pages/Detailed/MobileAssetChart.js
+++ b/src/pages/Detailed/MobileAssetChart.js
@@ -7,16 +7,12 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ReferenceLine,
-  Scatter,
-  Dot
+  ReferenceLine
 } from 'recharts'
 import { formatNumber } from './../../utils/formatting'
 import { getDateFormats } from '../../utils/dates'
-import { generateMetricsMarkup } from '../../ducks/SANCharts/utils.js'
+import { generateMetricsMarkup, Metrics } from '../../ducks/SANCharts/utils.js'
 import styles from './MobileAssetChart.module.scss'
-
-//
 
 const labelFormatter = date => {
   const { dddd, MMM, DD, YYYY } = getDateFormats(new Date(date))
@@ -28,8 +24,8 @@ const tickFormatter = date => {
   return `${DD} ${MMM} ${YY}`
 }
 
-const MobileAssetChart = ({ data, slug: asset, icoPrice, metrics }) => {
-  console.log(data, metrics)
+const MobileAssetChart = ({ data, slug: asset, icoPrice, extraMetric }) => {
+  console.log(extraMetric && Metrics[extraMetric.metric])
   return (
     <div>
       <ResponsiveContainer width='100%' height={300}>
@@ -69,15 +65,17 @@ const MobileAssetChart = ({ data, slug: asset, icoPrice, metrics }) => {
             dataKey='priceUsd'
             stroke='var(--jungle-green)'
           />
-          {metrics && generateMetricsMarkup(metrics)}
-          {metrics && [
-            <YAxis yAxisId='axis-anomaly' domain={['dataMin', 'auto']} hide />,
-            <Scatter
-              dataKey='metricValue'
-              yAxisId='axis-anomaly'
-              fill='#ff0000'
-            />
-          ]}
+          {extraMetric && generateMetricsMarkup([extraMetric.metric])}
+          {extraMetric &&
+            extraMetric.anomalies.map(({ datetime }) => (
+              <ReferenceLine
+                key={datetime}
+                yAxisId={`axis-${Metrics[extraMetric.metric].dataKey ||
+                  extraMetric.metric}`}
+                x={datetime}
+                stroke='red'
+              />
+            ))}
           {icoPrice && (
             <ReferenceLine
               yAxisId='axis-price'

--- a/src/pages/Detailed/MobileAssetChart.js
+++ b/src/pages/Detailed/MobileAssetChart.js
@@ -25,7 +25,6 @@ const tickFormatter = date => {
 }
 
 const MobileAssetChart = ({ data, slug: asset, icoPrice, extraMetric }) => {
-  console.log(extraMetric && Metrics[extraMetric.metric])
   return (
     <div>
       <ResponsiveContainer width='100%' height={300}>

--- a/src/pages/Detailed/MobileAssetChart.js
+++ b/src/pages/Detailed/MobileAssetChart.js
@@ -13,6 +13,8 @@ import { formatNumber } from './../../utils/formatting'
 import { getDateFormats } from '../../utils/dates'
 import styles from './MobileAssetChart.module.scss'
 
+//
+
 const labelFormatter = date => {
   const { dddd, MMM, DD, YYYY } = getDateFormats(new Date(date))
   return `${dddd}, ${MMM} ${DD} ${YYYY}`

--- a/src/pages/Detailed/MobileDetailedPage.js
+++ b/src/pages/Detailed/MobileDetailedPage.js
@@ -52,7 +52,7 @@ const MobileDetailedPage = props => {
     transactionVolumeInfo = {
       name: 'Transaction Volume',
       value: todayTransactionVolume,
-      label: '24h',
+      period: '24h',
       changes: TVDiff
     }
   }
@@ -69,9 +69,10 @@ const MobileDetailedPage = props => {
       todayActiveAddresses
     )
     activeAddressesInfo = {
+      metric: 'DAILY_ACTIVE_ADDRESSES',
       name: 'Daily Active Addresses',
       value: todayActiveAddresses,
-      label: '24h',
+      period: '24h',
       changes: DAADiff
     }
   }
@@ -111,9 +112,10 @@ const MobileDetailedPage = props => {
               devActivity30
             )
             devActivityInfo = {
+              metric: 'DEV_ACTIVITY',
               name: 'Development Activity',
               value: devActivity30,
-              label: '30d',
+              period: '30d',
               changes: DADiff
             }
           }
@@ -161,10 +163,18 @@ const MobileDetailedPage = props => {
                         />
                         <div className={styles.metrics}>
                           {activeAddressesInfo && (
-                            <MobileMetricCard {...activeAddressesInfo} />
+                            <MobileMetricCard
+                              {...activeAddressesInfo}
+                              slug={slug}
+                              onClick={console.log}
+                            />
                           )}
                           {devActivityInfo && (
-                            <MobileMetricCard {...devActivityInfo} />
+                            <MobileMetricCard
+                              {...devActivityInfo}
+                              slug={slug}
+                              onClick={console.log}
+                            />
                           )}
                           {transactionVolumeInfo && (
                             <MobileMetricCard

--- a/src/pages/Detailed/MobileDetailedPage.js
+++ b/src/pages/Detailed/MobileDetailedPage.js
@@ -29,7 +29,7 @@ const MobileDetailedPage = props => {
   const [extraMetric, setExtraMetric] = useState()
 
   const toggleExtraMetric = toggledMetric => {
-    if (extraMetric && toggledMetric.metric === extraMetric.metric) {
+    if (extraMetric && toggledMetric.name === extraMetric.name) {
       setExtraMetric(undefined)
     } else {
       setExtraMetric(toggledMetric)
@@ -95,7 +95,7 @@ const MobileDetailedPage = props => {
 
   const extraTimeserie = extraMetric
     ? {
-      [extraMetric.metric]: timeseriesOptions
+      [extraMetric.name]: timeseriesOptions
     }
     : {}
 
@@ -178,10 +178,10 @@ const MobileDetailedPage = props => {
                     const timeseries = [historyPrice.items]
                     if (
                       extraMetric &&
-                      otherTimeseries[extraMetric.metric] &&
-                      otherTimeseries[extraMetric.metric].items
+                      otherTimeseries[extraMetric.name] &&
+                      otherTimeseries[extraMetric.name].items
                     ) {
-                      timeseries.push(otherTimeseries[extraMetric.metric].items)
+                      timeseries.push(otherTimeseries[extraMetric.name].items)
                     }
                     return (
                       <>

--- a/src/pages/Detailed/MobileDetailedPage.js
+++ b/src/pages/Detailed/MobileDetailedPage.js
@@ -28,6 +28,14 @@ const MobileDetailedPage = props => {
   const [timeRange, setTimeRange] = useState('6m')
   const [extraMetric, setExtraMetric] = useState()
 
+  const toggleExtraMetric = toggledMetric => {
+    if (extraMetric && toggledMetric.metric === extraMetric.metric) {
+      setExtraMetric(undefined)
+    } else {
+      setExtraMetric(toggledMetric)
+    }
+  }
+
   const timeRangeBlock = (
     <div className={styles.timeRangeBlock}>
       <Selector
@@ -190,14 +198,16 @@ const MobileDetailedPage = props => {
                             <MobileMetricCard
                               {...activeAddressesInfo}
                               slug={slug}
-                              onClick={setExtraMetric}
+                              activeMetric={extraMetric}
+                              onClick={toggleExtraMetric}
                             />
                           )}
                           {devActivityInfo && (
                             <MobileMetricCard
                               {...devActivityInfo}
                               slug={slug}
-                              onClick={setExtraMetric}
+                              activeMetric={extraMetric}
+                              onClick={toggleExtraMetric}
                             />
                           )}
                           {transactionVolumeInfo && (

--- a/src/pages/Detailed/MobileDetailedPage.js
+++ b/src/pages/Detailed/MobileDetailedPage.js
@@ -159,18 +159,20 @@ const MobileDetailedPage = props => {
                           slug={slug}
                           icoPrice={icoPrice}
                         />
-                        {activeAddressesInfo && (
-                          <MobileMetricCard {...activeAddressesInfo} />
-                        )}
-                        {devActivityInfo && (
-                          <MobileMetricCard {...devActivityInfo} />
-                        )}
-                        {transactionVolumeInfo && (
-                          <MobileMetricCard
-                            {...transactionVolumeInfo}
-                            measure={ticker}
-                          />
-                        )}
+                        <div className={styles.metrics}>
+                          {activeAddressesInfo && (
+                            <MobileMetricCard {...activeAddressesInfo} />
+                          )}
+                          {devActivityInfo && (
+                            <MobileMetricCard {...devActivityInfo} />
+                          )}
+                          {transactionVolumeInfo && (
+                            <MobileMetricCard
+                              {...transactionVolumeInfo}
+                              measure={ticker}
+                            />
+                          )}
+                        </div>
                         <ShowIf beta>
                           {props.news && props.news.length > 0 && (
                             <>

--- a/src/pages/Detailed/MobileDetailedPage.js
+++ b/src/pages/Detailed/MobileDetailedPage.js
@@ -168,18 +168,12 @@ const MobileDetailedPage = props => {
                     }
 
                     const timeseries = [historyPrice.items]
-                    let chartMetrics
                     if (
                       extraMetric &&
                       otherTimeseries[extraMetric.metric] &&
                       otherTimeseries[extraMetric.metric].items
                     ) {
-                      console.log(extraMetric.anomalies)
-                      timeseries.push(
-                        otherTimeseries[extraMetric.metric].items,
-                        extraMetric.anomalies
-                      )
-                      chartMetrics = [extraMetric.metric]
+                      timeseries.push(otherTimeseries[extraMetric.metric].items)
                     }
                     return (
                       <>
@@ -189,7 +183,7 @@ const MobileDetailedPage = props => {
                           })}
                           slug={slug}
                           icoPrice={icoPrice}
-                          metrics={chartMetrics}
+                          extraMetric={extraMetric}
                         />
                         <div className={styles.metrics}>
                           {activeAddressesInfo && (

--- a/src/pages/Detailed/MobileDetailedPage.module.scss
+++ b/src/pages/Detailed/MobileDetailedPage.module.scss
@@ -8,6 +8,10 @@
   margin-bottom: 50px;
 }
 
+.metrics {
+  margin: 0 -16px;
+}
+
 .ticker {
   color: var(--waterloo);
 }


### PR DESCRIPTION
### Summary
Currently supported metrics (`DAILY_ACTIVE_ADDRESSES`, `DEV_ACTIVITY`) for anomalies could be toggled (behaves as a radio button) and displayed on the chart. Anomalies are fetched for a 1 week period.

### Changes
- Default `timeRange` was changed to `6m` from `all`. The reason is a better **loading time** and **time to interactive** (`all` has ~`700` data points, meanwhile `6m` ~`180`)

### Screenshots
![image](https://user-images.githubusercontent.com/25135650/59697605-d1d6ac00-91f6-11e9-97aa-14b6423d0398.png)
