### PR TITLE
fix: skipWaiting for sonar service worker

### DIFF
--- a/src/pages/Account/SettingsSonarWebPushNotifications.js
+++ b/src/pages/Account/SettingsSonarWebPushNotifications.js
@@ -109,6 +109,7 @@ const SettingsSonarWebPushNotifications = ({ classes = {}, className }) => {
             registerSonarActivitiesSw({
               hideRegistrationChecking: true,
               callback: () => {
+                console.log('Registered sonar service worker')
                 requestNotificationPermission(null, unRegisterSw)
                 sendParams()
                 toggle(true)

--- a/src/san-sonar-service-worker.js
+++ b/src/san-sonar-service-worker.js
@@ -302,7 +302,7 @@ const loadUrlParams = () => {
 }
 
 self.addEventListener('install', function (event) {
-  event.waitUntil(self.skipWaiting()) // Activate worker immediately
+  self.skipWaiting() // Activate worker immediately
 })
 
 self.addEventListener('activate', function (event) {

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -110,6 +110,7 @@ function registerValidSW (
           }
         }
       } else {
+        registration.update()
         callback && callback()
       }
     })


### PR DESCRIPTION
Fix: sometimes service worker does't start before page reload. Add service worker reload on toggle via account page