### PR TITLE
hotfix: disabled lock icon for "valuechange" component

### DIFF
--- a/src/components/ValueChange/ValueChange.js
+++ b/src/components/ValueChange/ValueChange.js
@@ -11,14 +11,15 @@ const Change = {
 const notChanged = ['texas-rose', 'lock-small']
 
 const ValueChange = ({ className, change, render }) => {
-  const [accent, triangle] = change !== 0 ? Change[change > 0] : notChanged
+  const changed = change !== 0
+  const [accent, triangle] = changed ? Change[change > 0] : notChanged
 
   return (
     <span
       className={cx(styles.change, className)}
       style={{ color: `var(--${accent})`, fill: `var(--${accent})` }}
     >
-      <Icon type={triangle} className={styles.triangle} />
+      {changed && <Icon type={triangle} className={styles.triangle} />}
       {render(Math.abs(change))}
     </span>
   )


### PR DESCRIPTION
Disabled lock icon for "valuechange" component if change value is 0
![image](https://user-images.githubusercontent.com/14061779/60418071-b2725280-9bea-11e9-8c9d-c5653008ade1.png)
