### PR TITLE
Feature/check activities sw

### DIFF
--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/channels/TriggerFormChannels.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/channels/TriggerFormChannels.js
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { useState } from 'react'
 import cx from 'classnames'
 import Message from '@santiment-network/ui/Message'
 import SidecarExplanationTooltip from '../../../../../SANCharts/SidecarExplanationTooltip'
 import FormikLabel from '../../../../../../components/formik-santiment-ui/FormikLabel'
 import FormikCheckboxes from '../../../../../../components/formik-santiment-ui/FormikCheckboxes'
 import TriggerChannelSettings from './TriggerChannelSettings'
+import { CHANNELS_MAP } from '../../../../utils/constants'
 import styles from '../../signal/TriggerForm.module.scss'
 
 const TriggerFormChannels = ({
@@ -18,6 +19,10 @@ const TriggerFormChannels = ({
   const settingsForEmailEnabled =
     !isEmailConnected && channels.some(type => type === 'Email')
 
+  const [channelsList] = useState(CHANNELS_MAP.map(({ label }) => label))
+
+  console.log(channels)
+
   return (
     <div className={cx(styles.row, styles.rowSingle)}>
       <div className={cx(styles.Field, styles.fieldFilled)}>
@@ -26,7 +31,7 @@ const TriggerFormChannels = ({
           <FormikCheckboxes
             name='channels'
             labelOnRight
-            options={['Email', 'Telegram']}
+            options={channelsList}
             disabledIndexes={['Email']}
             classes={styles}
           />

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.js
@@ -342,7 +342,6 @@ export const TriggerForm = ({
                               isPublic ? 'Public' : 'Private'
                             }
                             onSelect={toggleSignalPublic}
-                            style={{ marginRight: '20px' }}
                             labelClassName={styles.checkboxLabel}
                           />
                         </div>

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.module.scss
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.module.scss
@@ -83,10 +83,10 @@ $trigger-form-width: 534px;
 .notifyBlock {
   display: flex;
   margin-top: 5px;
+}
 
-  div:first-child {
-    margin-right: 20px;
-  }
+.labelClassName {
+  margin-right: 20px;
 }
 
 .Field {
@@ -123,7 +123,7 @@ $trigger-form-width: 534px;
 
 .checkboxLabel {
   cursor: pointer;
-  margin: 2px 0 0 10px !important;
+  margin: 2px 20px 0 10px !important;
   color: var(--mirage);
 
   @include text('body-3');

--- a/src/ducks/Signals/utils/constants.js
+++ b/src/ducks/Signals/utils/constants.js
@@ -1,3 +1,18 @@
+export const CHANNELS_MAP = [
+  {
+    value: 'email',
+    label: 'Email'
+  },
+  {
+    value: 'telegram',
+    label: 'Telegram'
+  },
+  {
+    value: 'web_push',
+    label: 'Web Push'
+  }
+]
+
 export const MAX_DESCR_LENGTH = 200
 export const MAX_TITLE_LENGTH = 120
 export const MIN_TITLE_LENGTH = 2

--- a/src/ducks/Signals/utils/utils.js
+++ b/src/ducks/Signals/utils/utils.js
@@ -45,7 +45,8 @@ import {
   NOT_VALID_ETH_ADDRESS,
   MIN_TITLE_LENGTH,
   MAX_TITLE_LENGTH,
-  MAX_DESCR_LENGTH
+  MAX_DESCR_LENGTH,
+  CHANNELS_MAP
 } from './constants'
 import {
   capitalizeStr,
@@ -369,7 +370,9 @@ export const mapTriggerToFormProps = currentTrigger => {
     signalType: signalType,
     percentThreshold: getPercentTreshold(settings) || BASE_PERCENT_THRESHOLD,
     threshold: mapTriggerToFormThreshold(settings) || BASE_THRESHOLD,
-    channels: [capitalizeStr(channel)],
+    channels: Array.isArray(channel)
+      ? channel.map(mapToFormChannel)
+      : [mapToFormChannel(channel)],
     ...frequencyModels,
     ...absolutePriceValues,
     ...trendingWordsParams,
@@ -482,8 +485,24 @@ export const mapAssetTarget = (target, ethAddress) => {
   }
 }
 
-export const getChannels = ({ channels }) =>
-  channels.length ? channels[0].toLowerCase() : undefined
+const mapToTriggerChannel = formLabel => {
+  return CHANNELS_MAP.find(({ label }) => label === formLabel).value
+}
+const mapToFormChannel = channelValue => {
+  return CHANNELS_MAP.find(({ value }) => value === channelValue).label
+}
+
+export const getChannels = ({ channels }) => {
+  if (!Array.isArray(channels)) {
+    return mapToTriggerChannel[channels]
+  } else {
+    if (channels.length === 1) {
+      return mapToTriggerChannel(channels[0])
+    } else {
+      return channels.map(mapToTriggerChannel)
+    }
+  }
+}
 
 export const isTrendingWordsByProjects = type =>
   type.value === TRENDING_WORDS_PROJECT_MENTIONED.value

--- a/src/pages/Account/SettingsSonarWebPushNotifications.js
+++ b/src/pages/Account/SettingsSonarWebPushNotifications.js
@@ -7,6 +7,7 @@ import {
   requestNotificationPermission
 } from '../../serviceWorker'
 import SidecarExplanationTooltip from '../../ducks/SANCharts/SidecarExplanationTooltip'
+import { getAPIUrl, getOrigin } from '../../utils/utils'
 import styles from './AccountPage.module.scss'
 
 export const getSanSonarSW = registrations => {
@@ -41,13 +42,17 @@ const SettingsSonarWebPushNotifications = ({ classes = {} }) => {
     }
   })
 
-  const unRegisterSw = () => {
+  const postMessage = data => {
     navigator &&
       navigator.serviceWorker &&
       navigator.serviceWorker.controller &&
-      navigator.serviceWorker.controller.postMessage({
-        type: 'SONAR_FEED_ACTIVITY_STOP'
-      })
+      navigator.serviceWorker.controller.postMessage(data)
+  }
+
+  const unRegisterSw = () => {
+    postMessage({
+      type: 'SONAR_FEED_ACTIVITY_STOP'
+    })
 
     setTimeout(() => {
       navigator.serviceWorker &&
@@ -78,6 +83,13 @@ const SettingsSonarWebPushNotifications = ({ classes = {} }) => {
             registerSonarActivitiesSw({
               hideRegistrationChecking: true,
               callback: () => {
+                postMessage({
+                  type: 'SONAR_FEED_PARAMS_START',
+                  data: {
+                    PUBLIC_API_ROUTE: getAPIUrl(),
+                    PUBLIC_FRONTEND_ROUTE: getOrigin()
+                  }
+                })
                 requestNotificationPermission(unRegisterSw)
                 toggle(true)
               }

--- a/src/pages/Account/SettingsSonarWebPushNotifications.js
+++ b/src/pages/Account/SettingsSonarWebPushNotifications.js
@@ -22,6 +22,28 @@ export const getSanSonarSW = registrations => {
     : undefined
 }
 
+const postMessage = data => {
+  navigator &&
+    navigator.serviceWorker &&
+    navigator.serviceWorker.controller &&
+    navigator.serviceWorker.controller.postMessage(data)
+}
+
+const sendParams = () => {
+  setTimeout(() => {
+    postMessage(
+      {
+        type: 'SONAR_FEED_PARAMS_START',
+        data: {
+          PUBLIC_API_ROUTE: getAPIUrl(),
+          PUBLIC_FRONTEND_ROUTE: getOrigin()
+        }
+      },
+      1000
+    )
+  })
+}
+
 const SettingsSonarWebPushNotifications = ({ classes = {} }) => {
   const [isActive, setIsActive] = useState(false)
 
@@ -41,13 +63,6 @@ const SettingsSonarWebPushNotifications = ({ classes = {} }) => {
       })
     }
   })
-
-  const postMessage = data => {
-    navigator &&
-      navigator.serviceWorker &&
-      navigator.serviceWorker.controller &&
-      navigator.serviceWorker.controller.postMessage(data)
-  }
 
   const unRegisterSw = () => {
     postMessage({
@@ -83,18 +98,13 @@ const SettingsSonarWebPushNotifications = ({ classes = {} }) => {
             registerSonarActivitiesSw({
               hideRegistrationChecking: true,
               callback: () => {
-                postMessage({
-                  type: 'SONAR_FEED_PARAMS_START',
-                  data: {
-                    PUBLIC_API_ROUTE: getAPIUrl(),
-                    PUBLIC_FRONTEND_ROUTE: getOrigin()
-                  }
-                })
                 requestNotificationPermission(unRegisterSw)
+                sendParams()
                 toggle(true)
               }
             })
           } else {
+            sendParams()
             toggle(true)
           }
         })

--- a/src/pages/SonarFeed/SonarFeedActivityPage.js
+++ b/src/pages/SonarFeed/SonarFeedActivityPage.js
@@ -44,6 +44,10 @@ const SonarFeedActivityPage = ({ activities, isLoading, isError }) => {
   }
 
   const sendUpdate = () => {
+    if (!activities) {
+      return
+    }
+
     navigator.serviceWorker &&
       navigator.serviceWorker.getRegistrations &&
       navigator.serviceWorker.getRegistrations().then(registrations => {

--- a/src/san-sonar-service-worker.js
+++ b/src/san-sonar-service-worker.js
@@ -1,13 +1,9 @@
 const ACTIVITIES_LOAD_TIMEOUT = 1000 * 60 * 15
-const PUBLIC_API_ROUTE = __API_URL__
-const PUBLIC_FRONTEND_ROUTE = __UI_URL__
 const WS_DB_NAME = 'serviceWorkerDb'
 const ACTIVITY_CHECKS_STORE_NAME = 'activityChecks'
 
-console.log(
-  `Started sonar service-worker: ${PUBLIC_API_ROUTE} and ${PUBLIC_FRONTEND_ROUTE}`
-)
-
+let PUBLIC_API_ROUTE
+let PUBLIC_FRONTEND_ROUTE
 let db
 let timeoutId
 let isStopped = false
@@ -182,6 +178,12 @@ const checkNewActivities = activities => {
 
 const loadAndCheckActivities = () => {
   if (isStopped || !PUBLIC_API_ROUTE || !PUBLIC_FRONTEND_ROUTE) {
+    console.log(
+      "Can't load sonar activities: ",
+      isStopped,
+      PUBLIC_API_ROUTE,
+      PUBLIC_FRONTEND_ROUTE
+    )
     return
   }
   console.log('Sonar is loading new activities')
@@ -232,6 +234,15 @@ self.addEventListener('message', function (event) {
       })
     } else if (type === 'SONAR_FEED_ACTIVITY_STOP') {
       stop()
+    } else if (type === 'SONAR_FEED_PARAMS_START') {
+      PUBLIC_API_ROUTE = data.PUBLIC_API_ROUTE
+      PUBLIC_FRONTEND_ROUTE = data.PUBLIC_FRONTEND_ROUTE
+
+      console.log(
+        `Started sonar service-worker: ${PUBLIC_API_ROUTE} and ${PUBLIC_FRONTEND_ROUTE}`
+      )
+
+      createActivitiesDB()
     }
   }
 })

--- a/webpack.sw.config.js
+++ b/webpack.sw.config.js
@@ -4,8 +4,8 @@ const webpack = require('webpack')
 const dotenv = require('dotenv')
 
 const envConfig = {...dotenv.config().parsed, ...dotenv.config({path: './.env.local'}).parsed}
-const apiUrl = envConfig.REACT_APP_BACKEND_URL || process.env.REACT_APP_BACKEND_URL
-const uiUrl = envConfig.REACT_APP_WEBSITE_URL || process.env.REACT_APP_WEBSITE_URL
+const apiUrl = envConfig.REACT_APP_BACKEND_URL || process.env.REACT_APP_BACKEND_URL || process.env.BACKEND_URL
+const uiUrl = envConfig.REACT_APP_WEBSITE_URL || process.env.REACT_APP_WEBSITE_URL || process.env.FRONTEND_URL
 
 module.exports = {
   mode: process.env.NODE_ENV,

--- a/webpack.sw.config.js
+++ b/webpack.sw.config.js
@@ -1,11 +1,6 @@
 const path = require('path')
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 const webpack = require('webpack')
-const dotenv = require('dotenv')
-
-const envConfig = {...dotenv.config().parsed, ...dotenv.config({path: './.env.local'}).parsed}
-const apiUrl = envConfig.REACT_APP_BACKEND_URL || process.env.REACT_APP_BACKEND_URL || process.env.BACKEND_URL
-const uiUrl = envConfig.REACT_APP_WEBSITE_URL || process.env.REACT_APP_WEBSITE_URL || process.env.FRONTEND_URL
 
 module.exports = {
   mode: process.env.NODE_ENV,
@@ -33,10 +28,6 @@ module.exports = {
   },
 
   plugins: [
-    new webpack.DefinePlugin({
-      __API_URL__: JSON.stringify(apiUrl),
-      __UI_URL__: JSON.stringify(uiUrl)
-    })
   ],
 
   optimization: {


### PR DESCRIPTION
Done:

service-worker which every N seconds/minutes check for new activities before user load activities page. If page loaded than code of page send message to service worker and it resets a counter of last checked activities.
Webpack build service worker from ./src-folder into ./public folder with required urls. Internal storage is IndexDb.
Title: ':N new activities in Sonar!'
Description: 'Open to check https://app-stage.santiment.net/sonar/activity'
![image](https://user-images.githubusercontent.com/14061779/63092169-81b36600-bf69-11e9-8151-38208bb9c9cf.png)

* add toggle in /account page for Web pushes
![image](https://user-images.githubusercontent.com/14061779/63092177-86781a00-bf69-11e9-9930-398f083e3645.png)
![image](https://user-images.githubusercontent.com/14061779/63092180-8a0ba100-bf69-11e9-8fcd-2e60375dc717.png)

* fixed some styles in /account page(padding, margins, mobile styles)