### PR TITLE
fix: sonar default route if opened signal from activities

### DIFF
--- a/src/ducks/Signals/common/constants.js
+++ b/src/ducks/Signals/common/constants.js
@@ -2,6 +2,10 @@ export const SIGNAL_ROUTES = {
   MY_SIGNALS: '/sonar/my-signals'
 }
 
+export const SIGNAL_ANCHORS = {
+  ACTIVITIES: '#activities'
+}
+
 export const TRIGGER_STEPS = {
   SETTINGS: 0,
   CONFIRM: 1

--- a/src/pages/SonarFeed/SonarFeedActivityPage.js
+++ b/src/pages/SonarFeed/SonarFeedActivityPage.js
@@ -7,6 +7,7 @@ import PageLoader from '../../components/Loader/PageLoader'
 import SonarFeedRecommendations from './SonarFeedRecommendations'
 import { dateDifferenceInWords } from '../../utils/dates'
 import { getSanSonarSW } from '../Account/SettingsSonarWebPushNotifications'
+import { SIGNAL_ANCHORS } from '../../ducks/Signals/common/constants'
 import styles from './SonarFeedActivityPage.module.scss'
 
 export const TRIGGER_ACTIVITIES_QUERY = gql`
@@ -83,8 +84,11 @@ const SonarFeedActivityPage = ({ activities, isLoading, isError }) => {
             <div className={styles.description}>
               <h4 className={styles.date}>{formatDate(triggeredAt)} by</h4>
 
-              <Link to={`/sonar/signal/${signalId}`} className={styles.link}>
-                '{title}'
+              <Link
+                to={`/sonar/signal/${signalId}${SIGNAL_ANCHORS.ACTIVITIES}`}
+                className={styles.link}
+              >
+                {title}
               </Link>
             </div>
             <Markdown source={Object.values(payload)[0]} />

--- a/src/pages/SonarFeed/SonarFeedPage.js
+++ b/src/pages/SonarFeed/SonarFeedPage.js
@@ -11,7 +11,10 @@ import { selectIsTelegramConnected } from '../../pages/UserSelectors'
 import SonarFeedHeader from './SonarFeedActions/SonarFeedHeader'
 import { showNotification } from '../../actions/rootActions'
 import SignalMasterModalForm from '../../ducks/Signals/signalModal/SignalMasterModalForm'
-import { SIGNAL_ROUTES } from '../../ducks/Signals/common/constants'
+import {
+  SIGNAL_ANCHORS,
+  SIGNAL_ROUTES
+} from '../../ducks/Signals/common/constants'
 import { getShareSignalParams } from '../../ducks/Signals/common/getSignal'
 import { sendParams } from '../Account/SettingsSonarWebPushNotifications'
 import styles from './SonarFeedPage.module.scss'
@@ -79,6 +82,12 @@ const SonarFeed = ({
   )
 
   const shareSignalParams = getShareSignalParams()
+  const defaultRoute =
+    hash === SIGNAL_ANCHORS.ACTIVITIES ? (
+      <Route component={tabs[1].component} />
+    ) : (
+      <Route component={tabs[0].component} />
+    )
 
   return (
     <div style={{ width: '100%' }} className='page'>
@@ -125,11 +134,10 @@ const SonarFeed = ({
         <Switch>
           {isUserLoading && <PageLoader className={styles.loader} />}
           {!isUserLoading && !isLoggedIn ? <InsightUnAuthPage /> : ''}
-          <Route path={tabs[0].index} component={tabs[0].component} />
           {tabs.map(({ index, component }) => (
             <Route key={index} path={index} component={component} />
           ))}
-          <Route component={tabs[0].component} />}
+          {defaultRoute}
         </Switch>
       </div>
     </div>


### PR DESCRIPTION
Summary:
* anchor for selected sonar page and trigger form

Screenshots:
![image](https://user-images.githubusercontent.com/14061779/63430153-92118800-c424-11e9-8297-3ce9cdad48e5.png)

