### PR TITLE
fix: mobile styles for headers of trigger blocks

### DIFF
--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/block/TriggerFormBlock.module.scss
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/block/TriggerFormBlock.module.scss
@@ -54,7 +54,7 @@
   margin-left: 5px;
 
   @include responsive('phone', 'phone-xs') {
-    margin: 0;
+    margin-left: 0;
   }
 }
 
@@ -68,5 +68,10 @@
 
 .headerContent {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex: 1;
+
+  @include responsive('phone', 'phone-xs') {
+    flex-direction: column;
+  }
 }

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricTypes/TriggerFormMetricTypes.module.scss
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricTypes/TriggerFormMetricTypes.module.scss
@@ -18,8 +18,11 @@
 }
 
 .textBlocks {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+
   @include responsive('phone', 'phone-xs') {
-    display: flex;
     flex-direction: column;
   }
 }


### PR DESCRIPTION
Done:
* fixed header styles in mobile
![image](https://user-images.githubusercontent.com/14061779/62304750-4dc74380-b487-11e9-8c59-fcc9aa31240e.png)
