### PR TITLE
enhance/chart-tooltip

### DIFF
--- a/src/ducks/SANCharts/Chart.module.scss
+++ b/src/ducks/SANCharts/Chart.module.scss
@@ -28,27 +28,69 @@
   }
 }
 
+.details {
+  @include text('caption');
+
+  position: absolute;
+  left: 60px;
+  top: 10px;
+  border: 1px solid var(--porcelain);
+  background: var(--white);
+  border-radius: 4px;
+  padding: 4px 8px;
+  z-index: 3;
+}
+
 .line {
   &::before,
   &::after {
     content: '';
     display: block;
     position: absolute;
-    background: red;
+    background: var(--mirage);
     z-index: 2;
   }
 
   &::before {
-    top: 0;
-    bottom: 0;
+    top: 32px;
+    bottom: 10px;
     width: 1px;
     transform: translateX(var(--x));
   }
 
   &::after {
-    left: 0;
+    left: 20px;
     right: 0;
     height: 1px;
     transform: translateY(var(--y));
+  }
+}
+
+.values {
+  &::before,
+  &::after {
+    @include text('caption', 'm');
+
+    display: block;
+    position: absolute;
+    background: var(--white);
+    z-index: 3;
+    border: 1px solid var(--porcelain);
+    border-radius: 4px;
+    padding: 0 5px;
+  }
+
+  &::before {
+    content: var(--xValue);
+    transform: translateX(calc(var(--x) - 50%));
+    bottom: 8px;
+  }
+
+  &::after {
+    content: var(--yValue);
+    transform: translateY(calc(var(--y) - 50%));
+    left: 8px;
+    width: 40px;
+    text-align: center;
   }
 }

--- a/src/ducks/SANCharts/Chart.module.scss
+++ b/src/ducks/SANCharts/Chart.module.scss
@@ -31,6 +31,7 @@
 .details {
   @include text('caption');
 
+  pointer-events: none;
   position: absolute;
   left: 60px;
   top: 10px;
@@ -42,6 +43,8 @@
 }
 
 .line {
+  pointer-events: none;
+
   &::before,
   &::after {
     content: '';

--- a/src/ducks/SANCharts/Chart.module.scss
+++ b/src/ducks/SANCharts/Chart.module.scss
@@ -40,6 +40,14 @@
   border-radius: 4px;
   padding: 4px 8px;
   z-index: 3;
+
+  &__title {
+    margin-bottom: 7px;
+  }
+}
+
+.zoom + .details {
+  left: 155px;
 }
 
 .line {

--- a/src/ducks/SANCharts/Chart.module.scss
+++ b/src/ducks/SANCharts/Chart.module.scss
@@ -27,3 +27,28 @@
     }
   }
 }
+
+.line {
+  &::before,
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    background: red;
+    z-index: 2;
+  }
+
+  &::before {
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    transform: translateX(var(--x));
+  }
+
+  &::after {
+    left: 0;
+    right: 0;
+    height: 1px;
+    transform: translateY(var(--y));
+  }
+}

--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -123,7 +123,7 @@ class ChartPage extends Component {
 
   onIntervalChange = option => {
     const { index: interval = option } = option
-    this.setState({ zoom: undefined, interval }, this.updateSearchQuery)
+    this.setState({ interval, zoom: undefined }, this.updateSearchQuery)
   }
 
   toggleMetric = metric => {

--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -123,7 +123,7 @@ class ChartPage extends Component {
 
   onIntervalChange = option => {
     const { index: interval = option } = option
-    this.setState({ interval, zoom: undefined }, this.updateSearchQuery)
+    this.setState({ zoom: undefined, interval }, this.updateSearchQuery)
   }
 
   toggleMetric = metric => {

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -54,7 +54,7 @@ class Charts extends React.Component {
     refAreaRight: undefined
   }
 
-  priceRef = React.createRef()
+  metricRef = React.createRef()
 
   onZoom = () => {
     let {
@@ -86,11 +86,11 @@ class Charts extends React.Component {
 
   getXToYCoordinates = () => {
     // HACK(vanguard): Because 'recharts' lib does not expose correct point "Y" coordinate
-    if (!this.priceRef.current || !this.priceRef.current.mainCurve) {
+    if (!this.metricRef.current || !this.metricRef.current.mainCurve) {
       return
     }
 
-    this.xToYCoordinates = this.priceRef.current.mainCurve
+    this.xToYCoordinates = this.metricRef.current.mainCurve
       .getAttribute('d')
       .slice(1)
       .split('L')
@@ -220,7 +220,9 @@ class Charts extends React.Component {
               tickFormatter={tickFormatter}
             />
             <YAxis hide />
-            {generateMetricsMarkup(metrics, { [tooltipMetric]: this.priceRef })}
+            {generateMetricsMarkup(metrics, {
+              ref: { [tooltipMetric]: this.metricRef }
+            })}
             {refAreaLeft && refAreaRight && (
               <ReferenceArea
                 x1={refAreaLeft}

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -210,7 +210,7 @@ class Charts extends React.Component {
                   className={styles.values}
                   style={{
                     '--xValue': `"${tickFormatter(xValue)}"`,
-                    '--yValue': `"${millify(yValue, 1)}"`
+                    '--yValue': `"${yValue ? millify(yValue, 1) : '-'}"`
                   }}
                 />
               </div>

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -128,8 +128,8 @@ class Charts extends React.Component {
     this.setState({ hovered: false })
   }
 
-  onMouseMove = throttle(e => {
-    if (!e) return
+  onMouseMove = throttle(event => {
+    if (!event) return
 
     if (!this.xToYCoordinates && !this.getXToYCoordinates()) {
       return
@@ -140,7 +140,7 @@ class Charts extends React.Component {
       activeLabel,
       activeCoordinate,
       activePayload
-    } = e
+    } = event
 
     const { tooltipMetric = 'historyPrice' } = this.state
 
@@ -222,9 +222,9 @@ class Charts extends React.Component {
             margin={CHART_MARGINS}
             onMouseLeave={this.onMouseLeave}
             onMouseEnter={this.getXToYCoordinates}
-            onMouseDown={e => {
-              if (!e) return
-              const { activeTooltipIndex, activeLabel } = e
+            onMouseDown={event => {
+              if (!event) return
+              const { activeTooltipIndex, activeLabel } = event
               this.setState({
                 refAreaLeft: activeLabel,
                 leftZoomIndex: activeTooltipIndex

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -107,7 +107,7 @@ class Charts extends React.Component {
 
   getXToYCoordinates = () => {
     // HACK(vanguard): Because 'recharts' lib does not expose correct point "Y" coordinate
-    if (!this.metricRef.current || !this.metricRef.current.mainCurve) {
+    if (!(this.metricRef.current && this.metricRef.current.mainCurve)) {
       return
     }
 

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -142,7 +142,8 @@ class Charts extends React.Component {
       activePayload
     } = e
 
-    const { tooltipMetric } = this.state
+    const { tooltipMetric = 'historyPrice' } = this.state
+
     this.setState({
       activePayload,
       refAreaRight: activeLabel,

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -46,12 +46,25 @@ function valueFormatter (value, name) {
   return value && value.toFixed ? value.toFixed(2) : value
 }
 
+const PRICE_METRIC = 'historyPrice'
+
 class Charts extends React.Component {
   state = {
     leftZoomIndex: undefined,
     rightZoomIndex: undefined,
     refAreaLeft: undefined,
     refAreaRight: undefined
+  }
+
+  componentDidUpdate (prevProps) {
+    const { metrics } = this.props
+    if (metrics !== prevProps.metrics) {
+      this.setState({
+        tooltipMetric: metrics.includes(PRICE_METRIC)
+          ? PRICE_METRIC
+          : metrics[0]
+      })
+    }
   }
 
   metricRef = React.createRef()
@@ -121,10 +134,7 @@ class Charts extends React.Component {
       activePayload
     } = e
 
-    const tooltipMetric = this.props.metrics.includes('historyPrice')
-      ? 'historyPrice'
-      : this.props.metrics[0]
-
+    const { tooltipMetric } = this.state
     this.setState({
       activePayload,
       refAreaRight: activeLabel,
@@ -150,12 +160,9 @@ class Charts extends React.Component {
       xValue,
       yValue,
       activePayload,
-      hovered
+      hovered,
+      tooltipMetric
     } = this.state
-
-    const tooltipMetric = metrics.includes('historyPrice')
-      ? 'historyPrice'
-      : metrics[0]
 
     return (
       <div className={styles.wrapper + ' ' + sharedStyles.chart}>

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -16,17 +16,19 @@ import { Metrics, generateMetricsMarkup } from './utils'
 import sharedStyles from './ChartPage.module.scss'
 import styles from './Chart.module.scss'
 
-const tickFormatter = date => {
-  const { DD, MMM, YY } = getDateFormats(new Date(date))
-  return `${DD} ${MMM} ${YY}`
-}
+const PRICE_METRIC = 'historyPrice'
 
 const CHART_MARGINS = {
   left: -10,
   right: 18
 }
 
-function tooltipLabelFormatter (value) {
+const tickFormatter = date => {
+  const { DD, MMM, YY } = getDateFormats(new Date(date))
+  return `${DD} ${MMM} ${YY}`
+}
+
+const tooltipLabelFormatter = value => {
   const date = new Date(value)
   const { MMMM, DD, YYYY } = getDateFormats(date)
   const { HH, mm } = getTimeFormats(date)
@@ -34,21 +36,21 @@ function tooltipLabelFormatter (value) {
   return `${HH}:${mm}, ${MMMM} ${DD}, ${YYYY}`
 }
 
-function valueFormatter (value, name) {
-  if (!Number.isFinite(+value)) return
+const valueFormatter = (value, name) => {
+  const numValue = +value
+  // NOTE(vanguard): Some values may not be present in a hovered data point, i.e. value === undefined/null;
+  if (!Number.isFinite(numValue)) return
 
   if (name === Metrics.historyPrice.label) {
-    return formatNumber(value, { currency: 'USD' })
+    return formatNumber(numValue, { currency: 'USD' })
   }
 
-  if (value > 900000) {
-    return millify(value, 2)
+  if (numValue > 900000) {
+    return millify(numValue, 2)
   }
 
-  return value && value.toFixed ? value.toFixed(2) : value
+  return numValue.toFixed(2)
 }
-
-const PRICE_METRIC = 'historyPrice'
 
 class Charts extends React.Component {
   state = {

--- a/src/ducks/SANCharts/utils.js
+++ b/src/ducks/SANCharts/utils.js
@@ -153,7 +153,10 @@ export const METRIC_COLORS = [
   'waterloo'
 ]
 
-export const generateMetricsMarkup = (metrics, { ref, data } = {}) => {
+export const generateMetricsMarkup = (
+  metrics,
+  { ref = {}, data = {} } = {}
+) => {
   let colorIndex = 0
   return metrics.reduce((acc, metric) => {
     const {

--- a/src/ducks/SANCharts/utils.js
+++ b/src/ducks/SANCharts/utils.js
@@ -153,7 +153,7 @@ export const METRIC_COLORS = [
   'waterloo'
 ]
 
-export const generateMetricsMarkup = (metrics, ref = {}) => {
+export const generateMetricsMarkup = (metrics, { ref, data } = {}) => {
   let colorIndex = 0
   return metrics.reduce((acc, metric) => {
     const {

--- a/src/ducks/SANCharts/utils.js
+++ b/src/ducks/SANCharts/utils.js
@@ -153,7 +153,7 @@ export const METRIC_COLORS = [
   'waterloo'
 ]
 
-export const generateMetricsMarkup = (metrics, data = {}) => {
+export const generateMetricsMarkup = (metrics, ref = {}) => {
   let colorIndex = 0
   return metrics.reduce((acc, metric) => {
     const {
@@ -185,8 +185,8 @@ export const generateMetricsMarkup = (metrics, data = {}) => {
         type='linear'
         yAxisId={`axis-${dataKey}`}
         name={label}
-        data={data[dataKey]}
         strokeWidth={1.5}
+        ref={ref[metric]}
         dataKey={dataKey}
         dot={false}
         isAnimationActive={false}

--- a/src/ducks/Signals/VisualBacktestChart.js
+++ b/src/ducks/Signals/VisualBacktestChart.js
@@ -47,6 +47,7 @@ const VisualBacktestChart = ({ data, price, metrics, showAxes = false }) => {
         <YAxis hide />
 
         {generateMetricsMarkup(metrics, {
+          // NOTE(vanguard): Why?
           active_addresses: formattedData
         })}
 

--- a/src/ducks/Signals/VisualBacktestChart.js
+++ b/src/ducks/Signals/VisualBacktestChart.js
@@ -47,8 +47,9 @@ const VisualBacktestChart = ({ data, price, metrics, showAxes = false }) => {
         <YAxis hide />
 
         {generateMetricsMarkup(metrics, {
-          // NOTE(vanguard): Why?
-          active_addresses: formattedData
+          data: {
+            active_addresses: formattedData
+          }
         })}
 
         {formattedData


### PR DESCRIPTION
### Summary
- Horizontal/Vertical reference lines on the chart hover (`historyPrice` metric referenced in a first place, if it's absent - the first available metric);
- Displaying `x`, `y` value labels of the hovered point;
- Static tooltip position at the top-left;

### Screenshots
![references](https://media.giphy.com/media/f4DgS3gwFrWfQ1lTiM/giphy.gif)
With zoom
![image](https://user-images.githubusercontent.com/25135650/61145534-65428a80-a4e0-11e9-86c5-9e2578396e81.png)
