### PR TITLE
enhance/no-data-metric

### DIFF
--- a/src/ducks/SANCharts/ChartMetricSelector.js
+++ b/src/ducks/SANCharts/ChartMetricSelector.js
@@ -83,6 +83,7 @@ const ChartMetricSelector = ({
               {categories[activeCategory] &&
                 categories[activeCategory].map(metric => {
                   const isActive = activeMetrics.includes(metric.key)
+                  const isDisabled = disabledMetrics.includes(metric.key)
                   return (
                     <Button
                       key={metric.label}
@@ -93,10 +94,16 @@ const ChartMetricSelector = ({
                       onMouseEnter={() => setMetric(metric)}
                       onClick={() => toggleMetric(metric.key)}
                       isActive={isActive}
-                      disabled={disabledMetrics.includes(metric.key)}
+                      disabled={isDisabled}
                     >
                       {metric.label}{' '}
-                      <Icon type={isActive ? 'subtract-round' : 'plus-round'} />
+                      {isDisabled ? (
+                        <span className={styles.btn_disabled}>no data</span>
+                      ) : (
+                        <Icon
+                          type={isActive ? 'subtract-round' : 'plus-round'}
+                        />
+                      )}
                     </Button>
                   )
                 })}

--- a/src/ducks/SANCharts/ChartMetricSelector.module.scss
+++ b/src/ducks/SANCharts/ChartMetricSelector.module.scss
@@ -37,6 +37,15 @@
 
 .btn {
   justify-content: space-between;
+
+  &_disabled {
+    @include text('caption');
+
+    background: var(--athens);
+    color: var(--casper);
+    padding: 0 4px;
+    border-radius: 4px;
+  }
 }
 
 .title {

--- a/src/ducks/SANCharts/ChartPage.module.scss
+++ b/src/ducks/SANCharts/ChartPage.module.scss
@@ -3,6 +3,7 @@
 .settings {
   display: flex;
   padding: 10px;
+  padding-left: 20px;
   justify-content: space-between;
 
   &__right {


### PR DESCRIPTION
### Summary
Displaying `no data` label for metrics with empty data;

### Screenshots
![image](https://user-images.githubusercontent.com/25135650/61350856-9c62c400-a871-11e9-8775-19b167775262.png)
