### PR TITLE
enhance/chart-metrics-selector-volume

### DIFF
--- a/src/ducks/SANCharts/ChartMetricSelector.js
+++ b/src/ducks/SANCharts/ChartMetricSelector.js
@@ -32,7 +32,13 @@ const getCategoryGraph = availableMetrics => {
       category.push(metric)
       continue
     }
-    categories[metricCategory] = [metric]
+
+    const metrics = [metric]
+    if (metric.key === 'historyPrice') {
+      metrics.push({ ...Metrics.volume, key: 'volume' })
+    }
+
+    categories[metricCategory] = metrics
   }
 
   return categories


### PR DESCRIPTION
### Summary
Handling case for adding the `Volume` metric.
It should be treated specially, because it is a part of the `historyPrice` data
