### PR TITLE
5100: changed default color of X-Y axes of trigger preview

### DIFF
--- a/src/ducks/Signals/VisualBacktestChart.js
+++ b/src/ducks/Signals/VisualBacktestChart.js
@@ -47,8 +47,7 @@ const VisualBacktestChart = ({ data, price, metrics, showXY = false }) => {
         <YAxis hide />
 
         {generateMetricsMarkup(metrics, {
-          active_addresses: formattedData,
-          price_volume_diff: formattedData
+          active_addresses: formattedData
         })}
 
         {formattedData
@@ -68,7 +67,7 @@ const VisualBacktestChart = ({ data, price, metrics, showXY = false }) => {
   return (
     <div
       className={cx(
-        chartStyles.wrapper + ' ' + sharedStyles.chart,
+        chartStyles.wrapper + ' ' + sharedStyles.chart + ' ' + styles.wrapper,
         styles.container
       )}
     >

--- a/src/ducks/Signals/chart/SignalPreview.js
+++ b/src/ducks/Signals/chart/SignalPreview.js
@@ -20,7 +20,7 @@ const CUSTOM_METRICS = {
   },
   volume: {
     ...Metrics.volume,
-    color: 'waterloo'
+    color: 'casper'
   }
 }
 

--- a/src/ducks/Signals/chart/SignalPreview.module.scss
+++ b/src/ducks/Signals/chart/SignalPreview.module.scss
@@ -17,6 +17,14 @@
   height: 100%;
 }
 
+.wrapper {
+  :global {
+    .recharts-cartesian-axis-line {
+      stroke: var(--casper);
+    }
+  }
+}
+
 .chartBlock {
   margin-top: 10px;
   width: 100%;


### PR DESCRIPTION
Done
* more visible colors for signal preview chart(X-Y, changed from porcelain to casper)
![image](https://user-images.githubusercontent.com/14061779/60582905-619d5e00-9d92-11e9-81f9-5a8f1d33d858.png)
