### PR TITLE
fix: not show confirm dialog if form was't changed

### DIFF
--- a/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.js
@@ -74,7 +74,8 @@ export const TriggerForm = ({
   lastPriceItem,
   settings,
   metaFormSettings,
-  id
+  id,
+  formChangedCallback
 }) => {
   const formMetric =
     metaFormSettings && metaFormSettings.metric
@@ -101,10 +102,22 @@ export const TriggerForm = ({
   }
 
   const [initialValues, setInitialValues] = useState(settings)
+  const [canCallFormChangCallback, setCanCallFormChanged] = useState(false)
 
   useEffect(() => {
     couldShowChart(initialValues) && getSignalBacktestingPoints(initialValues)
   }, [])
+
+  useEffect(() => {
+    setTimeout(() => {
+      !canCallFormChangCallback && setCanCallFormChanged(true)
+    })
+
+    return () => {
+      setCanCallFormChanged(false)
+      formChangedCallback(false)
+    }
+  })
 
   const toggleSignalPublic = () => {
     setInitialValues({ ...initialValues, isPublic: !initialValues.isPublic })
@@ -211,6 +224,10 @@ export const TriggerForm = ({
                     !newValues.descriptionChangedByUser &&
                       setFieldValue('description', getNewDescription(newValues))
                   }
+
+                  canCallFormChangCallback &&
+                    formChangedCallback &&
+                    formChangedCallback(true)
                 }
               }}
             />

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/signalsList/TriggersForm.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/signalsList/TriggersForm.js
@@ -17,7 +17,8 @@ export const TriggersForm = ({
   canRedirect,
   metaFormSettings,
   onSettingsChange,
-  onClose
+  onClose,
+  formChangedCallback
 }) => {
   return (
     <div>
@@ -30,6 +31,7 @@ export const TriggersForm = ({
           settings={settings}
           onSettingsChange={onSettingsChange}
           onRemovedSignal={onClose}
+          formChangedCallback={formChangedCallback}
         />
       ))}
     </div>

--- a/src/ducks/Signals/signalFormManager/signalMaster/SignalMaster.js
+++ b/src/ducks/Signals/signalFormManager/signalMaster/SignalMaster.js
@@ -29,7 +29,8 @@ const SignalMaster = ({
   redirect,
   updateTrigger,
   createTrigger,
-  isShared = false
+  isShared = false,
+  formChangedCallback
 }) => {
   const { triggerId, isLoading, isError } = propsTrigger
 
@@ -101,6 +102,7 @@ const SignalMaster = ({
         canRedirect={canRedirect}
         metaFormSettings={metaFormSettings}
         onSettingsChange={handleSettingsChange}
+        formChangedCallback={formChangedCallback}
       />
     </div>
   )

--- a/src/ducks/Signals/signalModal/SignalMasterModalForm.js
+++ b/src/ducks/Signals/signalModal/SignalMasterModalForm.js
@@ -42,6 +42,7 @@ const SignalMasterModalForm = ({
   const [dialogOpenState, setDialogOpenState] = useState(hasTrigger)
   const [dialogTitle, onSetDialogTitle] = useState('')
   const [isApproving, setIsAppoving] = useState(false)
+  const [isChanged, setIsChanged] = useState(false)
 
   useEffect(
     data => {
@@ -65,8 +66,13 @@ const SignalMasterModalForm = ({
     }
   }
 
-  const onCloseModal = () =>
-    isLoggedIn ? setIsAppoving(true) : setDialogOpenState(false)
+  const onCloseMainModal = () => {
+    isChanged && isLoggedIn ? setIsAppoving(true) : setDialogOpenState(false)
+  }
+
+  const formChangedCallback = isChanged => {
+    setIsChanged(isChanged)
+  }
 
   return (
     <GetSignal
@@ -92,7 +98,7 @@ const SignalMasterModalForm = ({
             <Dialog
               open={dialogOpenState}
               onOpen={() => setDialogOpenState(true)}
-              onClose={onCloseModal}
+              onClose={onCloseMainModal}
               trigger={
                 dialogTrigger ||
                 signalModalTrigger(
@@ -135,6 +141,7 @@ const SignalMasterModalForm = ({
                       onClose={() => setDialogOpenState(false)}
                       canRedirect={canRedirect}
                       metaFormSettings={metaFormSettings}
+                      formChangedCallback={formChangedCallback}
                     />
                   ) : (
                     <SignalAnon />


### PR DESCRIPTION
Done: 
* do't show confirmation(close) dialog for trigger if form was't changed