### PR TITLE
5536: fixed price explanation label and default value for PV signals

### DIFF
--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/TriggerFormMetricValues.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/TriggerFormMetricValues.js
@@ -29,13 +29,17 @@ export const TriggerFormMetricValues = ({
     absoluteBorderLeft = 0,
     percentThreshold,
     timeWindowUnit,
-    timeWindow
+    timeWindow,
+    target
   },
   lastPrice
 }) => {
   const metricValue = getFormMetricValue(type)
 
   const isPriceMetric = metric.value === PRICE
+
+  const isSingleTarget =
+    target && ((Array.isArray(target) && target.length === 1) || !!target.value)
 
   const isTimeWindow = METRIC_TYPES_DEPENDENCIES[metricValue].includes(
     'timeWindow'
@@ -56,7 +60,9 @@ export const TriggerFormMetricValues = ({
             step='any'
             placeholder='Upper border'
           />
-          {isPriceMetric && <LastPriceComponent lastPrice={lastPrice} />}
+          {isPriceMetric && isSingleTarget && (
+            <LastPriceComponent lastPrice={lastPrice} />
+          )}
         </div>
       )}
       {type &&
@@ -86,7 +92,9 @@ export const TriggerFormMetricValues = ({
             placeholder='Absolute value'
             prefix={isPriceMetric ? '$' : ''}
           />
-          {isPriceMetric && <LastPriceComponent lastPrice={lastPrice} />}
+          {isPriceMetric && isSingleTarget && (
+            <LastPriceComponent lastPrice={lastPrice} />
+          )}
         </div>
       )}
 
@@ -100,7 +108,9 @@ export const TriggerFormMetricValues = ({
             prefix='%'
             placeholder='Percentage amount'
           />
-          {isPriceMetric && <LastPriceComponent lastPrice={lastPrice} />}
+          {isPriceMetric && isSingleTarget && (
+            <LastPriceComponent lastPrice={lastPrice} />
+          )}
         </div>
       )}
 

--- a/src/ducks/Signals/utils/constants.js
+++ b/src/ducks/Signals/utils/constants.js
@@ -169,7 +169,7 @@ export const METRIC_TO_TYPES = {
 }
 
 export const METRIC_TYPES_DEPENDENCIES = {
-  [PRICE_VOLUME_DIFFERENCE]: ['threshold'],
+  [PRICE_VOLUME_DIFFERENCE]: [],
   [DAILY_ACTIVE_ADDRESSES]: ['percentThreshold', 'timeWindow'],
   [PRICE_PERCENT_CHANGE]: ['percentThreshold', 'timeWindow'],
   [PRICE_ABSOLUTE_CHANGE_SINGLE_BORDER]: ['absoluteThreshold'],
@@ -258,7 +258,7 @@ export const METRIC_TARGET_OPTIONS = [
   METRIC_TARGET_WATCHLIST
 ]
 
-export const BASE_THRESHOLD = 0.002
+export const BASE_THRESHOLD = 0.002 // # DEFAULT FOR PV-signals. Do't change!
 export const BASE_PERCENT_THRESHOLD = 5
 
 const DEFAULT_TARGET = {

--- a/src/ducks/Signals/utils/utils.js
+++ b/src/ducks/Signals/utils/utils.js
@@ -552,13 +552,13 @@ export const mapFormToDAATriggerSettings = formProps => {
 }
 
 export const mapFormToPVDTriggerSettings = formProps => {
-  const { target, threshold, signalType } = formProps
+  const { target, signalType } = formProps
   const newTarget = mapTriggerTarget(target, signalType)
   return {
     type: PRICE_VOLUME_DIFFERENCE,
     ...newTarget,
     channel: getChannels(formProps),
-    threshold: threshold
+    threshold: BASE_THRESHOLD
   }
 }
 


### PR DESCRIPTION
Done:
* not show price explanation label if for than 1 slug selected
* default 0.002 threshold for PV-signals