### PR TITLE
enhance/chart-displaying

### DIFF
--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -4,6 +4,7 @@ import Loadable from 'react-loadable'
 import GetTimeSeries from '../../ducks/GetTimeSeries/GetTimeSeries'
 import { ERRORS } from '../GetTimeSeries/reducers'
 import Charts from './Charts'
+import { Metrics } from './utils'
 import { getNewInterval } from './IntervalSelector'
 import { getIntervalByTimeRange } from '../../utils/dates'
 import styles from './ChartPage.module.scss'
@@ -221,7 +222,8 @@ class ChartPage extends Component {
           slug,
           from,
           to,
-          interval
+          interval,
+          ...Metrics[metric].reqMeta
         }
       }
       return acc

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -8,7 +8,7 @@ import {
   ReferenceArea
 } from 'recharts'
 import Button from '@santiment-network/ui/Button'
-import { formatNumber, labelFormatter } from './../../utils/formatting'
+import { formatNumber, millify, labelFormatter } from './../../utils/formatting'
 import { getDateFormats } from '../../utils/dates'
 import mixWithPaywallArea from './../../components/PaywallArea/PaywallArea'
 import { Metrics, generateMetricsMarkup } from './utils'
@@ -120,17 +120,12 @@ class Charts extends React.Component {
                 if (name === Metrics.historyPrice.label) {
                   return formatNumber(value, { currency: 'USD' })
                 }
-                if (
-                  name === Metrics.dailyActiveAddresses.label ||
-                  name === Metrics.socialVolume.label ||
-                  name === Metrics.networkGrowth.label ||
-                  name === Metrics.dailyActiveDeposits.label ||
-                  name === Metrics.devActivity.label
-                ) {
-                  return value
+
+                if (value > 900000) {
+                  return millify(value, 2)
                 }
 
-                return value.toFixed(2)
+                return value.toFixed ? value.toFixed(2) : value
               }}
             />
             {mixWithPaywallArea({

--- a/src/ducks/SANCharts/utils.js
+++ b/src/ducks/SANCharts/utils.js
@@ -71,7 +71,8 @@ export const Metrics = {
   mvrvRatio: {
     node: Line,
     label: 'Market Value To Realized Value',
-    category: 'On-chain'
+    category: 'On-chain',
+    dataKey: 'mvrv'
   },
   transactionVolume: {
     node: Line,
@@ -190,6 +191,7 @@ export const generateMetricsMarkup = (metrics, data = {}) => {
         dot={false}
         isAnimationActive={false}
         opacity={opacity}
+        connectNulls
         {...rest}
       />
     )

--- a/src/ducks/SANCharts/utils.js
+++ b/src/ducks/SANCharts/utils.js
@@ -16,7 +16,8 @@ export const Metrics = {
     fill: true,
     dataKey: 'volume',
     category: 'Financial',
-    color: 'mystic'
+    color: 'waterloo',
+    opacity: 0.4
   },
   socialVolume: {
     node: Line,
@@ -48,13 +49,13 @@ export const Metrics = {
   },
   percentOfTokenSupplyOnExchanges: {
     node: Line,
-    label: 'Percent of token supply on exchanges',
+    label: 'Percent of Token Supply on Exchanges',
     dataKey: 'percentOnExchanges',
     category: 'On-chain'
   },
   topHoldersPercentOfTotalSupply: {
     node: Line,
-    label: 'In top holders total',
+    label: 'In Top Holders Total',
     // TODO: Add support for 3 datakeys of single metric:
     // inExchanges outsideExchanges inTopHoldersTotal
     dataKey: 'inTopHoldersTotal',
@@ -160,7 +161,8 @@ export const generateMetricsMarkup = (metrics, data = {}) => {
       color,
       yAxisVisible = false,
       orientation = 'left',
-      dataKey = metric
+      dataKey = metric,
+      opacity = 1
     } = typeof metric === 'object' ? metric : Metrics[metric]
 
     const rest = {
@@ -187,6 +189,7 @@ export const generateMetricsMarkup = (metrics, data = {}) => {
         dataKey={dataKey}
         dot={false}
         isAnimationActive={false}
+        opacity={opacity}
         {...rest}
       />
     )

--- a/src/ducks/SANCharts/utils.js
+++ b/src/ducks/SANCharts/utils.js
@@ -93,7 +93,11 @@ export const Metrics = {
     dataKey: 'activity',
     category: 'Development',
     description:
-      "Based on number of Github 'events' including issue interactions, PRs, comments, and wiki edits, plus the number of public repositories a project is maintaining"
+      "Based on number of Github 'events' including issue interactions, PRs, comments, and wiki edits, plus the number of public repositories a project is maintaining",
+    reqMeta: {
+      transform: 'movingAverage',
+      movingAverageIntervalBase: 7
+    }
   },
   tokenVelocity: {
     node: Line,


### PR DESCRIPTION
### Summary
- Adding ability to specify additional request information for chart metrics via `reqMeta` property object [[code]](https://github.com/santiment/app/pull/423/files#diff-28220447578a85d78719e1a7d0dec143R226);
  - Changed `devActivity.movingAverage` to the `7` days [[code]](https://github.com/santiment/app/pull/423/files#diff-6484b8b3dcc9e3cb29c7ac1a5b5d5cabR98);
- Millifying tooltip values that are larger than `1000000` [[code]](https://github.com/santiment/app/pull/423/files#diff-eb7ebf6a04e59345be3dcd27c8aad654R124);
- Increased Tooltip labels naming consistency;
- Connecting chart nulls;
- Fixed `mvrv` metric