### PR TITLE
fix: sonar default routes and loaded icon for form

### DIFF
--- a/src/ducks/HistoricalBalance/balanceView/BalanceView.module.scss
+++ b/src/ducks/HistoricalBalance/balanceView/BalanceView.module.scss
@@ -67,7 +67,7 @@
 }
 
 .walletInput {
-  height: 36px;
+  height: 32px;
 }
 
 .address {

--- a/src/ducks/Signals/signalModal/SignalMasterModalForm.js
+++ b/src/ducks/Signals/signalModal/SignalMasterModalForm.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { push } from 'react-router-redux'
 import { connect } from 'react-redux'
 import cx from 'classnames'
-import Loader from '@santiment-network/ui/Loader/Loader'
+import PageLoader from '../../../components/Loader/PageLoader'
 import Button from '@santiment-network/ui/Button'
 import Icon from '@santiment-network/ui/Icon'
 import Dialog from '@santiment-network/ui/Dialog'
@@ -135,7 +135,7 @@ const SignalMasterModalForm = ({
               <Dialog.ScrollContent className={styles.TriggerPanel}>
                 {isError && <NoSignal triggerId={triggerId} />}
                 {!isError && isLoading && (
-                  <Loader className={styles.loading}>Loading...</Loader>
+                  <PageLoader className={styles.loading} />
                 )}
                 {!isError &&
                   !isLoading &&

--- a/src/pages/SonarFeed/SonarFeedPage.js
+++ b/src/pages/SonarFeed/SonarFeedPage.js
@@ -163,7 +163,7 @@ const SonarFeed = ({
               />
             )}
           />
-          }
+          <Route component={tabs[0].component} />}
         </Switch>
       </div>
     </div>


### PR DESCRIPTION
Done:
1. Support of custom routes for sonar (redirect into '/my-signals')
2. Preview for loading of signal