### PR TITLE
fix/styles-chart-sidecar

### DIFF
--- a/src/ducks/SANCharts/ChartSidecar.js
+++ b/src/ducks/SANCharts/ChartSidecar.js
@@ -42,22 +42,24 @@ const ChartSidecar = ({ onSlugSelect }) => {
         </div>
       ) : (
         <div className={styles.content}>
-          <div className={styles.visible}>
-            <RecentlyWatched
-              className={styles.section}
-              onProjectClick={onSlugSelect}
-              onWatchlistClick={setOpenedList}
-              classes={styles}
-            />
-            <section className={styles.section}>
-              <h2 className={styles.subtitle}>Social gainers and losers</h2>
-              <GainersLosersTabs
-                timeWindow='2d'
-                size={8}
+          <div className={styles.content__container}>
+            <div className={styles.visible}>
+              <RecentlyWatched
+                className={styles.section}
                 onProjectClick={onSlugSelect}
+                onWatchlistClick={setOpenedList}
                 classes={styles}
               />
-            </section>
+              <section className={styles.section}>
+                <h2 className={styles.subtitle}>Social gainers and losers</h2>
+                <GainersLosersTabs
+                  timeWindow='2d'
+                  size={8}
+                  onProjectClick={onSlugSelect}
+                  classes={styles}
+                />
+              </section>
+            </div>
           </div>
         </div>
       )}

--- a/src/ducks/SANCharts/ChartSidecar.module.scss
+++ b/src/ducks/SANCharts/ChartSidecar.module.scss
@@ -1,5 +1,9 @@
 @import '~@santiment-network/ui/mixins';
 
+:global(#intercom-container) {
+  display: none !important;
+}
+
 .wrapper {
   position: fixed;
   top: 0;
@@ -61,11 +65,16 @@
 }
 
 .content {
-  position: relative;
   height: 100%;
   width: 100%;
   overflow-y: auto;
   padding: 20px 16px;
+
+  &__container {
+    position: relative;
+    height: 100%;
+    width: 100%;
+  }
 
   &_assets {
     display: flex;
@@ -81,6 +90,7 @@
 
 .visible {
   position: absolute;
+  width: 100%;
 }
 
 .subtitle {


### PR DESCRIPTION
### Summary
Fixing the width of the section when it's only the `Gainers and Losers`. Hiding intercom when on `/chart`