### PR TITLE
fix: replaced tg label 'Connected' by 'Reconnect'

### DIFF
--- a/src/pages/Account/SettingsConnections.js
+++ b/src/pages/Account/SettingsConnections.js
@@ -20,7 +20,7 @@ const getMetamaskBtnText = (address, connecting) => {
 
 const getTelegramBtnText = (connected, connecting) => {
   if (connected) {
-    return 'Connected'
+    return 'Reconnect'
   }
 
   return connecting ? 'Connecting' : 'Connect'


### PR DESCRIPTION
Done:
* replaced telegram label
![image](https://user-images.githubusercontent.com/14061779/61372721-96380c00-a8a0-11e9-9b40-ddf93f02e900.png)
