### PR TITLE
fix/GL-header

### DIFF
--- a/src/pages/assets/AssetsOverviewPage.js
+++ b/src/pages/assets/AssetsOverviewPage.js
@@ -51,7 +51,7 @@ const AssetsOverview = ({
               isLoggedIn={isLoggedIn}
               className={styles.watchlists}
             />
-            <h2 className={styles.subtitle}>Gainers and losers</h2>
+            <h2 className={styles.subtitle}>Social gainers and losers</h2>
             <section className={styles.gainers}>
               <GainersLosersTabs
                 timeWindow='2d'


### PR DESCRIPTION
### Summary
Changing header of the `Gainers and Losers` section on the `assets overview` for mobile devices from `Gainers and losers` to `Social gainers and losers`