### PR TITLE
Hotfix/san 5693 share signals

### DIFF
--- a/src/components/SignalCard/SignalCard.module.scss
+++ b/src/components/SignalCard/SignalCard.module.scss
@@ -121,6 +121,7 @@
 
 .share {
   cursor: pointer;
+  padding: 0;
 }
 
 .removeSignal {

--- a/src/components/SignalCard/controls/MoreSignalActions.js
+++ b/src/components/SignalCard/controls/MoreSignalActions.js
@@ -70,9 +70,9 @@ const MoreSignalActions = ({
 }
 
 const SignalShareTrigger = ({ ...props }) => (
-  <div {...props} className={styles.share}>
+  <Button as='a' {...props} className={styles.share}>
     Share
-  </div>
+  </Button>
 )
 
 export default MoreSignalActions

--- a/src/components/SignalCard/controls/MoreSignalActions.js
+++ b/src/components/SignalCard/controls/MoreSignalActions.js
@@ -7,11 +7,14 @@ import Icon from '@santiment-network/ui/Icon'
 import Panel from '@santiment-network/ui/Panel/Panel'
 import { RemoveSignalButton } from './SignalControls'
 import ShareModalTrigger from '../../Share/ShareModalTrigger'
+import { mapStateToQS } from '../../../utils/utils'
 import styles from '../SignalCard.module.scss'
 
 const generateShareLink = (id, title) => {
-  const { origin, pathname } = window.location
-  return `${origin}${pathname}?name=${title}@${id}#shared`
+  const { origin } = window.location
+  return `${origin}/sonar/signal/${id}${mapStateToQS({
+    title
+  })}`
 }
 
 const MoreSignalActions = ({

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -134,7 +134,9 @@ class SmoothDropdown extends Component {
   }
 
   openDropdown = (ddItem, trigger) => {
-    const dropdownItem = this.ddItemsRef.get(ddItem).current
+    const dropdownItem = this.ddItemsRef
+      ? this.ddItemsRef.get(ddItem).current
+      : undefined
     if (!dropdownItem) return
     const { verticalOffset, verticalMotion } = this.props
     const ddContent = dropdownItem.querySelector('.dd__content')

--- a/src/ducks/Signals/common/getSignal.js
+++ b/src/ducks/Signals/common/getSignal.js
@@ -18,7 +18,13 @@ export const getShareSignalParams = () => {
   )(search)
 
   const isShared = hash === '#shared'
-  return { isShared, title, id }
+
+  // GarageInc: code above is for support old sharing of signals, remove in future(September/October)
+  const parsedSignalParams = qs.parse(window.location.search, {
+    arrayFormat: 'comma'
+  })
+
+  return { isShared, title, id, ...parsedSignalParams }
 }
 
 const GetSignal = ({ render, ...props }) => render(props)

--- a/src/ducks/Signals/common/getSignal.js
+++ b/src/ducks/Signals/common/getSignal.js
@@ -11,20 +11,26 @@ const getInfoFromQuery = (listname = '') => {
 
 export const getShareSignalParams = () => {
   const { search, hash } = window.location || {}
-  const { title, id } = compose(
+  const oldParsed = compose(
     getInfoFromQuery,
     parsed => parsed.name,
     qs.parse
   )(search)
-
-  const isShared = hash === '#shared'
 
   // GarageInc: code above is for support old sharing of signals, remove in future(September/October)
   const parsedSignalParams = qs.parse(window.location.search, {
     arrayFormat: 'comma'
   })
 
-  return { isShared, title, id, ...parsedSignalParams }
+  const isShared =
+    hash === '#shared' || Object.keys(parsedSignalParams).length > 0
+
+  const triggerParams = { isShared, ...oldParsed, ...parsedSignalParams }
+  Object.keys(triggerParams).forEach(key =>
+    triggerParams[key] === undefined ? delete triggerParams[key] : ''
+  )
+
+  return triggerParams
 }
 
 const GetSignal = ({ render, ...props }) => render(props)

--- a/src/ducks/Signals/common/getSignal.js
+++ b/src/ducks/Signals/common/getSignal.js
@@ -27,7 +27,9 @@ export const getShareSignalParams = () => {
 
   const triggerParams = { isShared, ...oldParsed, ...parsedSignalParams }
   Object.keys(triggerParams).forEach(key =>
-    triggerParams[key] === undefined ? delete triggerParams[key] : ''
+    triggerParams[key] === undefined || triggerParams[key] === ''
+      ? delete triggerParams[key]
+      : ''
   )
 
   return triggerParams

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/TriggerFormHistoricalBalance.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/TriggerFormHistoricalBalance.js
@@ -239,7 +239,9 @@ const enhance = compose(
     name: 'assetsByWallet',
     props: mapAssetsHeldByAddressToProps,
     skip: ({ byAddress }) =>
-      !byAddress || (Array.isArray(byAddress) && byAddress.length > 1),
+      !byAddress ||
+      (Array.isArray(byAddress) &&
+        (byAddress.length > 1 || byAddress.length === 0)),
     options: ({ byAddress }) => {
       return {
         variables: {

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/TriggerFormHistoricalBalance.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/TriggerFormHistoricalBalance.js
@@ -239,9 +239,7 @@ const enhance = compose(
     name: 'assetsByWallet',
     props: mapAssetsHeldByAddressToProps,
     skip: ({ byAddress }) =>
-      !byAddress ||
-      (Array.isArray(byAddress) &&
-        (byAddress.length > 1 || byAddress.length === 0)),
+      !byAddress || (Array.isArray(byAddress) && byAddress.length !== 1),
     options: ({ byAddress }) => {
       return {
         variables: {

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/channels/TriggerFormChannels.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/channels/TriggerFormChannels.js
@@ -19,38 +19,40 @@ const TriggerFormChannels = ({
     !isEmailConnected && channels.some(type => type === 'Email')
 
   return (
-    <SidecarExplanationTooltip
-      closeTimeout={500}
-      localStorageSuffix='_TRIGGER_FORM_EXPLANATION'
-      position='top'
-      title='Connect channels'
-      description='Get fast notifications through Email or Telegram'
-      className={styles.explanation}
-    >
-      <div className={cx(styles.row, styles.rowSingle)}>
-        <div className={cx(styles.Field, styles.fieldFilled)}>
-          <FormikLabel text='Notify me via' />
-          <div className={styles.notifyBlock}>
-            <FormikCheckboxes
-              name='channels'
-              labelOnRight
-              options={['Email', 'Telegram']}
-              disabledIndexes={['Email']}
-              classes={styles}
-            />
-            <TriggerChannelSettings
-              isTelegramSettings={settingsForTelegramEnabled}
-              isEmailSettings={settingsForEmailEnabled}
-            />
+    <div className={cx(styles.row, styles.rowSingle)}>
+      <div className={cx(styles.Field, styles.fieldFilled)}>
+        <SidecarExplanationTooltip
+          closeTimeout={500}
+          localStorageSuffix='_TRIGGER_FORM_EXPLANATION'
+          position='top'
+          title='Connect channels'
+          description='Get fast notifications through Email or Telegram'
+          className={styles.explanation}
+        >
+          <div>
+            <FormikLabel text='Notify me via' />
           </div>
-          {errors.channels && (
-            <div className={cx(styles.row, styles.messages)}>
-              <Message variant='warn'>{errors.channels}</Message>
-            </div>
-          )}
+        </SidecarExplanationTooltip>
+        <div className={styles.notifyBlock}>
+          <FormikCheckboxes
+            name='channels'
+            labelOnRight
+            options={['Email', 'Telegram']}
+            disabledIndexes={['Email']}
+            classes={styles}
+          />
+          <TriggerChannelSettings
+            isTelegramSettings={settingsForTelegramEnabled}
+            isEmailSettings={settingsForEmailEnabled}
+          />
         </div>
+        {errors.channels && (
+          <div className={cx(styles.row, styles.messages)}>
+            <Message variant='warn'>{errors.channels}</Message>
+          </div>
+        )}
       </div>
-    </SidecarExplanationTooltip>
+    </div>
   )
 }
 

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/projectsSelector/TriggerProjectsSelector.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/projectsSelector/TriggerProjectsSelector.js
@@ -12,6 +12,7 @@ export const TriggerProjectsSelector = ({
   setFieldValue,
   onChange,
   values: { target = [] },
+  values,
   name
 }) => {
   const [listItems, setListItems] = useState([])
@@ -32,11 +33,15 @@ export const TriggerProjectsSelector = ({
         }
       }
 
-      if (target && target.length === 0 && listItems.length > 0) {
+      if (
+        Array.isArray(target) &&
+        target.length === 0 &&
+        listItems.length > 0
+      ) {
         setSelectedAssets([])
       }
     },
-    [target]
+    [target, projects]
   )
 
   const setSelectedAssets = selectedAssets => {

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.js
@@ -212,7 +212,7 @@ export const TriggerForm = ({
                     canLoadChart &&
                     getSignalBacktestingPoints(newValues)
 
-                  if (!id) {
+                  if (!id && !isShared) {
                     !newValues.titleChangedByUser &&
                       setFieldValue('title', getNewTitle(newValues))
                     !newValues.descriptionChangedByUser &&

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.module.scss
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.module.scss
@@ -237,6 +237,8 @@ a {
 .submitButton {
   width: 120px;
   margin-left: auto;
+  display: flex;
+  justify-content: center;
 }
 
 .descriptionTextarea {

--- a/src/ducks/Signals/signalModal/SignalMasterModalForm.js
+++ b/src/ducks/Signals/signalModal/SignalMasterModalForm.js
@@ -85,10 +85,6 @@ const SignalMasterModalForm = ({
       render={({ trigger = {}, userId: triggerUserId }) => {
         const { isLoading, isError } = trigger
 
-        if (isError) {
-          throw new Error(`Can't find such public trigger with id ${triggerId}`)
-        }
-
         let isShared =
           isOldShared || (triggerUserId && +userId !== triggerUserId)
 
@@ -136,10 +132,16 @@ const SignalMasterModalForm = ({
               {...dialogProps}
             >
               <Dialog.ScrollContent className={styles.TriggerPanel}>
-                {isLoading && (
+                {isError && (
+                  <div className={styles.notSignalInfo}>
+                    Signal is not available for loading :(
+                  </div>
+                )}
+                {!isError && isLoading && (
                   <Loader className={styles.loading}>Loading...</Loader>
                 )}
-                {!isLoading &&
+                {!isError &&
+                  !isLoading &&
                   (isLoggedIn ? (
                     <SignalMaster
                       isShared={isShared}

--- a/src/ducks/Signals/signalModal/SignalMasterModalForm.js
+++ b/src/ducks/Signals/signalModal/SignalMasterModalForm.js
@@ -27,13 +27,14 @@ const SignalMasterModalForm = ({
   trigger: dialogTrigger,
   buttonParams = {},
   dialogProps,
-  shareParams = {}
+  shareParams = {},
+  userId
 }) => {
-  const { id: shareId, isShared } = shareParams
+  const { id: shareId, isShared: isOldShared } = shareParams
 
   if (!triggerId && match) {
     triggerId = match.params.id
-  } else if (isShared) {
+  } else if (isOldShared && shareId) {
     triggerId = shareId
   }
 
@@ -81,15 +82,18 @@ const SignalMasterModalForm = ({
   return (
     <GetSignal
       triggerId={triggerId}
-      render={({ trigger = {} }) => {
+      render={({ trigger = {}, userId: triggerUserId }) => {
         const { isLoading, isError } = trigger
-
-        if (isShared && trigger.trigger) {
-          trigger.trigger = { ...trigger.trigger, ...shareParams }
-        }
 
         if (isError) {
           throw new Error(`Can't find such public trigger with id ${triggerId}`)
+        }
+
+        let isShared =
+          isOldShared || (triggerUserId && +userId !== triggerUserId)
+
+        if (isShared && trigger && trigger.trigger) {
+          trigger.trigger = { ...trigger.trigger, ...shareParams }
         }
 
         return (
@@ -161,7 +165,8 @@ const SignalMasterModalForm = ({
 
 const mapStateToProps = state => {
   return {
-    isLoggedIn: checkIsLoggedIn(state)
+    isLoggedIn: checkIsLoggedIn(state),
+    userId: +state.user.data.id
   }
 }
 

--- a/src/ducks/Signals/signalModal/SignalMasterModalForm.js
+++ b/src/ducks/Signals/signalModal/SignalMasterModalForm.js
@@ -12,6 +12,7 @@ import GetSignal from '../common/getSignal'
 import { SIGNAL_ROUTES } from '../common/constants'
 import SignalAnon from './SignalAnon'
 import ConfirmSignalModalClose from './confirmClose/ConfirmSignalModalClose'
+import Image from '../../../pages/SonarFeed/sonar_activity_artboard.png'
 import styles from './SignalMasterModalForm.module.scss'
 
 const SignalMasterModalForm = ({
@@ -132,12 +133,7 @@ const SignalMasterModalForm = ({
               {...dialogProps}
             >
               <Dialog.ScrollContent className={styles.TriggerPanel}>
-                {isError && (
-                  <div className={styles.notSignalInfo}>
-                    Trigger with id {triggerId} does not exist or it is a
-                    private trigger owned by another user :(
-                  </div>
-                )}
+                {isError && <NoSignal triggerId={triggerId} />}
                 {!isError && isLoading && (
                   <Loader className={styles.loading}>Loading...</Loader>
                 )}
@@ -200,4 +196,13 @@ const signalModalTrigger = (
     <Icon type='plus-round' className={styles.newSignal__icon} />
     {label}
   </Button>
+)
+
+const NoSignal = ({ triggerId }) => (
+  <div className={styles.notSignalInfo}>
+    <img className={styles.noSignalImage} alt='Artboard' src={Image} />
+    Trigger with id {triggerId} does not exist.
+    <br />
+    Or it is a private trigger owned by another user.
+  </div>
 )

--- a/src/ducks/Signals/signalModal/SignalMasterModalForm.js
+++ b/src/ducks/Signals/signalModal/SignalMasterModalForm.js
@@ -86,7 +86,7 @@ const SignalMasterModalForm = ({
         const { isLoading, isError } = trigger
 
         let isShared =
-          isOldShared || (triggerUserId && +userId !== triggerUserId)
+          isOldShared || (!!triggerUserId && +userId !== triggerUserId)
 
         if (isShared && trigger && trigger.trigger) {
           trigger.trigger = { ...trigger.trigger, ...shareParams }
@@ -134,7 +134,8 @@ const SignalMasterModalForm = ({
               <Dialog.ScrollContent className={styles.TriggerPanel}>
                 {isError && (
                   <div className={styles.notSignalInfo}>
-                    Signal is not available for loading :(
+                    Trigger with id {triggerId} does not exist or it is a
+                    private trigger owned by another user :(
                   </div>
                 )}
                 {!isError && isLoading && (

--- a/src/ducks/Signals/signalModal/SignalMasterModalForm.module.scss
+++ b/src/ducks/Signals/signalModal/SignalMasterModalForm.module.scss
@@ -25,11 +25,16 @@
 }
 
 .notSignalInfo {
-  width: 300px;
+  width: 534px;
   height: 200px;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 20px;
+
+  @include responsive('phone', 'phone-xs') {
+    width: initial;
+  }
 }
 
 .shared {

--- a/src/ducks/Signals/signalModal/SignalMasterModalForm.module.scss
+++ b/src/ducks/Signals/signalModal/SignalMasterModalForm.module.scss
@@ -24,6 +24,14 @@
   position: relative;
 }
 
+.notSignalInfo {
+  width: 300px;
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .shared {
   @include text('body-3');
 

--- a/src/ducks/Signals/signalModal/SignalMasterModalForm.module.scss
+++ b/src/ducks/Signals/signalModal/SignalMasterModalForm.module.scss
@@ -26,15 +26,20 @@
 
 .notSignalInfo {
   width: 534px;
-  height: 200px;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 20px;
+  flex-direction: column;
+  text-align: center;
 
   @include responsive('phone', 'phone-xs') {
     width: initial;
   }
+}
+
+.noSignalImage {
+  margin-bottom: 20px;
 }
 
 .shared {

--- a/src/ducks/Signals/utils/utils.js
+++ b/src/ducks/Signals/utils/utils.js
@@ -752,13 +752,15 @@ export const mapGQLTriggerToProps = ({ data: { trigger, loading, error } }) => {
   }
 
   const checkingTrigger = trigger ? trigger.trigger : undefined
+  const { userId } = trigger || {}
 
   return {
     trigger: {
       trigger: checkingTrigger,
       isLoading: loading,
       isError: !!error
-    }
+    },
+    userId: +userId
   }
 }
 

--- a/src/ducks/Signals/utils/utils.js
+++ b/src/ducks/Signals/utils/utils.js
@@ -746,7 +746,7 @@ export const mapGQLTriggerToProps = ({ data: { trigger, loading, error } }) => {
         isError: !!error,
         isEmpty: true,
         trigger: null,
-        isLoading: loading
+        isLoading: !!loading
       }
     }
   }
@@ -757,7 +757,7 @@ export const mapGQLTriggerToProps = ({ data: { trigger, loading, error } }) => {
   return {
     trigger: {
       trigger: checkingTrigger,
-      isLoading: loading,
+      isLoading: !!loading,
       isError: !!error
     },
     userId: +userId

--- a/src/pages/SonarFeed/SonarFeedActivityPage.js
+++ b/src/pages/SonarFeed/SonarFeedActivityPage.js
@@ -10,7 +10,7 @@ import { dateDifferenceInWords } from '../../utils/dates'
 export const TRIGGER_ACTIVITIES_QUERY = gql`
   query signalsHistoricalActivity($datetime: DateTime!) {
     activities: signalsHistoricalActivity(
-      limit: 5
+      limit: 10
       cursor: { type: BEFORE, datetime: $datetime }
     ) {
       cursor {

--- a/src/pages/SonarFeed/SonarFeedMySignalsPage.js
+++ b/src/pages/SonarFeed/SonarFeedMySignalsPage.js
@@ -10,6 +10,7 @@ const SonarFeedMySignalsPage = ({ match, setLoadingSignalId }) => {
   if (match && match.params && match.params.id) {
     triggerId = match.params.id
   }
+
   setLoadingSignalId && setLoadingSignalId(triggerId)
 
   return (

--- a/src/pages/SonarFeed/SonarFeedPage.js
+++ b/src/pages/SonarFeed/SonarFeedPage.js
@@ -17,6 +17,7 @@ import styles from './SonarFeedPage.module.scss'
 
 const baseLocation = '/sonar'
 const editTriggerSettingsModalLocation = `${baseLocation}/signal/:id/edit`
+const openTriggerSettingsModalLocation = `${baseLocation}/signal/:id`
 
 const tabs = [
   {
@@ -80,7 +81,10 @@ const SonarFeed = ({
 
   useEffect(
     () => {
-      if (triggerId && !matchPath(pathname, editTriggerSettingsModalLocation)) {
+      const isTrigger =
+        matchPath(pathname, editTriggerSettingsModalLocation) ||
+        matchPath(pathname, openTriggerSettingsModalLocation)
+      if (triggerId && !isTrigger) {
         setTriggerId(undefined)
       }
     },
@@ -143,6 +147,16 @@ const SonarFeed = ({
           ,
           <Route
             path={editTriggerSettingsModalLocation}
+            exact
+            render={props => (
+              <LoadableEditSignalPage
+                setLoadingSignalId={setLoadingSignalId}
+                {...props}
+              />
+            )}
+          />
+          <Route
+            path={openTriggerSettingsModalLocation}
             exact
             render={props => (
               <LoadableEditSignalPage

--- a/src/pages/SonarFeed/SonarFeedPage.js
+++ b/src/pages/SonarFeed/SonarFeedPage.js
@@ -96,10 +96,12 @@ const SonarFeed = ({
       {isDesktop ? (
         <div className={styles.header}>
           <SonarFeedHeader />
-          <SignalMasterModalForm
-            triggerId={triggerId}
-            shareParams={shareSignalParams}
-          />
+          {!isUserLoading && (
+            <SignalMasterModalForm
+              triggerId={triggerId}
+              shareParams={shareSignalParams}
+            />
+          )}
         </div>
       ) : (
         <div className={styles.header}>
@@ -107,10 +109,12 @@ const SonarFeed = ({
             title={<SonarFeedHeader />}
             rightActions={
               <div className={styles.addSignal}>
-                <SignalMasterModalForm
-                  triggerId={triggerId}
-                  shareParams={shareSignalParams}
-                />
+                {!isUserLoading && (
+                  <SignalMasterModalForm
+                    triggerId={triggerId}
+                    shareParams={shareSignalParams}
+                  />
+                )}
               </div>
             }
           />

--- a/src/pages/SonarFeed/SonarFeedPage.js
+++ b/src/pages/SonarFeed/SonarFeedPage.js
@@ -36,14 +36,6 @@ const tabs = [
       loading: () => <PageLoader />
     })
   }
-  // {
-  // index: `${baseLocation}/explore`,
-  // content: 'Explore',
-  // component: Loadable({
-  // loader: () => import('../../components/SignalCard/SignalCardsGrid'),
-  // loading: () => <PageLoader />
-  // })
-  // },
 ]
 
 const LoadableSignalDetailsPage = Loadable({
@@ -81,11 +73,13 @@ const SonarFeed = ({
 
   useEffect(
     () => {
-      const isTrigger =
+      const pathParams =
         matchPath(pathname, editTriggerSettingsModalLocation) ||
         matchPath(pathname, openTriggerSettingsModalLocation)
-      if (triggerId && !isTrigger) {
+      if (triggerId && !pathParams) {
         setTriggerId(undefined)
+      } else if (pathParams) {
+        setTriggerId(pathParams.params.id)
       }
     },
     [pathname]


### PR DESCRIPTION
Done:
* fixed bug with assets/projects field in trigger form
* new signal routes. User can share his own triggers(edit existing and create a new with a basic filled params)
* handle not available triggers (private or not existing)
![image](https://user-images.githubusercontent.com/14061779/62783687-94d7b900-bac5-11e9-8b88-c95976eab4a0.png)

* fixed share urls (whitespaces)
http://local.santiment.net:3000/sonar/signal/422?title=Santiment%20Network%20Token%20price%20goes%20below%20%2425.00
![image](https://user-images.githubusercontent.com/14061779/62779154-0f4f0b80-babb-11e9-9326-dbcf0acc87af.png)
![image](https://user-images.githubusercontent.com/14061779/62779176-1fff8180-babb-11e9-9baf-c1d2fff9f58e.png)
 
