### PR TITLE
feature/chart-metric-selector-groups

### DIFF
--- a/src/ducks/SANCharts/ChartMetricSelector.js
+++ b/src/ducks/SANCharts/ChartMetricSelector.js
@@ -180,7 +180,7 @@ const ChartMetricSelector = ({
           <div className={styles.visible}>
             {activeMetric && (
               <div className={styles.visible__scroll}>
-                <h3 className={styles.title}>{activeMetric.label}</h3>
+                <h4 className={styles.title}>{activeMetric.label}</h4>
                 <p className={styles.text}>{activeMetric.description}</p>
               </div>
             )}

--- a/src/ducks/SANCharts/ChartMetricSelector.js
+++ b/src/ducks/SANCharts/ChartMetricSelector.js
@@ -14,9 +14,9 @@ const NO_GROUP = '_'
 const DEFAULT_CATEGORIES = {
   Financial: [
     {
-      label: 'Price',
-    },
-  ],
+      label: 'Price'
+    }
+  ]
 }
 
 const addItemToGraph = (categories, metricCategory, metrics) => {
@@ -75,8 +75,6 @@ const getCategoryGraph = availableMetrics => {
     }, {})
   })
 
-  console.log(categories)
-
   memo.lastInput = availableMetrics
   memo.result = categories
 
@@ -109,20 +107,20 @@ const ChartMetricSelector = ({
   toggleMetric,
   activeMetrics,
   disabledMetrics,
-  data: { project: { availableMetrics = [] } = {}, loading },
+  data: { project: { availableMetrics = [] } = {}, loading }
 }) => {
   const categories = getCategoryGraph(availableMetrics)
 
   const [activeCategory, setCategory] = React.useState('Financial')
   const [activeMetric, setMetric] = React.useState(
-    DEFAULT_CATEGORIES.Financial[0],
+    DEFAULT_CATEGORIES.Financial[0]
   )
 
   useEffect(
     () => () => {
       memo = {}
     },
-    [],
+    []
   )
 
   return (
@@ -196,5 +194,5 @@ const ChartMetricSelector = ({
 export default graphql(PROJECT_METRICS_BY_SLUG_QUERY, {
   options: ({ slug }) => {
     return { variables: { slug } }
-  },
+  }
 })(ChartMetricSelector)

--- a/src/ducks/SANCharts/ChartMetricSelector.js
+++ b/src/ducks/SANCharts/ChartMetricSelector.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import cx from 'classnames'
 import { graphql } from 'react-apollo'
 import Panel from '@santiment-network/ui/Panel/Panel'
@@ -9,15 +9,17 @@ import { PROJECT_METRICS_BY_SLUG_QUERY } from './gql'
 import { Metrics } from './utils'
 import styles from './ChartMetricSelector.module.scss'
 
+const NO_GROUP = '_'
+
 const DEFAULT_CATEGORIES = {
   Financial: [
     {
-      label: 'Price'
-    }
-  ]
+      label: 'Price',
+    },
+  ],
 }
 
-const addMetricToCategory = (categories, metricCategory, metrics) => {
+const addItemToGraph = (categories, metricCategory, metrics) => {
   const category = categories[metricCategory]
   if (category) {
     category.push(...metrics)
@@ -26,7 +28,17 @@ const addMetricToCategory = (categories, metricCategory, metrics) => {
   }
 }
 
+let memo = {}
+
 const getCategoryGraph = availableMetrics => {
+  if (availableMetrics.length === 0) {
+    return {}
+  }
+
+  if (memo.lastInput === availableMetrics) {
+    return memo.result
+  }
+
   const categories = {}
   const { length } = availableMetrics
 
@@ -40,7 +52,7 @@ const getCategoryGraph = availableMetrics => {
 
     if (Array.isArray(targetMetric)) {
       const metricCategory = targetMetric[0].category
-      addMetricToCategory(categories, metricCategory, targetMetric)
+      addItemToGraph(categories, metricCategory, targetMetric)
       continue
     }
 
@@ -52,10 +64,44 @@ const getCategoryGraph = availableMetrics => {
       metrics.push({ ...Metrics.volume, key: 'volume' })
     }
 
-    addMetricToCategory(categories, metricCategory, metrics)
+    addItemToGraph(categories, metricCategory, metrics)
   }
 
+  Object.keys(categories).forEach(key => {
+    categories[key] = categories[key].reduce((acc, metric) => {
+      const { group = NO_GROUP } = metric
+      addItemToGraph(acc, group, [metric])
+      return acc
+    }, {})
+  })
+
+  console.log(categories)
+
+  memo.lastInput = availableMetrics
+  memo.result = categories
+
   return categories
+}
+
+const ActionBtn = ({ children, isActive, isDisabled, ...props }) => {
+  return (
+    <Button
+      variant='ghost'
+      fluid
+      className={styles.btn}
+      classes={styles}
+      isActive={isActive}
+      disabled={isDisabled}
+      {...props}
+    >
+      {children}{' '}
+      {isDisabled ? (
+        <span className={styles.btn_disabled}>no data</span>
+      ) : (
+        <Icon type={isActive ? 'subtract-round' : 'plus-round'} />
+      )}
+    </Button>
+  )
 }
 
 const ChartMetricSelector = ({
@@ -63,13 +109,20 @@ const ChartMetricSelector = ({
   toggleMetric,
   activeMetrics,
   disabledMetrics,
-  data: { project: { availableMetrics = [] } = {}, loading }
+  data: { project: { availableMetrics = [] } = {}, loading },
 }) => {
   const categories = getCategoryGraph(availableMetrics)
 
   const [activeCategory, setCategory] = React.useState('Financial')
   const [activeMetric, setMetric] = React.useState(
-    DEFAULT_CATEGORIES.Financial[0]
+    DEFAULT_CATEGORIES.Financial[0],
+  )
+
+  useEffect(
+    () => () => {
+      memo = {}
+    },
+    [],
   )
 
   return (
@@ -99,32 +152,29 @@ const ChartMetricSelector = ({
           <div className={styles.visible}>
             <div className={styles.visible__scroll}>
               {categories[activeCategory] &&
-                categories[activeCategory].map(metric => {
-                  const isActive = activeMetrics.includes(metric.key)
-                  const isDisabled = disabledMetrics.includes(metric.key)
-                  return (
-                    <Button
-                      key={metric.label}
-                      variant='ghost'
-                      fluid
-                      className={styles.btn}
-                      classes={styles}
-                      onMouseEnter={() => setMetric(metric)}
-                      onClick={() => toggleMetric(metric.key)}
-                      isActive={isActive}
-                      disabled={isDisabled}
-                    >
-                      {metric.label}{' '}
-                      {isDisabled ? (
-                        <span className={styles.btn_disabled}>no data</span>
-                      ) : (
-                        <Icon
-                          type={isActive ? 'subtract-round' : 'plus-round'}
-                        />
-                      )}
-                    </Button>
-                  )
-                })}
+                Object.keys(categories[activeCategory]).map(group => (
+                  <div key={group} className={styles.group}>
+                    {group !== NO_GROUP && (
+                      <h3 className={styles.group__title}>{group}</h3>
+                    )}
+                    {categories[activeCategory][group].map(metric => {
+                      const isActive = activeMetrics.includes(metric.key)
+                      const isDisabled = disabledMetrics.includes(metric.key)
+
+                      return (
+                        <ActionBtn
+                          key={metric.label}
+                          onMouseEnter={() => setMetric(metric)}
+                          onClick={() => toggleMetric(metric.key)}
+                          isActive={isActive}
+                          isDisabled={isDisabled}
+                        >
+                          {metric.label}
+                        </ActionBtn>
+                      )
+                    })}
+                  </div>
+                ))}
             </div>
           </div>
         </div>
@@ -146,5 +196,5 @@ const ChartMetricSelector = ({
 export default graphql(PROJECT_METRICS_BY_SLUG_QUERY, {
   options: ({ slug }) => {
     return { variables: { slug } }
-  }
+  },
 })(ChartMetricSelector)

--- a/src/ducks/SANCharts/ChartMetricSelector.module.scss
+++ b/src/ducks/SANCharts/ChartMetricSelector.module.scss
@@ -20,8 +20,7 @@
   border-right: 1px solid var(--porcelain);
 }
 
-.category,
-.metrics {
+.category {
   padding: 8px;
 }
 
@@ -81,8 +80,12 @@
   }
 }
 
-.active {
+.categories .active {
   background: var(--athens);
+}
+
+.metrics .active {
+  fill: var(--casper);
 }
 
 .constraint {
@@ -90,4 +93,20 @@
 
   color: var(--waterloo);
   margin: 0;
+}
+
+.group {
+  padding: 12px 8px 8px;
+  border-bottom: 1px solid var(--porcelain);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &__title {
+    @include text('caption', 'm');
+
+    color: var(--waterloo);
+    margin: 12px 12px 8px;
+  }
 }

--- a/src/ducks/SANCharts/utils.js
+++ b/src/ducks/SANCharts/utils.js
@@ -11,90 +11,91 @@ export const Metrics = {
     category: 'Financial'
   },
   volume: {
+    category: 'Financial',
     node: Bar,
     label: 'Volume',
     fill: true,
     dataKey: 'volume',
-    category: 'Financial',
     color: 'waterloo',
     opacity: 0.4
   },
   socialVolume: {
+    category: 'Social',
+    group: 'Group 2',
     node: Bar,
     label: 'Social Volume',
-    color: 'malibu',
-    category: 'Social'
+    color: 'malibu'
   },
   tokenAgeConsumed: {
+    category: 'On-chain',
     node: Bar,
     label: 'Token Age Consumed',
     fill: true,
-    category: 'On-chain',
     description:
       'The amount of movement of tokens between addresses. One use for this metric is to spot large amounts of tokens moving after sitting for a long period of time.'
   },
   exchangeFundsFlow: {
+    category: 'On-chain',
     node: Line,
     label: 'Exchange Flow Balance',
-    category: 'On-chain',
     description:
       'The flows of tokens going in to and out of exchange wallets combined on one graph. If the value is positive, more tokens entered the exchange than left. If the value is negative, more flowed out of exchanges than flowed in.'
   },
   dailyActiveAddresses: {
+    category: 'On-chain',
     node: Bar,
     label: 'Daily Active Addresses',
-    category: 'On-chain',
     description:
       'The number of unique addresses that participated in transactions for a given day.',
     color: 'texas-rose'
   },
   percentOfTokenSupplyOnExchanges: {
+    category: 'On-chain',
     node: Line,
     label: 'Percent of Token Supply on Exchanges',
-    dataKey: 'percentOnExchanges',
-    category: 'On-chain'
+    dataKey: 'percentOnExchanges'
   },
   topHoldersPercentOfTotalSupply: {
+    category: 'On-chain',
     node: Line,
     label: 'In Top Holders Total',
     // TODO: Add support for 3 datakeys of single metric:
     // inExchanges outsideExchanges inTopHoldersTotal
-    dataKey: 'inTopHoldersTotal',
-    category: 'On-chain'
+    dataKey: 'inTopHoldersTotal'
   },
   tokenCirculation: {
+    category: 'On-chain',
     node: Line,
     label: 'Token Circulation',
-    category: 'On-chain',
     description:
       "The distribution of non-transacted tokens over time (in other words, how many tokens are being hodled, and for how long). The green line shows the token price. Each of the other coloured bands represents the number of tokens that haven't moved (have stayed in the same wallet) for the specified amount of time."
   },
   mvrvRatio: {
+    category: 'On-chain',
     node: Line,
     label: 'Market Value To Realized Value',
-    category: 'On-chain',
     dataKey: 'mvrv'
   },
   transactionVolume: {
+    category: 'On-chain',
     node: Bar,
     label: 'Transaction Volume',
-    category: 'On-chain',
     description:
       'The total number of tokens within all transfers that have occurred on the network. This metric can show a large amount of tokens moving at once, and/or a large number of transactions in a short amount of time'
   },
   networkGrowth: {
+    category: 'On-chain',
     node: Line,
     label: 'Network Growth',
-    category: 'On-chain',
     description:
       'The number of new addresses being created on the network each day.'
   },
   devActivity: {
+    category: 'Development',
     node: Line,
     color: 'heliotrope',
     label: 'Development Activity',
     dataKey: 'activity',
-    category: 'Development',
     description:
       "Based on number of Github 'events' including issue interactions, PRs, comments, and wiki edits, plus the number of public repositories a project is maintaining",
     reqMeta: {
@@ -103,51 +104,53 @@ export const Metrics = {
     }
   },
   tokenVelocity: {
+    category: 'On-chain',
     node: Line,
     label: 'Token Velocity',
-    category: 'On-chain',
     description:
       'Similar to velocity of money, Token Velocity is the frequency at which tokens change wallets in a given interval of time. This metric is derived by dividing transaction volume by the number of tokens in circulation, to get the average number of times a token changes hands each day.'
   },
   dailyActiveDeposits: {
+    category: 'On-chain',
     node: Bar,
     label: 'Daily Active Deposits',
-    dataKey: 'activeDeposits',
-    category: 'On-chain'
+    dataKey: 'activeDeposits'
   },
   historyTwitterData: {
+    category: 'Social',
+    group: 'Group 1',
     node: Line,
     label: 'Twitter',
-    category: 'Social',
     dataKey: 'followersCount'
   },
   socialDominance: {
+    category: 'Social',
+    group: 'Group 2',
     node: Line,
     label: 'Social Dominance',
-    category: 'Social',
     dataKey: 'dominance'
   },
   realizedValue: {
+    category: 'On-chain',
     node: Line,
     label: 'Realized Value',
-    category: 'On-chain',
     dataKey: 'realizedValue'
   },
   ethSpentOverTime: {
+    category: 'On-chain',
     node: Line,
     label: 'Eth Spent Over Time',
-    category: 'On-chain',
     dataKey: 'ethSpent'
   }
 }
 
 const DerivedMetrics = [
   {
+    category: 'On-chain',
     parent: 'nvtRatio',
     key: 'nvtRatioCirculation',
     node: Line,
-    label: 'NVT Ratio Circulation',
-    category: 'On-chain'
+    label: 'NVT Ratio Circulation'
   },
   {
     parent: 'nvtRatio',


### PR DESCRIPTION
### Summary
- Adding support for grouping metrics by adding [`group` field to the metric](https://github.com/santiment/app/pull/482/files#diff-6484b8b3dcc9e3cb29c7ac1a5b5d5cabR24);
- [Memoizing metrics graph](https://github.com/santiment/app/pull/482/files#diff-c50bc933e1d9c74c1d53114a529360b5R78) calculation for faster rendering;
- Selected metric no longer has background;
- Selected metric minus now has a `porcelain` fill;

### Screenshots
![image](https://user-images.githubusercontent.com/25135650/62207221-48d99580-b39c-11e9-8744-af73a68a4010.png)
