### PR TITLE
enhance/assets-overview

### DIFF
--- a/src/components/GainersAndLosers/GainersLosersTabs.module.scss
+++ b/src/components/GainersAndLosers/GainersLosersTabs.module.scss
@@ -1,5 +1,5 @@
 .wrapper {
-  padding: 20px 20px 0;
+  padding: 12px;
 }
 
 .tabs {
@@ -8,14 +8,19 @@
 }
 
 .project {
-  margin-bottom: 22px;
   display: flex;
   align-items: center;
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 8px;
+
+  &:hover {
+    background: var(--athens);
+  }
 }
 
 .name {
   margin-left: 8px;
-  width: 85px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/components/GainersAndLosers/GainersLosersTabs.module.scss
+++ b/src/components/GainersAndLosers/GainersLosersTabs.module.scss
@@ -1,3 +1,5 @@
+@import '~@santiment-network/ui/mixins';
+
 .wrapper {
   padding: 12px;
 }
@@ -5,6 +7,17 @@
 .tabs {
   width: 100%;
   padding: 16px 20px 0;
+
+  @include responsive('phone', 'phone-xs') {
+    padding: 0;
+
+    & > div {
+      justify-content: center;
+      margin: 0;
+      padding: 16px;
+      width: 50%;
+    }
+  }
 }
 
 .project {

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -91,9 +91,8 @@ const Navbar = ({ activeLink = '/' }) => {
               }
 
               return (
-                <ShowIf {...showIf}>
+                <ShowIf {...showIf} key={link}>
                   <Button
-                    key={link}
                     variant='flat'
                     as={props => <Link {...props} to={{ pathname: link }} />}
                     isActive={activeLink.includes(link)}

--- a/src/components/Trends/HelpPopup/HelpPopup.js
+++ b/src/components/Trends/HelpPopup/HelpPopup.js
@@ -8,7 +8,8 @@ import styles from './HelpPopup.module.scss'
 const HelpPopup = () => (
   <Tooltip
     className={styles.tooltip}
-    position='center'
+    align='center'
+    on='click'
     trigger={
       <div className={styles.trigger}>
         <Icon type='question-round-small' className={styles.description} />

--- a/src/components/Trends/HelpPopup/HelpPopup.module.scss
+++ b/src/components/Trends/HelpPopup/HelpPopup.module.scss
@@ -1,10 +1,11 @@
-@import "~@santiment-network/ui/mixins.scss";
+@import '~@santiment-network/ui/mixins.scss';
 
 .trigger {
   display: flex;
   align-items: center;
   color: var(--casper);
   margin-left: 10px;
+  cursor: pointer;
 }
 
 .description {

--- a/src/components/WatchlistHistory/WatchlistHistoryTemplate.module.scss
+++ b/src/components/WatchlistHistory/WatchlistHistoryTemplate.module.scss
@@ -1,4 +1,4 @@
-@import "~@santiment-network/ui/mixins.scss";
+@import '~@santiment-network/ui/mixins.scss';
 
 .wrapper {
   display: flex;
@@ -63,6 +63,7 @@
 .loader {
   margin-left: 12px;
   line-height: 30px;
+  font-size: 5px;
 }
 
 .description {

--- a/src/components/Watchlists/MyWatchlist.js
+++ b/src/components/Watchlists/MyWatchlist.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import { Button } from '@santiment-network/ui'
 import WatchlistCard from './WatchlistCard'
@@ -31,10 +32,10 @@ const WatchlistEmptySection = ({ watchlists }) => (
   </EmptySection>
 )
 
-const MyWatchlist = ({ isLoggedIn }) => (
+const MyWatchlist = ({ isLoggedIn, className }) => (
   <GetWatchlists
     render={({ isWatchlistsLoading, watchlists }) => (
-      <div className={styles.wrapper}>
+      <div className={cx(styles.wrapper, className)}>
         <DesktopOnly>
           <div className={styles.header}>
             <h4 className={styles.heading}>My watchlists</h4>

--- a/src/pages/Dashboard/DashboardPage.js
+++ b/src/pages/Dashboard/DashboardPage.js
@@ -49,7 +49,6 @@ const DashboardPage = ({ isLoggedIn, hasMetamask, history }) => (
           timeWindow='2d'
           size={8}
           onProjectClick={({ coinmarketcapId }) => {
-            console.log(history, coinmarketcapId)
             history.push(`/projects/${coinmarketcapId}`)
           }}
         />

--- a/src/pages/Dashboard/DashboardPage.js
+++ b/src/pages/Dashboard/DashboardPage.js
@@ -11,7 +11,7 @@ import GainersLosersTabs from '../../components/GainersAndLosers/GainersLosersTa
 import AnonBannerStaticExperiment from '../../components/Banner/AnonBanner/AnonBannerStaticExperiment'
 import styles from './DashboardPage.module.scss'
 
-const DashboardPage = ({ isLoggedIn, hasMetamask }) => (
+const DashboardPage = ({ isLoggedIn, hasMetamask, history }) => (
   <div className={styles.wrapper + ' page'}>
     {isLoggedIn ? (
       <DashboardPageOnboard hasMetamask={hasMetamask} />
@@ -45,7 +45,14 @@ const DashboardPage = ({ isLoggedIn, hasMetamask }) => (
         />
       </div>
       <div className={styles.column__GLTable}>
-        <GainersLosersTabs timeWindow='2d' size={8} />
+        <GainersLosersTabs
+          timeWindow='2d'
+          size={8}
+          onProjectClick={({ coinmarketcapId }) => {
+            console.log(history, coinmarketcapId)
+            history.push(`/projects/${coinmarketcapId}`)
+          }}
+        />
       </div>
     </div>
     <div className={styles.section}>

--- a/src/pages/assets/AssetsOverview.module.scss
+++ b/src/pages/assets/AssetsOverview.module.scss
@@ -33,3 +33,11 @@
 .recents {
   margin-bottom: 32px;
 }
+
+.gainers {
+  padding: 0 16px;
+}
+
+.watchlists {
+  margin-bottom: 32px;
+}

--- a/src/pages/assets/AssetsOverviewPage.js
+++ b/src/pages/assets/AssetsOverviewPage.js
@@ -57,7 +57,6 @@ const AssetsOverview = ({
                 timeWindow='2d'
                 size={8}
                 onProjectClick={({ coinmarketcapId }) => {
-                  console.log(history, coinmarketcapId)
                   history.push(`/projects/${coinmarketcapId}`)
                 }}
               />

--- a/src/pages/assets/AssetsOverviewPage.js
+++ b/src/pages/assets/AssetsOverviewPage.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { graphql } from 'react-apollo'
 import { compose } from 'redux'
 import { connect } from 'react-redux'
+import { withRouter } from 'react-router-dom'
 import cx from 'classnames'
 import { CATEGORIES, WATCHLISTS_BY_FUNCTION } from './assets-overview-constants'
 import { PROJECTS_BY_FUNCTION_SHORT_QUERY } from '../../queries/WatchlistGQL'
@@ -10,11 +11,17 @@ import MobileHeader from './../../components/MobileHeader/MobileHeader'
 import { DesktopOnly, MobileOnly } from './../../components/Responsive'
 import MyWatchlist from '../../components/Watchlists/MyWatchlist'
 import PageLoader from '../../components/Loader/PageLoader'
+import GainersLosersTabs from '../../components/GainersAndLosers/GainersLosersTabs'
 import RecentlyWatched from '../../components/RecentlyWatched/RecentlyWatched'
 import { checkIsLoggedIn } from './../UserSelectors'
 import styles from './AssetsOverview.module.scss'
 
-const AssetsOverview = ({ slugs, isLoggedIn, isPublicWatchlistsLoading }) => {
+const AssetsOverview = ({
+  slugs,
+  isLoggedIn,
+  isPublicWatchlistsLoading,
+  history
+}) => {
   return (
     <div className={cx(styles.overviewPage, 'page')}>
       <DesktopOnly>
@@ -40,7 +47,21 @@ const AssetsOverview = ({ slugs, isLoggedIn, isPublicWatchlistsLoading }) => {
             <RecentlyWatched className={styles.recents} />
             <h2 className={styles.subtitle}>Categories</h2>
             <WatchlistCards watchlists={CATEGORIES} slugs={slugs} />
-            <MyWatchlist isLoggedIn={isLoggedIn} />
+            <MyWatchlist
+              isLoggedIn={isLoggedIn}
+              className={styles.watchlists}
+            />
+            <h2 className={styles.subtitle}>Gainers and losers</h2>
+            <section className={styles.gainers}>
+              <GainersLosersTabs
+                timeWindow='2d'
+                size={8}
+                onProjectClick={({ coinmarketcapId }) => {
+                  console.log(history, coinmarketcapId)
+                  history.push(`/projects/${coinmarketcapId}`)
+                }}
+              />
+            </section>
           </>
         )}
       </MobileOnly>
@@ -74,4 +95,4 @@ const enhance = compose(
   connect(mapStateToProps)
 )
 
-export default enhance(AssetsOverview)
+export default withRouter(enhance(AssetsOverview))


### PR DESCRIPTION
### Summary
- Social `gainers and losers` icons and name fixes. By clicking on project client is lead to the `/projects/:project`  page;
- Adding `gainers and losers`on the assets overview page;
- Loading dots size fix on the `/assets/:page`

### Screenshots
`/assets` page
![image](https://user-images.githubusercontent.com/25135650/60525058-5b59a400-9cf6-11e9-81b7-d3a22dc4f0d7.png)
