### PR TITLE
5100: fixed signal volume(as default), channel borders

### DIFF
--- a/src/ducks/Signals/VisualBacktestChart.js
+++ b/src/ducks/Signals/VisualBacktestChart.js
@@ -80,7 +80,7 @@ const VisualBacktestChart = ({ data, price, metrics, showXY = false }) => {
 }
 
 const formatTooltipValue = (isPrice, value) =>
-  isPrice ? formatNumber(value, { currency: 'USD' }) : value
+  isPrice ? formatNumber(value, { currency: 'USD' }) : value.toFixed(2)
 
 const CustomTooltip = ({ active, payload }) => {
   if (active && payload && payload[0]) {

--- a/src/ducks/Signals/chart/SignalPreview.js
+++ b/src/ducks/Signals/chart/SignalPreview.js
@@ -17,13 +17,6 @@ const CUSTOM_METRICS = {
     dataKey: 'active_addresses',
     orientation: 'right',
     yAxisVisible: true
-  },
-  volume: {
-    node: Bar,
-    color: 'waterloo',
-    label: 'Volume',
-    fill: true,
-    dataKey: 'price_volume_diff'
   }
 }
 

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/signal/__snapshots__/TriggerForm.spec.js.snap
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/signal/__snapshots__/TriggerForm.spec.js.snap
@@ -63,8 +63,6 @@ exports[`TriggerForm smoke 1`] = `
   enableReinitialize={true}
   initialValues={
     Object {
-      "absoluteBorderLeft": 50,
-      "absoluteBorderRight": 75,
       "absoluteThreshold": 25,
       "channels": Array [
         "Telegram",

--- a/src/ducks/Signals/signalFormManager/signalMaster/SignalMaster.js
+++ b/src/ducks/Signals/signalFormManager/signalMaster/SignalMaster.js
@@ -28,7 +28,7 @@ export class SignalMaster extends React.PureComponent {
     step: TRIGGER_STEPS.SETTINGS,
     trigger: {
       title: `Signal_[${new Date().toLocaleDateString('en-US')}]`,
-      description: 'Any',
+      description: '',
       isActive: true,
       isPublic: false
     }

--- a/src/ducks/Signals/utils/constants.js
+++ b/src/ducks/Signals/utils/constants.js
@@ -237,8 +237,6 @@ export const METRIC_DEFAULT_VALUES = {
     frequencyTimeType: { ...FREQUENCY_TIME_TYPE_DAILY_MODEL },
     frequencyTimeValue: { ...frequencyTymeValueBuilder(1) },
     absoluteThreshold: 25,
-    absoluteBorderLeft: 50,
-    absoluteBorderRight: 75,
     threshold: BASE_THRESHOLD,
     timeWindow: 1,
     timeWindowUnit: { label: 'Days', value: 'd' },
@@ -257,9 +255,7 @@ export const METRIC_DEFAULT_VALUES = {
     type: PRICE_PERCENT_CHANGE_UP_MODEL,
     isRepeating: true,
     channels: ['Telegram'],
-    absoluteThreshold: 25,
-    absoluteBorderLeft: 50,
-    absoluteBorderRight: 75
+    absoluteThreshold: 25
   },
   daily_active_addresses: {
     frequencyType: { ...FREQUENCY_TYPE_DAILY_MODEL },

--- a/src/ducks/Signals/utils/utils.js
+++ b/src/ducks/Signals/utils/utils.js
@@ -511,7 +511,7 @@ export const validateTriggerForm = values => {
     }
   }
 
-  if (values.type.metric === PRICE_ABSOLUTE_CHANGE_DOUBLE_BORDER) {
+  if (values.type.subMetric === PRICE_ABSOLUTE_CHANGE_DOUBLE_BORDER) {
     if (!values.absoluteBorderLeft) {
       errors.absoluteBorderLeft = REQUIRED_MESSAGE
     }


### PR DESCRIPTION
Done
* using default volume for backtesting chart, fixed channel borders (for Price metric)
![image](https://user-images.githubusercontent.com/14061779/60578343-b4bee300-9d89-11e9-82db-6fe64c292808.png)
