### PR TITLE
feature/chart-more-timeranges

### DIFF
--- a/src/ducks/SANCharts/ChartSettings.js
+++ b/src/ducks/SANCharts/ChartSettings.js
@@ -31,7 +31,7 @@ const ChartSettings = ({
       />
       <div className={styles.settings__right}>
         <Selector
-          options={['1w', '1m', '3m', '6m']}
+          options={['1d', '5d', '1w', '1m', '3m', '6m', '1y', 'all']}
           onSelectOption={onTimerangeChange}
           defaultSelected={defaultTimerange}
           className={styles.ranges}


### PR DESCRIPTION
### Summary
Adding `1d`, `5d`, `1y`, `all` options to the timerange selector;

### Screenshots
![image](https://user-images.githubusercontent.com/25135650/60943916-159d6c80-a2f0-11e9-88fa-c7b16ecf2529.png)
