### PR TITLE
5100: fix metrics buttons for small trigger form, add description val-n

### DIFF
--- a/src/ducks/SANCharts/ChartMetrics.js
+++ b/src/ducks/SANCharts/ChartMetrics.js
@@ -71,11 +71,19 @@ class ChartMetrics extends Component {
               key={label}
               type='button'
               data-metric={metric}
-              className={cx(styles.btn, metrics.has(metric) && styles.active)}
+              className={cx(
+                styles.btn,
+                classes.metricButton,
+                metrics.has(metric) && styles.active
+              )}
               onClick={this.onClick}
               disabled={disabledMetrics.includes(metric)}
             >
-              <Label variant='circle' accent={color} className={styles.label} />
+              <Label
+                variant='circle'
+                accent={color}
+                className={cx(styles.label, classes.metricLabel)}
+              />
               {label}
             </button>
           )

--- a/src/ducks/Signals/chart/SignalPreview.js
+++ b/src/ducks/Signals/chart/SignalPreview.js
@@ -17,6 +17,10 @@ const CUSTOM_METRICS = {
     dataKey: 'active_addresses',
     orientation: 'right',
     yAxisVisible: true
+  },
+  volume: {
+    ...Metrics.volume,
+    color: 'waterloo'
   }
 }
 

--- a/src/ducks/Signals/chart/SignalPreview.module.scss
+++ b/src/ducks/Signals/chart/SignalPreview.module.scss
@@ -42,3 +42,15 @@
 .metrics {
   padding: 0;
 }
+
+.metricButton {
+  padding: 0;
+  height: 20px;
+  border: none;
+  background: no-repeat;
+  margin-right: 25px;
+}
+
+.metricLabel {
+  margin-bottom: 0;
+}

--- a/src/ducks/Signals/signalFormManager/aboutForm/AboutForm.js
+++ b/src/ducks/Signals/signalFormManager/aboutForm/AboutForm.js
@@ -22,7 +22,7 @@ const AboutForm = ({ triggerMeta, isEdit = false, onSubmit, onBack }) => {
         } else if (values.title.length > 120) {
           errors.title = 'Title has to be less than 120 characters'
         }
-        if (values.description.length > 240) {
+        if (!values.description || values.description.length > 240) {
           errors.description = 'Description has to be less than 240 characters'
         }
         return errors
@@ -56,7 +56,7 @@ const AboutForm = ({ triggerMeta, isEdit = false, onSubmit, onBack }) => {
             <div className={styles.row}>
               <div className={styles.Field}>
                 <Label accent='waterloo' className={styles.label}>
-                  Description ({description.length}/140)
+                  Description ({(description || '').length}/140)
                 </Label>
                 <FormikInput
                   name='description'

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.module.scss
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.module.scss
@@ -28,7 +28,7 @@ $trigger-form-width: 496px;
 
 .signalPreview {
   display: block !important;
-  padding: 15px;
+  padding: 15px 15px 0 15px;
   background: var(--white);
   border: 1px solid var(--porcelain);
 

--- a/src/ducks/Signals/utils/utils.js
+++ b/src/ducks/Signals/utils/utils.js
@@ -50,7 +50,7 @@ const getFormTriggerTarget = target => {
 }
 
 const getFormTriggerType = (type, operation) => {
-  if (!operation || Object.keys(operation).length === 0) {
+  if (!operation) {
     switch (type) {
       case DAILY_ACTIVE_ADDRESSES: {
         return DAILY_ACTIVE_ADDRESSES_METRIC

--- a/src/ducks/Signals/utils/utils.js
+++ b/src/ducks/Signals/utils/utils.js
@@ -50,7 +50,7 @@ const getFormTriggerTarget = target => {
 }
 
 const getFormTriggerType = (type, operation) => {
-  if (!operation) {
+  if (!operation || Object.keys(operation).length === 0) {
     switch (type) {
       case DAILY_ACTIVE_ADDRESSES: {
         return DAILY_ACTIVE_ADDRESSES_METRIC
@@ -141,7 +141,7 @@ const getTriggerOperation = ({
       break
     }
     default: {
-      break
+      return undefined
     }
   }
 


### PR DESCRIPTION
Done
* metrics button for small chart and default waterloo color
![image](https://user-images.githubusercontent.com/14061779/60581287-336a4f00-9d8f-11e9-834f-0355a12af03d.png)
