### PR TITLE
5258: add lost enabled parameter for signal form

### DIFF
--- a/src/ducks/Signals/signalModal/SignalMasterModalForm.js
+++ b/src/ducks/Signals/signalModal/SignalMasterModalForm.js
@@ -14,6 +14,7 @@ const SignalMasterModalForm = ({
   label = 'New signal',
   metaFormSettings,
   canRedirect = true,
+  enabled = true,
   triggerId,
   isLoggedIn,
   redirect,
@@ -53,7 +54,12 @@ const SignalMasterModalForm = ({
         setDialogOpenState(true)
       }}
       onClose={onClose}
-      trigger={signalModalTrigger(isLoggedIn, label, variant, border)}
+      trigger={signalModalTrigger(
+        isLoggedIn && enabled,
+        label,
+        variant,
+        border
+      )}
       title={dialogTitle}
       classes={styles}
     >


### PR DESCRIPTION
Fixed trigger form button enabled/disabled state (lost from merge)
![image](https://user-images.githubusercontent.com/14061779/60492790-5aa01e00-9cb4-11e9-8a72-56045941b4ee.png)
