### PR TITLE
enhance/no-bars-y-ref-line

### DIFF
--- a/src/ducks/SANCharts/Chart.module.scss
+++ b/src/ducks/SANCharts/Chart.module.scss
@@ -99,6 +99,13 @@
     height: 1px;
     transform: translateY(var(--y));
   }
+
+  &_noY {
+    &::after,
+    .values::after {
+      display: none;
+    }
+  }
 }
 
 .values {

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -214,7 +214,7 @@ class Charts extends React.Component {
                 })}
               </div>
               <div
-                className={styles.line}
+                className={cx(styles.line, !y && styles.line_noY)}
                 style={{
                   '--x': `${x}px`,
                   '--y': `${y}px`


### PR DESCRIPTION
### Summary
Hiding `Y-Reference` line when `y` value was not found