### PR TITLE
fix/headings-and-images

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
-    "medium-draft": "^0.5.10",
+    "medium-draft": "^0.5.15",
     "moment": "^2.19.3",
     "ms": "^2.1.1",
     "nprogress": "^0.2.0",

--- a/src/components/Editor/Editor.scss
+++ b/src/components/Editor/Editor.scss
@@ -307,7 +307,6 @@
     margin: 20px auto;
 
     .md-block-image-inner-container {
-      max-height: 500px;
       box-sizing: border-box;
       border: none;
       background: transparent;

--- a/src/components/Editor/Editor.scss
+++ b/src/components/Editor/Editor.scss
@@ -1,298 +1,343 @@
-@import "../../mixins.scss";
-@import "~@santiment-network/ui/mixins.scss";
-@import "~@santiment-network/ui/variables.scss";
+@import "~@santiment-network/ui/mixins";
+@import "~@santiment-network/ui/variables";
 
-:global{
-    .md-RichEditor-root {
-        @include text-normal;
-        font-size: 18px;
-        line-height: 28px;
-        background: var(--white);
-        color: var(--black);
-        position: relative;
-        
-        & span::selection {
-            background: var(--green-light-2);
-        }
+:global {
+  .md-RichEditor-root {
+    background: var(--white);
+    color: var(--mirage);
+    position: relative;
 
-        @include responsive('phone-xs') {
-            font-size: 14px;
-            line-height: 20px;
-        }
+    & span::selection {
+      background: var(--green-light-2);
     }
 
-    .public-DraftEditorPlaceholder-inner {
-        color: var(--grey-dark);
+    @include text('body-1', 't');
+
+    @include responsive('phone-xs') {
+      font-size: 14px;
+      line-height: 20px;
     }
 
-    .public-DraftEditorPlaceholder-root{
-        position: absolute;
-        z-index: 1;
-        pointer-events: none;
-    }
-
-    .public-DraftEditor-content {
-
-        h1 {
-            color: var(--black);
-            font-weight: 800 !important;
-            line-height: 42px !important;
-            font-size: 30px !important;
-        }
-
-        h2 {
-            color: var(--black);
-            font-weight: 800;
-            line-height: 34px;
-            font-size: 24px;
-        }
-    }
-
-    .md-editor-toolbar {
-        height: 32px;
-        position: absolute;
-        background: $dark-4;
-        display: flex;
-        color: $light-gray3;
-        fill: $light-gray3;
-        cursor: auto;
-        z-index: 2;
-        border-radius: $border-radius;
-        transition: all .1s ease;
-        visibility: hidden;
-        box-shadow: 0px 2px 2px rgba(21, 24, 31, 0.04), 0px 2px 6px rgba(0, 0, 0, 0.08), 0px 4px 12px rgba(0, 0, 0, 0.08);
-        padding: 6px 0;
-
-        &.md-editor-toolbar--isopen {
-            visibility: visible;
-        }
-
-        a {
-            color: var(--green);
-            text-decoration: none;
-            padding: 3px 8px;
-        }
-    }
-
-    .md-RichEditor-controls {
-        height: 20px;
-        display: flex;
-        align-items: center;
-        border-right: 1px solid #7b829d;
-
-        &:last-of-type {
-            border-right: none;
-        }
-    }
-
-    .md-RichEditor-styleButton {
-        display: inline-flex;
-        width: 32px;
-        height: 20px;
-        justify-content: center;
-        align-items: center;
-        cursor: pointer;
-    }
-
-    .md-RichEditor-activeButton {
-        fill: var(--green);
-    }
-
-    [class*=hint--]{
-        position: relative;
-
-        &[aria-label]:after {
-            background: #4c516c;
-            white-space: nowrap;
-            font-size: 12px;
-            padding: 4px 10px;
-            content: attr(aria-label);
-            margin-top: -8px;
-        }
-
-        &:before {
-            content: "";
-            position: absolute;
-            border: 6px solid transparent;
-            z-index: 1000001;
-            margin-top: 15px;
-        }
-
-        &:after,
-        &:before {
-            position: absolute;
-            visibility: hidden;
-            opacity: 0;
-            left: 50%;
-            transform: translate3d(-50%, -32px, 0);
-            z-index: 1000000;
-            pointer-events: none;
-            transition: .3s ease;
-        }
-
-        &:hover:after,
-        &:hover:before {
-            visibility: visible;
-            opacity: 1;
-        }
-    }
-
-
-    .hint--top-left:before, .hint--top-right:before, .hint--top:before {
-        border-top-color: #4c516c;
-    }
-
-    .md-RichEditor-blockquote {
+    & .public-DraftEditor-content {
+      h1 {
+        color: var(--mirage);
         margin: 0;
-        padding: 23px 32px;
-        background-color: #e2f2ff;
-        background: var(--grey-light);
-        border-radius: $border-radius;
-        font-size: 24px;
-        line-height: 34px;
-        color: var(--black);
-        position: relative;
 
-        &::before {
-            content: '“';
-            position: absolute;
-            display: block;
-            left: 28px;
-            top: 1px;
-            font-size: 74px;
-            font-family: sans-serif;
-            font-weight: bold;
-            color: var(--grey-dark);
-        }
+        @include text('h3', 'm');
+      }
 
-        & + .md-block-quote::before {
-            display: none;
-        }
-        
+      h2 {
+        color: var(--mirage);
+        margin: 0;
+
+        @include text('h4', 'm');
+      }
     }
 
-    .md-RichEditor-show-link-input {
-        width: 100%;
-        padding: 4px 10px;
-    }
-
-    .md-url-input-close {
+    .md-block-image-caption--empty {
+      &::before {
+        content: 'Add image caption...';
+        color: var(--casper);
         position: absolute;
-        right: 8px;
-        top: 2.5px;
-        font-size: 20px;
-        cursor: pointer;
-    }
-
-    .md-url-input {
-        box-sizing: border-box;
-        display: block;
-        width: 100%;
-        height: 100%;
-        padding-right: 11px;
-        border: none;
-        outline: none;
-        background: $dark-4;
-        color: $white;
-    }
-
-    .md-editor-toolbar-unlink-button,
-    .md-editor-toolbar-edit-button {
-        background: transparent;
-        border: none;
-        color: $light-gray3;
-        cursor: pointer;
-    }
-
-    .md-side-toolbar {
-        position: absolute;
-        left: -36px;
-        @include responsive('phone-xs') {
-            left: -8px;
-            margin-top: 25px;
-        }
-    }
-
-    .md-open-button + div {
-        z-index: 9;
-        position: absolute;
-        top: 0;
         left: 0;
-        animation-fill-mode: forwards;
-        animation-name: fade;
-        animation-duration: 200ms;
-        margin-top: 7px;
-    }
-
-    @keyframes :global(fade) {
-        from {
-            opacity: 0;
-            left: 0;
-        }
-        to {
-            opacity: 1;
-            left: 36px;
-        }
-    }
-
-    .md-add-button {
-        cursor: pointer;
-        outline: none;
-        background: transparent;
-        border-radius: 50%;
-        border: 2px solid var(--black);
-        width: 16px;
-        height: 18px;
-        position: relative;
-        margin-top: 7px;
-
-        svg {
-            display: none;
-        }
-
-        &.md-open-button::before {
-            transform: translate3d(-44%, -50%, 0) rotate(45deg);
-        }
-
-        &::before {
-            color: var(--black);
-            content: '+';
-            display: inline-block;
-            position: absolute;
-            font-size: 17px;
-            line-height: 0;
-            transition: transform 200ms;
-            font-family: Rubik, sans-serif;
-            left: 52%;
-            top: 45%;
-            transform: translate3d(-50%, -50%, 0);
-        }
-    }
-
-
-    .md-block-image {
-        max-width: 70%;
-        margin: 1em auto;
+        cursor: text;
+        width: 720px;
         text-align: center;
-        background: var(--grey-light-2);
-        font-size: 13px;
-        border: 1px solid var(--grey-light-3);
+      }
+    }
+  }
 
-        img {
-            cursor: pointer;
-            max-width: 100%;
-        }
+  .md-RichEditor-readonly {
+    .md-block-image-caption--empty {
+      display: none;
+    }
+  }
+
+  .public-DraftEditorPlaceholder-inner {
+    color: var(--casper);
+
+    @include text('body-1', 't');
+  }
+
+  .public-DraftEditorPlaceholder-root {
+    position: absolute;
+    z-index: 1;
+    pointer-events: none;
+  }
+
+  .md-editor-toolbar {
+    height: 32px;
+    position: absolute;
+    background: $fiord;
+    display: flex;
+    color: $mystic;
+    fill: $mystic;
+    cursor: auto;
+    z-index: 2;
+    border-radius: $border-radius;
+    transition: all 0.1s ease;
+    visibility: hidden;
+    box-shadow: 0 2px 2px rgba(21, 24, 31, 0.04), 0 2px 6px rgba(0, 0, 0, 0.08), 0 4px 12px rgba(0, 0, 0, 0.08);
+    padding: 6px 0;
+
+    &.md-editor-toolbar--isopen {
+      visibility: visible;
     }
 
-    #nprogress {
-        .bar {
-            height: 3px;
-            background: var(--green);
-        }
-
-        .peg {
-            box-shadow: 0 0 10px var(--green-light-2), 0 0 5px var(--green-light-2);
-        }
-
+    a {
+      color: var(--green);
+      text-decoration: none;
+      padding: 3px 8px;
     }
+  }
+
+  .md-RichEditor-controls {
+    height: 20px;
+    display: flex;
+    align-items: center;
+    border-right: 1px solid #7b829d;
+
+    &:last-of-type {
+      border-right: none;
+    }
+  }
+
+  .md-RichEditor-styleButton {
+    display: inline-flex;
+    width: 32px;
+    height: 20px;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+  }
+
+  .md-RichEditor-activeButton {
+    fill: var(--green);
+  }
+
+  [class*=hint--] {
+    position: relative;
+
+    &[aria-label]::after {
+      background: #4c516c;
+      white-space: nowrap;
+      font-size: 12px;
+      padding: 4px 10px;
+      content: attr(aria-label);
+      margin-top: -8px;
+    }
+
+    &::before {
+      content: "";
+      position: absolute;
+      border: 6px solid transparent;
+      z-index: 1000001;
+      margin-top: 15px;
+    }
+
+    &::after,
+    &::before {
+      position: absolute;
+      visibility: hidden;
+      opacity: 0;
+      left: 50%;
+      transform: translate3d(-50%, -32px, 0);
+      z-index: 1000000;
+      pointer-events: none;
+      transition: 0.3s ease;
+    }
+
+    &:hover::after,
+    &:hover::before {
+      visibility: visible;
+      opacity: 1;
+    }
+  }
+
+  .hint--top-left::before,
+  .hint--top-right::before,
+  .hint--top::before {
+    border-top-color: #4c516c;
+  }
+
+  .md-RichEditor-blockquote {
+    margin: 0;
+    padding: 23px 32px;
+    background: var(--athens);
+    border-radius: $border-radius;
+    color: var(--mirage);
+    position: relative;
+
+    @include text('h4');
+
+    &::before {
+      content: '“';
+      position: absolute;
+      display: block;
+      left: 28px;
+      top: 1px;
+      font-size: 74px;
+      font-family: sans-serif;
+      font-weight: bold;
+      color: var(--casper);
+    }
+
+    & + .md-block-quote::before {
+      display: none;
+    }
+  }
+
+  .md-RichEditor-show-link-input {
+    width: 100%;
+    padding: 0 10px;
+  }
+
+  .md-url-input-close {
+    position: absolute;
+    right: 8px;
+    top: 2.5px;
+    font-size: 20px;
+    cursor: pointer;
+  }
+
+  .md-url-input {
+    box-sizing: border-box;
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding-right: 11px;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: $white;
+
+    &::placeholder {
+      color: $white;
+      padding-left: 3px;
+    }
+  }
+
+  .md-editor-toolbar-unlink-button,
+  .md-editor-toolbar-edit-button {
+    background: transparent;
+    border: none;
+    color: $light-gray3;
+    cursor: pointer;
+  }
+
+  .md-link {
+    color: var(--jungle-green);
+
+    &:hover {
+      color: var(--jungle-green-hover);
+      cursor: pointer;
+    }
+  }
+
+  .md-side-toolbar {
+    position: absolute;
+    left: -36px;
+
+    @include responsive('phone-xs') {
+      left: -8px;
+      margin-top: 25px;
+    }
+  }
+
+  .md-open-button + div {
+    z-index: 9;
+    position: absolute;
+    top: 0;
+    left: 0;
+    animation-fill-mode: forwards;
+    animation-name: fade;
+    animation-duration: 200ms;
+    margin-top: 7px;
+  }
+
+  @keyframes:global (fade) {
+    from {
+      opacity: 0;
+      left: 0;
+    }
+
+    to {
+      opacity: 1;
+      left: 36px;
+    }
+  }
+
+  .md-add-button {
+    cursor: pointer;
+    outline: none;
+    background: transparent;
+    border-radius: 50%;
+    border: 2px solid var(--black);
+    width: 16px;
+    height: 18px;
+    position: relative;
+    margin-top: 7px;
+
+    svg {
+      display: none;
+    }
+
+    &.md-open-button::before {
+      transform: translate3d(-44%, -50%, 0) rotate(45deg);
+    }
+
+    &::before {
+      color: var(--black);
+      content: '+';
+      display: inline-block;
+      position: absolute;
+      font-size: 17px;
+      line-height: 0;
+      transition: transform 200ms;
+      font-family: Rubik, sans-serif;
+      left: 52%;
+      top: 45%;
+      transform: translate3d(-50%, -50%, 0);
+    }
+  }
+
+  .md-block-image {
+    font-size: 13px;
+    width: fit-content;
+    margin: 20px auto;
+
+    .md-block-image-inner-container {
+      max-height: 500px;
+      box-sizing: border-box;
+      border: none;
+      background: transparent;
+    }
+
+    img {
+      cursor: pointer;
+      max-height: 500px;
+      max-width: 100%;
+      object-fit: scale-down;
+    }
+
+    figcaption {
+      text-align: center;
+
+      span span {
+        width: 100%;
+        display: block;
+      }
+    }
+  }
+
+  #nprogress {
+    .bar {
+      height: 3px;
+      background: var(--green);
+    }
+
+    .peg {
+      box-shadow: 0 0 10px var(--green-light-2), 0 0 5px var(--green-light-2);
+    }
+  }
 }

--- a/src/components/Insight/InsightEditor/InsightEditor.js
+++ b/src/components/Insight/InsightEditor/InsightEditor.js
@@ -119,7 +119,7 @@ class InsightEditor extends Component {
           />
           <Editor
             defaultEditorContent={this.defaultEditorContent}
-            placeholder='Write something interesting here...'
+            placeholder='Write something interesting ...'
             onChange={this.onTextChange}
           />
         </div>

--- a/src/components/Insight/InsightEditor/InsightEditor.module.scss
+++ b/src/components/Insight/InsightEditor/InsightEditor.module.scss
@@ -18,7 +18,7 @@
 
 .title {
   font-weight: 800;
-  line-height: 50px;
+  line-height: 44px;
   font-size: 38px;
   color: var(--mirage);
   background: var(--white) !important;

--- a/src/components/Insight/InsightEditor/InsightEditorTitle.js
+++ b/src/components/Insight/InsightEditor/InsightEditorTitle.js
@@ -6,7 +6,7 @@ const InsightEditorTitle = ({ className = '', ...props }) => {
   return (
     <AutoresizeTextarea
       className={`${styles.title} ${className}`}
-      placeholder='Enter title here'
+      placeholder='Name your insight'
       {...props}
     />
   )

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -51,7 +51,10 @@ const sanitizeMediumDraftHtml = html =>
       ...sanitizeHtml.defaults.allowedTags,
       'figure',
       'figcaption',
-      'img'
+      'img',
+      'h1',
+      'h2',
+      'u'
     ],
     allowedAttributes: {
       ...sanitizeHtml.defaults.allowedAttributes,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10014,10 +10014,10 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-medium-draft@^0.5.10:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/medium-draft/-/medium-draft-0.5.10.tgz#e367c8f40f3beb09a6c1f870f35f1355c1bec3c5"
-  integrity sha512-FeRYk9O9b9OgOa5WKJbRkLtUXma9697ptPAocnroJV5zp5w0114EHljWPBUmp1kkEf7/hT2wNShcL9uwfIZMtA==
+medium-draft@^0.5.15:
+  version "0.5.15"
+  resolved "https://registry.yarnpkg.com/medium-draft/-/medium-draft-0.5.15.tgz#699dac1b3831d9e4c7a84d57b32c7843d6b09d37"
+  integrity sha512-gcp2z8WuzrQ3BhnmTjPIbWHHs9HOWn2SGiTi0p72hBoopGribwAws30BHr5Ob8PJoA0KPy29Ed9Kr81LGp3BQA==
   dependencies:
     draft-js "^0.10.0"
     immutable "^3.7.6"


### PR DESCRIPTION
**Summary**
1) fixed missed styles for headings and underline text in view mode
2) changed width, height and placeholder for images

**Screenshots**
headings and underline text in view mode
![image](https://user-images.githubusercontent.com/24521041/60389151-9628c580-9ac5-11e9-829f-ca16b5526bad.png)
images:
![image](https://user-images.githubusercontent.com/24521041/60389212-85c51a80-9ac6-11e9-9795-e623682d10b9.png)

