### PR TITLE
enhance/chart-paywall-boundaries

### DIFF
--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -239,7 +239,9 @@ class ChartPage extends Component {
       hideSettings = {},
       classes = {},
       adjustNightMode,
-      children
+      children,
+      leftBoundaryDate,
+      rightBoundaryDate
     } = this.props
 
     const requestedMetrics = metrics.reduce((acc, metric) => {
@@ -329,6 +331,8 @@ class ChartPage extends Component {
                     settings={settings}
                     title={title}
                     metrics={finalMetrics}
+                    leftBoundaryDate={leftBoundaryDate}
+                    rightBoundaryDate={rightBoundaryDate}
                     children={children}
                   />
                 </div>

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -174,6 +174,8 @@ class Charts extends React.Component {
       title,
       isZoomed,
       hasPremium,
+      leftBoundaryDate,
+      rightBoundaryDate,
       children
     } = this.props
     const {
@@ -285,6 +287,8 @@ class Charts extends React.Component {
             )}
             {!hasPremium &&
               displayPaywall({
+                leftBoundaryDate,
+                rightBoundaryDate,
                 data: chartData
               })}
             {chartData.length > 0 && (

--- a/src/ducks/SANCharts/Paywall.js
+++ b/src/ducks/SANCharts/Paywall.js
@@ -65,23 +65,25 @@ const getPaywallX = (array, target, rawEstimate) => {
 
 const displayPaywall = ({
   data,
-  leftHistoricalDate = LEFT_HISTORICAL_DATE,
-  rightHistoricalDate = RIGHT_HISTORICAL_DATE
+  leftBoundaryDate = LEFT_HISTORICAL_DATE,
+  rightBoundaryDate = RIGHT_HISTORICAL_DATE
 }) => {
   if (!data || !data.length) return
 
   const lastItemDate = new Date(data[data.length - 1].datetime)
   const firstItemDate = new Date(data[0].datetime)
 
-  const isInsideLeftPaywall = lastItemDate <= leftHistoricalDate
-  const isInsideRightPaywall = firstItemDate >= rightHistoricalDate
+  const isInsideLeftPaywall = lastItemDate <= leftBoundaryDate
+  const isInsideRightPaywall = firstItemDate >= rightBoundaryDate
 
   const hasLeftPaywall =
-    isInsideLeftPaywall ||
-    (!isInsideRightPaywall && leftHistoricalDate >= firstItemDate)
+    leftBoundaryDate &&
+    (isInsideLeftPaywall ||
+      (!isInsideRightPaywall && leftBoundaryDate >= firstItemDate))
   const hasRightPaywall =
-    isInsideRightPaywall ||
-    (!isInsideLeftPaywall && rightHistoricalDate <= lastItemDate)
+    rightBoundaryDate &&
+    (isInsideRightPaywall ||
+      (!isInsideLeftPaywall && rightBoundaryDate <= lastItemDate))
 
   return [
     hasLeftPaywall && (
@@ -90,7 +92,7 @@ const displayPaywall = ({
         x2={
           isInsideLeftPaywall
             ? +lastItemDate
-            : getPaywallX(data, leftHistoricalDate)
+            : getPaywallX(data, leftBoundaryDate)
         }
         {...AREA_STYLES}
       />
@@ -101,7 +103,7 @@ const displayPaywall = ({
         x1={
           isInsideRightPaywall
             ? +firstItemDate
-            : getPaywallX(data, rightHistoricalDate)
+            : getPaywallX(data, rightBoundaryDate)
         }
         {...AREA_STYLES}
       />

--- a/src/pages/Chart/index.js
+++ b/src/pages/Chart/index.js
@@ -1,11 +1,14 @@
 import React from 'react'
 import GA from 'react-ga'
-import { graphql } from 'react-apollo'
+import { graphql, Query } from 'react-apollo'
 import ChartWidget from '../../ducks/SANCharts/ChartPage'
 import InsightsWrap from '../../components/Insight/InsightsWrap'
 import AnonBannerCardB from '../../components/Banner/AnonBanner/AnonBannerCardB'
 import { ALL_INSIGHTS_BY_PAGE_QUERY } from '../../queries/InsightsGQL'
+import { USER_SUBSCRIPTIONS_QUERY } from '../../queries/plans'
 import { creationDateSort } from '../Insights/utils'
+import { getCurrentSanbaseSubscription } from '../../utils/plans'
+import paywallBoundaries from './paywallBoundaries'
 import styles from './index.module.scss'
 
 function onGetStartedClick () {
@@ -24,14 +27,25 @@ export default graphql(ALL_INSIGHTS_BY_PAGE_QUERY, {
   const sortedInsights = insights.sort(creationDateSort).slice(0, 6)
   return (
     <div className={styles.wrapper + ' page'}>
-      <ChartWidget
-        adjustNightMode={false}
-        slug='bitcoin'
-        title='Bitcoin (BTC)'
-        projectId='1505'
-        metrics={['historyPrice', 'mvrvRatio', 'socialVolume']}
-        classes={styles}
-      />
+      <Query query={USER_SUBSCRIPTIONS_QUERY}>
+        {({ data: { currentUser } }) => {
+          const subscription = getCurrentSanbaseSubscription(currentUser)
+          const userPlan = subscription ? subscription.plan.name : 'FREE'
+          const boundaries = paywallBoundaries[userPlan]
+
+          return (
+            <ChartWidget
+              adjustNightMode={false}
+              slug='bitcoin'
+              title='Bitcoin (BTC)'
+              projectId='1505'
+              metrics={['historyPrice', 'mvrvRatio', 'socialVolume']}
+              classes={styles}
+              {...boundaries}
+            />
+          )
+        }}
+      </Query>
       {isLoggedIn || (
         <AnonBannerCardB
           onClick={onGetStartedClick}

--- a/src/pages/Chart/paywallBoundaries.js
+++ b/src/pages/Chart/paywallBoundaries.js
@@ -1,0 +1,25 @@
+import { getTimeIntervalFromToday, DAY, MONTH } from '../../utils/dates'
+
+const { from: FREE_LEFT_BOUNDARY_DATE } = getTimeIntervalFromToday(-24, MONTH)
+const { from: FREE_RIGHT_BOUNDARY_DATE } = getTimeIntervalFromToday(-1, MONTH)
+
+const { from: BASIC_LEFT_BOUNDARY_DATE } = getTimeIntervalFromToday(-24, MONTH)
+const { from: BASIC_RIGHT_BOUNDARY_DATE } = getTimeIntervalFromToday(-7, DAY)
+
+const { from: PRO_LEFT_BOUNDARY_DATE } = getTimeIntervalFromToday(-36, MONTH)
+const PRO_RIGHT_BOUNDARY_DATE = false
+
+export default {
+  FREE: {
+    leftBoundaryDate: FREE_LEFT_BOUNDARY_DATE,
+    rightBoundaryDate: FREE_RIGHT_BOUNDARY_DATE
+  },
+  BASIC: {
+    leftBoundaryDate: BASIC_LEFT_BOUNDARY_DATE,
+    rightBoundaryDate: BASIC_RIGHT_BOUNDARY_DATE
+  },
+  PRO: {
+    leftBoundaryDate: PRO_LEFT_BOUNDARY_DATE,
+    rightBoundaryDate: PRO_RIGHT_BOUNDARY_DATE
+  }
+}

--- a/src/pages/Chart/paywallBoundaries.js
+++ b/src/pages/Chart/paywallBoundaries.js
@@ -9,6 +9,9 @@ const { from: BASIC_RIGHT_BOUNDARY_DATE } = getTimeIntervalFromToday(-7, DAY)
 const { from: PRO_LEFT_BOUNDARY_DATE } = getTimeIntervalFromToday(-36, MONTH)
 const PRO_RIGHT_BOUNDARY_DATE = false
 
+const ENTERPRISE_LEFT_BOUNDARY_DATE = false
+const ENTERPRISE_RIGHT_BOUNDARY_DATE = false
+
 export default {
   FREE: {
     leftBoundaryDate: FREE_LEFT_BOUNDARY_DATE,
@@ -21,5 +24,9 @@ export default {
   PRO: {
     leftBoundaryDate: PRO_LEFT_BOUNDARY_DATE,
     rightBoundaryDate: PRO_RIGHT_BOUNDARY_DATE
+  },
+  ENTERPRISE: {
+    leftBoundaryDate: ENTERPRISE_LEFT_BOUNDARY_DATE,
+    rightBoundaryDate: ENTERPRISEPRO_RIGHT_BOUNDARY_DATE
   }
 }

--- a/src/pages/Chart/paywallBoundaries.js
+++ b/src/pages/Chart/paywallBoundaries.js
@@ -27,6 +27,6 @@ export default {
   },
   ENTERPRISE: {
     leftBoundaryDate: ENTERPRISE_LEFT_BOUNDARY_DATE,
-    rightBoundaryDate: ENTERPRISEPRO_RIGHT_BOUNDARY_DATE
+    rightBoundaryDate: ENTERPRISE_RIGHT_BOUNDARY_DATE
   }
 }


### PR DESCRIPTION
### Summary
Adjusting `Paywall` boundaries to the current user plan;

Boundaries:
- **FREE**: [`2 years`](https://github.com/santiment/app/pull/489/files#diff-623f67d5329459bdc6912f5471698fdaR3) and [`1 month`](https://github.com/santiment/app/pull/489/files#diff-623f67d5329459bdc6912f5471698fdaR4);
- **BASIC**: [`2 years`](https://github.com/santiment/app/pull/489/files#diff-623f67d5329459bdc6912f5471698fdaR6) and [`1 week`](https://github.com/santiment/app/pull/489/files#diff-623f67d5329459bdc6912f5471698fdaR7);
- **PRO**: [`3 years`](https://github.com/santiment/app/pull/489/files#diff-623f67d5329459bdc6912f5471698fdaR9) and [`no boundary`](https://github.com/santiment/app/pull/489/files#diff-623f67d5329459bdc6912f5471698fdaR10);
- **ENTERPRISE**: [`no boundary`](https://github.com/santiment/app/pull/489/files#diff-623f67d5329459bdc6912f5471698fdaR12) and [`no boundary`](https://github.com/santiment/app/pull/489/files#diff-623f67d5329459bdc6912f5471698fdaR13);