### PR TITLE
feature/chart-datetime-scale

### DIFF
--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -256,10 +256,14 @@ class Charts extends React.Component {
             }}
             onMouseMove={this.onMouseMove}
             onMouseUp={refAreaLeft && refAreaRight && this.onZoom}
-            data={chartData}
+            data={chartData.map(({ datetime, ...rest }) => ({
+              ...rest,
+              datetime: +new Date(datetime)
+            }))}
           >
             <XAxis
               dataKey='datetime'
+              scale='time'
               tickLine={false}
               minTickGap={100}
               tickFormatter={tickFormatter}

--- a/src/ducks/Signals/chart/SignalPreview.js
+++ b/src/ducks/Signals/chart/SignalPreview.js
@@ -133,7 +133,11 @@ const SignalPreview = ({ type, points = [], target: slug, height }) => {
           }}
         >
           {triggeredSignals.map(({ datetime }) => (
-            <ReferenceLine key={datetime} stroke='green' x={datetime} />
+            <ReferenceLine
+              key={datetime}
+              stroke='green'
+              x={+new Date(datetime)}
+            />
           ))}
         </ChartWidget>
       </ChartExpandView>


### PR DESCRIPTION
### Summary
Moving `/chart` widget from `linear` to a `time` scale 