### PR TITLE
enhance/chart-intervals

### DIFF
--- a/src/ducks/SANCharts/ChartSettings.js
+++ b/src/ducks/SANCharts/ChartSettings.js
@@ -34,7 +34,7 @@ const ChartSettings = ({
       />
       <div className={styles.settings__right}>
         <Selector
-          options={['1d', '5d', '1w', '1m', '3m', '6m', '1y', 'all']}
+          options={['1d', '1w', '1m', '3m', '6m', '1y', 'all']}
           onSelectOption={onTimerangeChange}
           defaultSelected={defaultTimerange}
           className={styles.ranges}

--- a/src/ducks/SANCharts/IntervalSelector.js
+++ b/src/ducks/SANCharts/IntervalSelector.js
@@ -27,8 +27,11 @@ const getAvailableIntervals = (from, to) => {
       '1h'
     ]
   }
-  if (diff < 33) {
+  if (diff < 20) {
     return ['1h', '2h', '3h']
+  }
+  if (diff < 33) {
+    return ['2h', '3h', '4h']
   }
   if (diff < 63) {
     return ['6h', '8h', '12h']


### PR DESCRIPTION
### Summary
- Fixing complexity error for a `1m` timerange with a `1h` interval by changing minimal interval to `2h`;
- Removing `5d` timeRange;