### PR TITLE
enhance/settings-api-keys

### DIFF
--- a/src/components/SubscriptionCancelDialog/CancellationScreen.js
+++ b/src/components/SubscriptionCancelDialog/CancellationScreen.js
@@ -9,7 +9,7 @@ const CancellationScreen = ({
   cancelSubscription,
   addNot,
   id,
-  loading,
+  loading
 }) => {
   return (
     <>
@@ -39,7 +39,7 @@ const CancellationScreen = ({
           isLoading={loading}
           onClick={() =>
             cancelSubscription({
-              variables: { subscriptionId: +id },
+              variables: { subscriptionId: +id }
             })
               .then(() => {
                 closeDialog()
@@ -47,7 +47,7 @@ const CancellationScreen = ({
                   variant: 'success',
                   title: `You have successfully canceled your subscription.`,
                   description: 'We will miss you!',
-                  dismissAfter: 5000,
+                  dismissAfter: 5000
                 })
               })
               .catch(e =>
@@ -56,8 +56,8 @@ const CancellationScreen = ({
                   title: `Error during the cancellation`,
                   description: formatError(e.message),
                   dismissAfter: 5000,
-                  actions: contactAction,
-                }),
+                  actions: contactAction
+                })
               )
           }
         >

--- a/src/pages/Account/SettingsAPIKeys.js
+++ b/src/pages/Account/SettingsAPIKeys.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { Icon, Label, Button } from '@santiment-network/ui'
+import Icon from '@santiment-network/ui/Icon'
+import Label from '@santiment-network/ui/Label'
+import Button from '@santiment-network/ui/Button'
 import copy from 'copy-to-clipboard'
 import Settings from './Settings'
 import * as actions from '../../actions/types'
@@ -10,7 +12,7 @@ const SettingsAPIKeys = ({ apikey, generateAPIKey, revokeAPIKey }) => (
   <Settings id='api-keys' header='API keys'>
     <Settings.Row>
       <div className={styles.setting__left}>
-        <Label>API Keys</Label>
+        <Label>Neuro API</Label>
         <Label className={styles.setting__description} accent='waterloo'>
           The api key will give you access to the data that requires SAN token
           staking.
@@ -40,8 +42,15 @@ const SettingsAPIKeys = ({ apikey, generateAPIKey, revokeAPIKey }) => (
               </Button>
             </>
           ) : (
-            <Button onClick={generateAPIKey} variant='fill' accent='positive'>
-              Generate
+            <Button
+              as='a'
+              href='https://neuro.santiment.net/account/'
+              rel='noopener noreferrer'
+              target='_blank'
+              variant='fill'
+              accent='positive'
+            >
+              Explore Neuro
             </Button>
           )}
         </div>

--- a/src/pages/Account/SettingsAPIKeys.js
+++ b/src/pages/Account/SettingsAPIKeys.js
@@ -44,7 +44,7 @@ const SettingsAPIKeys = ({ apikey, generateAPIKey, revokeAPIKey }) => (
           ) : (
             <Button
               as='a'
-              href='https://neuro.santiment.net/account/'
+              href='https://neuro.santiment.net/account#api-keys'
               rel='noopener noreferrer'
               target='_blank'
               variant='fill'

--- a/src/pages/Account/SettingsSubscription.js
+++ b/src/pages/Account/SettingsSubscription.js
@@ -12,13 +12,13 @@ import { getCurrentSanbaseSubscription, formatPrice } from '../../utils/plans'
 import { getDateFormats } from '../../utils/dates'
 import {
   USER_SUBSCRIPTIONS_QUERY,
-  RENEW_SUBSCRIPTION_MUTATION,
+  RENEW_SUBSCRIPTION_MUTATION
 } from '../../queries/plans'
 import styles from './SettingsSubscription.module.scss'
 
 const PERIOD_END_ACTION = {
   false: 'renew',
-  true: 'cancel',
+  true: 'cancel'
 }
 
 const PlanText = ({ subscription }) => {
@@ -26,7 +26,7 @@ const PlanText = ({ subscription }) => {
     const {
       currentPeriodEnd,
       cancelAtPeriodEnd,
-      plan: { amount, name, interval },
+      plan: { amount, name, interval }
     } = subscription
 
     const { MMMM, DD, YYYY } = getDateFormats(new Date(currentPeriodEnd))


### PR DESCRIPTION
### Summary
If user does not have API key, leading him to a `Neuro` page;
### Screenshot
![image](https://user-images.githubusercontent.com/25135650/62249663-97fee500-b3f3-11e9-9f7f-d88914665971.png)
