### PR TITLE
enhance/chart-metrics-colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.8",
     "@fortawesome/free-solid-svg-icons": "^5.5.0",
     "@fortawesome/react-fontawesome": "^0.1.3",
-    "@santiment-network/ui": "^0.5.44",
+    "@santiment-network/ui": "^0.5.46",
     "@trainline/react-skeletor": "^1.0.2",
     "animate-components": "^1.4.8",
     "apollo-cache-inmemory": "^1.1.2",

--- a/src/ducks/SANCharts/utils.js
+++ b/src/ducks/SANCharts/utils.js
@@ -15,11 +15,13 @@ export const Metrics = {
     label: 'Volume',
     fill: true,
     dataKey: 'volume',
-    category: 'Financial'
+    category: 'Financial',
+    color: 'mystic'
   },
   socialVolume: {
     node: Line,
     label: 'Social Volume',
+    color: 'malibu',
     category: 'Social'
   },
   tokenAgeConsumed: {
@@ -86,6 +88,7 @@ export const Metrics = {
   },
   devActivity: {
     node: Line,
+    color: 'heliotrope',
     label: 'Development Activity',
     dataKey: 'activity',
     category: 'Development',
@@ -137,11 +140,11 @@ export const Metrics = {
 export const getMetricCssVarColor = metric => `var(--${Metrics[metric].color})`
 
 export const METRIC_COLORS = [
-  'persimmon',
-  'heliotrope',
   'texas-rose',
   'dodger-blue',
-  'malibu'
+  'lima',
+  'heliotrope',
+  'waterloo'
 ]
 
 export const generateMetricsMarkup = (metrics, data = {}) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,10 +1466,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@santiment-network/ui@^0.5.44":
-  version "0.5.44"
-  resolved "https://registry.yarnpkg.com/@santiment-network/ui/-/ui-0.5.44.tgz#639d04c19b35d9f2dfad310e6f84fe0d721f16fa"
-  integrity sha512-X4VpJf792irmUUvkmMkywLfXoDD2INj6mteU5r2dZtQry3SuscOHDeTlDWKeHrwZfkVBNlT0d6KEBDy5nGnK2g==
+"@santiment-network/ui@^0.5.46":
+  version "0.5.46"
+  resolved "https://registry.yarnpkg.com/@santiment-network/ui/-/ui-0.5.46.tgz#4529f9d9ebfc03e6941229c7215b9c92ec0db3bd"
+  integrity sha512-1wHrspnH2jTUtOyjOm7tM+R2aumxoP1eWnXhWrfoqt8Eb3SFTD1YSeGywZJmNNzGNDA4PnDUGtf2wIyUT6CWeg==
 
 "@semantic-ui-react/event-stack@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
### Summary
- Assigned constant colors to the following metrics:
  - `Volume` -> `mystic` (grey);
  - `Social Volume` -> `malibu` (light-blue);
  - `Dev. Activity` -> `heliotrope` (purple);

- Dynamics colors changed:
  - Removed `persimmon` (red) from the available colors;
  - Now it contains  `['texas-rose', 'dodger-blue', 'lima', 'heliotrope', 'waterloo']`

 ### Screenshots
![image](https://user-images.githubusercontent.com/25135650/60942318-e0dae680-a2ea-11e9-8f82-be52089d7b11.png)
