### PR TITLE
fix: notify user about denied permissions in browser settings

### DIFF
--- a/src/pages/Account/AccountPage.module.scss
+++ b/src/pages/Account/AccountPage.module.scss
@@ -343,3 +343,11 @@
 .pushLoader {
   font-size: 5px;
 }
+
+.description {
+  margin-top: 4px;
+}
+
+.warning {
+  color: var(--persimmon);
+}

--- a/src/pages/Account/SettingsSonarWebPushNotifications.js
+++ b/src/pages/Account/SettingsSonarWebPushNotifications.js
@@ -53,9 +53,16 @@ export const sendParams = () => {
 
 const SettingsSonarWebPushNotifications = ({ classes = {}, className }) => {
   const [isActive, setIsActive] = useState(false)
+  const [isPermissionsGranted, setPermissionsGranted] = useState(true)
 
   const toggle = value => {
     setIsActive(value)
+    value && setPermissionsGranted(true)
+  }
+
+  const noPermissionsCallback = () => {
+    unRegisterSw()
+    setPermissionsGranted(false)
   }
 
   useEffect(
@@ -70,7 +77,7 @@ const SettingsSonarWebPushNotifications = ({ classes = {}, className }) => {
           }
         })
       }
-      requestNotificationPermission(null, unRegisterSw)
+      requestNotificationPermission(null, noPermissionsCallback)
     },
     [isActive]
   )
@@ -110,7 +117,7 @@ const SettingsSonarWebPushNotifications = ({ classes = {}, className }) => {
               hideRegistrationChecking: true,
               callback: () => {
                 console.log('Registered sonar service worker')
-                requestNotificationPermission(null, unRegisterSw)
+                requestNotificationPermission(null, noPermissionsCallback)
                 sendParams()
                 toggle(true)
               }
@@ -125,7 +132,18 @@ const SettingsSonarWebPushNotifications = ({ classes = {}, className }) => {
 
   return (
     <div className={cx(classes.container, styles.settingBlock, className)}>
-      <Label className={classes.left}>Browser notifications</Label>
+      <div className={classes.left}>
+        <div>Browser notifications</div>
+        {!isPermissionsGranted && (
+          <Label
+            className={cx(styles.description, styles.warning)}
+            accent='waterloo'
+          >
+            Notification permissions denied in browser settings. Please, check
+            your browser notification settings.
+          </Label>
+        )}
+      </div>
       <div className={cx(styles.setting__right_notifications, classes.right)}>
         <SidecarExplanationTooltip
           closeTimeout={500}


### PR DESCRIPTION
Summary: 
* notify user about denied permssions for notifications in his browser

Screenshots:
![image](https://user-images.githubusercontent.com/14061779/63526495-2d2f5e00-c508-11e9-934a-73b6a5a08f9f.png)
![image](https://user-images.githubusercontent.com/14061779/63526526-3a4c4d00-c508-11e9-81c9-3f20e73a87fb.png)
