### PR TITLE
enhance/watchlist-by-slug

### DIFF
--- a/src/components/WatchlistOverview/WatchlistHistory/WatchlistHistoryGQL.js
+++ b/src/components/WatchlistOverview/WatchlistHistory/WatchlistHistoryGQL.js
@@ -52,3 +52,22 @@ export const WATCHLIST_HISTORY_QUERY = gql`
     }
   }
 `
+
+export const WATCHLIST_BY_SLUG_HISTORY_QUERY = gql`
+  query watchlistBySlug(
+    $slug: String!
+    $from: DateTime!
+    $to: DateTime!
+    $interval: String = "1d"
+  ) {
+    watchlistBySlug(slug: $slug) {
+      name
+      id
+      historicalStats(from: $from, to: $to, interval: $interval) {
+        datetime
+        marketcap
+        volume
+      }
+    }
+  }
+`

--- a/src/components/Watchlists/WatchlistCard.js
+++ b/src/components/Watchlists/WatchlistCard.js
@@ -8,10 +8,11 @@ import PropTypes from 'prop-types'
 import { Area, AreaChart, ResponsiveContainer } from 'recharts'
 import PercentChanges from '../PercentChanges'
 import {
+  CATEGORY_HISTORY_QUERY,
   PROJECTS_HISTORY_QUERY,
-  CATEGORY_HISTORY_QUERY
+  WATCHLIST_HISTORY_QUERY,
+  WATCHLIST_BY_SLUG_HISTORY_QUERY
 } from '../WatchlistOverview/WatchlistHistory/WatchlistHistoryGQL'
-import { WATCHLIST_HISTORY_QUERY } from '../WatchlistOverview/WatchlistHistory/WatchlistHistoryGQL'
 import ExplanationTooltip from '../ExplanationTooltip/ExplanationTooltip'
 import Gradients from '../WatchlistOverview/Gradients'
 import { TRENDING_WATCHLIST_NAME } from '../../pages/assets/assets-overview-constants'
@@ -34,7 +35,7 @@ const WatchlistCard = ({
   onClick,
   slugs
 }) => {
-  if (name === TRENDING_WATCHLIST_NAME && slugs.length === 0) return null
+  if (name === TRENDING_WATCHLIST_NAME && stats.length === 0) return null
   const { marketcap: latestMarketcap } = stats.slice(-1)[0] || {}
   const { marketcap } = stats.slice(0, 1)[0] || {}
   const change = marketcap
@@ -126,7 +127,7 @@ const enhance = compose(
         interval: INTERVAL
       }
     }),
-    skip: ({ slugs }) => !slugs.length,
+    skip: ({ slugs }) => !slugs || !slugs.length,
     props: ({ data: { projectsListHistoryStats = [], loading, error } }) => ({
       stats: filterEmptyStats(projectsListHistoryStats),
       isLoading: loading,
@@ -144,6 +145,24 @@ const enhance = compose(
     skip: ({ slug }) => !slug,
     props: ({ data: { historyPrice = [], loading, error } }) => ({
       stats: filterEmptyStats(historyPrice),
+      isLoading: loading,
+      isError: error
+    })
+  }),
+  graphql(WATCHLIST_BY_SLUG_HISTORY_QUERY, {
+    options: ({ bySlug }) => ({
+      variables: {
+        slug: bySlug,
+        ...getTimeIntervalFromToday(-6, DAY),
+        interval: INTERVAL
+      }
+    }),
+    skip: ({ bySlug }) => !bySlug,
+    props: ({ data: { watchlistBySlug = {}, loading, error } }) => ({
+      stats:
+        watchlistBySlug && watchlistBySlug.historicalStats
+          ? filterEmptyStats(watchlistBySlug.historicalStats)
+          : [],
       isLoading: loading,
       isError: error
     })

--- a/src/components/Watchlists/WatchlistCards.js
+++ b/src/components/Watchlists/WatchlistCards.js
@@ -3,23 +3,16 @@ import PropTypes from 'prop-types'
 import WatchlistCard from './WatchlistCard'
 import styles from './WatchlistCards.module.scss'
 
-const WatchlistCards = ({ watchlists = [], slugs = {} }) => (
+const WatchlistCards = ({ watchlists = [] }) => (
   <div className={styles.wrapper}>
-    {watchlists.map(({ name, assetType, id, ...rest }) => (
-      <WatchlistCard
-        key={name}
-        name={name}
-        id={id}
-        slugs={slugs[assetType] || []}
-        {...rest}
-      />
+    {watchlists.map(({ name, ...rest }) => (
+      <WatchlistCard key={name} name={name} {...rest} />
     ))}
   </div>
 )
 
 WatchlistCards.propTypes = {
-  watchlists: PropTypes.array.isRequired,
-  slugs: PropTypes.object.isRequired
+  watchlists: PropTypes.array.isRequired
 }
 
 export default WatchlistCards

--- a/src/ducks/SANCharts/Categories.js
+++ b/src/ducks/SANCharts/Categories.js
@@ -1,14 +1,8 @@
 import React from 'react'
 import { graphql } from 'react-apollo'
 import { compose } from 'redux'
-import {
-  WATCHLISTS_BY_SLUG,
-  PUBLIC_WATCHLISTS
-} from '../../pages/assets/assets-overview-constants'
-import {
-  WATCHLIST_QUERY,
-  WATCHLIST_BY_SLUG_SHORT_QUERY
-} from '../../queries/WatchlistGQL'
+import { WATCHLISTS_BY_SLUG } from '../../pages/assets/assets-overview-constants'
+import {WATCHLIST_BY_SLUG_SHORT_QUERY} from '../../queries/WatchlistGQL'
 import WatchlistCard from '../../components/Watchlists/WatchlistCard'
 
 const Categories = ({ slugs, onClick, watchlists }) => {
@@ -27,16 +21,6 @@ const Categories = ({ slugs, onClick, watchlists }) => {
   })
 }
 
-const getPublicWatchlists = () =>
-  PUBLIC_WATCHLISTS.map(({ id }) =>
-    graphql(WATCHLIST_QUERY, {
-      options: () => ({ variables: { id: +id } }),
-      props: ({ data: { watchlist }, ownProps: { watchlists = [] } }) => ({
-        watchlists: [...watchlists, watchlist]
-      })
-    })
-  )
-
 const getPublicWatchlistsBySlug = () =>
   WATCHLISTS_BY_SLUG.map(({ bySlug }) =>
     graphql(WATCHLIST_BY_SLUG_SHORT_QUERY, {
@@ -50,9 +34,6 @@ const getPublicWatchlistsBySlug = () =>
     })
   )
 
-const enhance = compose(
-  ...getPublicWatchlists(),
-  ...getPublicWatchlistsBySlug()
-)
+const enhance = compose(...getPublicWatchlistsBySlug())
 
 export default enhance(Categories)

--- a/src/ducks/SANCharts/Categories.js
+++ b/src/ducks/SANCharts/Categories.js
@@ -2,19 +2,19 @@ import React from 'react'
 import { graphql } from 'react-apollo'
 import { compose } from 'redux'
 import {
-  WATCHLISTS_BY_FUNCTION,
+  WATCHLISTS_BY_SLUG,
   PUBLIC_WATCHLISTS
 } from '../../pages/assets/assets-overview-constants'
 import {
   WATCHLIST_QUERY,
-  PROJECTS_BY_FUNCTION_BIG_QUERY
+  WATCHLIST_BY_SLUG_SHORT_QUERY
 } from '../../queries/WatchlistGQL'
 import WatchlistCard from '../../components/Watchlists/WatchlistCard'
 
 const Categories = ({ slugs, onClick, watchlists }) => {
   return watchlists.map(watchlist => {
-    if (!watchlist) return null
     const { name, listItems } = watchlist || {}
+    if (!watchlist || listItems.length === 0) return null
     return (
       <WatchlistCard
         key={name}
@@ -37,29 +37,22 @@ const getPublicWatchlists = () =>
     })
   )
 
-const getProjectsByFunction = () => {
-  const { byFunction } = WATCHLISTS_BY_FUNCTION[0]
-
-  return graphql(PROJECTS_BY_FUNCTION_BIG_QUERY, {
-    options: () => ({ variables: { function: byFunction } }),
-    props: ({
-      data: { loading = true, allProjectsByFunction = [] },
-      ownProps: { watchlists = [] }
-    }) => ({
-      watchlists: [
-        ...watchlists,
-        {
-          name: 'Top 50 ERC20',
-          listItems: allProjectsByFunction.map(project => ({ project }))
-        }
-      ]
+const getPublicWatchlistsBySlug = () =>
+  WATCHLISTS_BY_SLUG.map(({ bySlug }) =>
+    graphql(WATCHLIST_BY_SLUG_SHORT_QUERY, {
+      options: () => ({ variables: { slug: bySlug } }),
+      props: ({
+        data: { watchlistBySlug },
+        ownProps: { watchlists = [] }
+      }) => ({
+        watchlists: [...watchlists, watchlistBySlug]
+      })
     })
-  })
-}
+  )
 
 const enhance = compose(
   ...getPublicWatchlists(),
-  getProjectsByFunction()
+  ...getPublicWatchlistsBySlug()
 )
 
 export default enhance(Categories)

--- a/src/epics/fetchAssetsEpic.js
+++ b/src/epics/fetchAssetsEpic.js
@@ -7,7 +7,7 @@ import {
   currenciesGQL
 } from './../pages/Projects/allProjectsGQL'
 import {
-  PROJECTS_BY_FUNCTION_BIG_QUERY,
+  WATCHLIST_BY_SLUG_BIG_QUERY,
   WATCHLIST_WITH_TRENDS_AND_SETTINGS_QUERY
 } from '../queries/WatchlistGQL.js'
 import * as actions from './../actions/types'
@@ -102,65 +102,43 @@ export const fetchAssetsFromListEpic = (action$, store, { client }) =>
     .mergeMap(({ payload: { list, filters } }) => {
       return Observable.from(
         client.watchQuery({
-          query: list.function
-            ? PROJECTS_BY_FUNCTION_BIG_QUERY
+          query: list.slug
+            ? WATCHLIST_BY_SLUG_BIG_QUERY
             : WATCHLIST_WITH_TRENDS_AND_SETTINGS_QUERY,
-          variables: list.function
-            ? { function: list.function }
+          variables: list.slug
+            ? { slug: list.slug, filters }
             : { id: list.id, filters },
           context: { isRetriable: true },
           fetchPolicy: 'network-only'
         })
       )
         .concatMap(({ data }) => {
-          const { watchlist } = data
-          if (!watchlist && !list.function) {
+          const watchlist = data.watchlist || data.watchlistBySlug
+
+          if (!watchlist) {
             return Observable.of({
               type: actions.ASSETS_FETCH_SUCCESS,
-              payload: {
-                items: [],
-                trendingAssets: [],
-                isCurrentUserTheAuthor: false,
-                isLoading: false,
-                error: false,
-                isPublicWatchlist: false
-              }
+              payload: {}
             })
           }
 
-          const { allProjectsByFunction } = data
-
-          const items = list.function
-            ? allProjectsByFunction
-            : watchlist.listItems.map(asset => asset.project)
-          const isCurrentUserTheAuthor =
-            !list.function &&
-            store.getState().user.data.id === watchlist.user.id
-
-          const trendingAssets = list.function
-            ? []
-            : watchlist.stats.trendingProjects
-
+          const { isPublic, user, settings, listItems, stats, id } = watchlist
           const { watchlistsSettings } = store.getState().watchlistUi
+          const payload = {
+            items: listItems.map(asset => asset.project),
+            trendingAssets: stats.trendingProjects,
+            isCurrentUserTheAuthor: store.getState().user.data.id === user.id,
+            isPublicWatchlist: isPublic
+          }
 
-          if (watchlist && watchlist.settings && !watchlistsSettings[list.id]) {
-            const { tableColumns = {}, pageSize } = watchlist.settings
+          if (settings && !watchlistsSettings[id]) {
+            const { tableColumns = {}, pageSize } = settings
             return Observable.from([
-              {
-                type: actions.ASSETS_FETCH_SUCCESS,
-                payload: {
-                  items,
-                  trendingAssets,
-                  isCurrentUserTheAuthor,
-                  isLoading: false,
-                  error: false,
-                  isPublicWatchlist: list.function || watchlist.isPublic
-                }
-              },
+              { type: actions.ASSETS_FETCH_SUCCESS, payload },
               {
                 type: actions.WATCHLIST_SETTINGS_SAVE_SUCCESS,
                 payload: {
-                  key: list.id,
+                  key: id,
                   hiddenColumns: tableColumns.hiddenColumns,
                   sorting: tableColumns.sorting,
                   pageSize
@@ -168,18 +146,7 @@ export const fetchAssetsFromListEpic = (action$, store, { client }) =>
               }
             ])
           }
-
-          return Observable.of({
-            type: actions.ASSETS_FETCH_SUCCESS,
-            payload: {
-              items,
-              trendingAssets,
-              isCurrentUserTheAuthor,
-              isLoading: false,
-              error: false,
-              isPublicWatchlist: list.function || watchlist.isPublic
-            }
-          })
+          return Observable.of({ type: actions.ASSETS_FETCH_SUCCESS, payload })
         })
         .catch(handleError)
     })

--- a/src/pages/assets/AssetsOverviewPage.js
+++ b/src/pages/assets/AssetsOverviewPage.js
@@ -1,11 +1,8 @@
 import React from 'react'
-import { graphql } from 'react-apollo'
-import { compose } from 'redux'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import cx from 'classnames'
-import { CATEGORIES, WATCHLISTS_BY_FUNCTION } from './assets-overview-constants'
-import { PROJECTS_BY_FUNCTION_SHORT_QUERY } from '../../queries/WatchlistGQL'
+import { CATEGORIES } from './assets-overview-constants'
 import WatchlistCards from '../../components/Watchlists/WatchlistCards'
 import MobileHeader from './../../components/MobileHeader/MobileHeader'
 import { DesktopOnly, MobileOnly } from './../../components/Responsive'
@@ -46,7 +43,7 @@ const AssetsOverview = ({
           <>
             <RecentlyWatched className={styles.recents} />
             <h2 className={styles.subtitle}>Categories</h2>
-            <WatchlistCards watchlists={CATEGORIES} slugs={slugs} />
+            <WatchlistCards watchlists={CATEGORIES} />
             <MyWatchlist
               isLoggedIn={isLoggedIn}
               className={styles.watchlists}
@@ -70,28 +67,4 @@ const AssetsOverview = ({
 
 const mapStateToProps = state => ({ isLoggedIn: checkIsLoggedIn(state) })
 
-const getProjectsByFunction = () =>
-  WATCHLISTS_BY_FUNCTION.map(({ assetType, byFunction }) =>
-    graphql(PROJECTS_BY_FUNCTION_SHORT_QUERY, {
-      options: () => ({ variables: { function: byFunction } }),
-      props: ({
-        data: { loading = true, allProjectsByFunction = [] },
-        ownProps: { slugs = {}, isLoading }
-      }) => ({
-        isLoading: loading || isLoading,
-        slugs: {
-          ...slugs,
-          [assetType]: loading
-            ? []
-            : allProjectsByFunction.map(({ slug }) => slug)
-        }
-      })
-    })
-  )
-
-const enhance = compose(
-  ...getProjectsByFunction(),
-  connect(mapStateToProps)
-)
-
-export default withRouter(enhance(AssetsOverview))
+export default withRouter(connect(mapStateToProps)(AssetsOverview))

--- a/src/pages/assets/GetAssets.js
+++ b/src/pages/assets/GetAssets.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux'
 import { compose } from 'redux'
 import * as actions from './../../actions/types.js'
 import { sortBy } from './../../utils/sortMethods'
-import { WATCHLISTS_BY_FUNCTION } from '../assets/assets-overview-constants'
+import { WATCHLISTS_BY_SLUG } from '../assets/assets-overview-constants'
 
 export const SORT_TYPES = {
   marketcap: 'marketcapUsd',
@@ -20,45 +20,36 @@ class GetAssets extends Component {
 
   static defaultProps = {
     sortBy: SORT_TYPES.marketcap,
-    Assets: {
-      items: []
-    }
+    Assets: { items: [] }
   }
 
   getInfoFromListname = (listname = '') => {
     const [listName, listId] = listname.split('@')
-    const listByFunction = WATCHLISTS_BY_FUNCTION.find(
+    const listBySlug = WATCHLISTS_BY_SLUG.find(
       ({ assetType }) => assetType === listName
     )
     return listId
       ? { listName, listId }
-      : {
-        listName,
-        listFunction: listByFunction ? listByFunction.byFunction : null
-      }
+      : { listName, listSlug: listBySlug && listBySlug.bySlug }
   }
 
   getType = () => {
     const { search, hash } = this.props.location || {}
-    const { listName, listId, listFunction } = compose(
+    const { listName, listId, listSlug } = compose(
       this.getInfoFromListname,
       parsed => parsed.name,
       qs.parse
     )(search)
     const type =
       hash === '#shared' ? 'list#shared' : this.props.type || qs.parse(search)
-    return { type, listName, listId, listFunction }
+    return { type, listName, listId, listSlug }
   }
 
   componentDidMount () {
-    const { type, listName, listId, listFunction } = this.getType()
+    const { type, listName, listId, listSlug } = this.getType()
     this.props.fetchAssets({
       type,
-      list: {
-        name: listName,
-        id: listId,
-        function: listFunction
-      },
+      list: { name: listName, id: listId, slug: listSlug },
       minVolume: this.props.minVolume
     })
   }
@@ -69,14 +60,10 @@ class GetAssets extends Component {
       pathname !== (prevProps.location || {}).pathname ||
       search !== (prevProps.location || {}).search
     ) {
-      const { type, listName, listId, listFunction } = this.getType()
+      const { type, listName, listId, listSlug } = this.getType()
       this.props.fetchAssets({
         type,
-        list: {
-          name: listName,
-          id: listId,
-          function: listFunction
-        },
+        list: { name: listName, id: listId, slug: listSlug },
         minVolume: this.props.minVolume
       })
     }
@@ -111,9 +98,7 @@ const mapDispatchToProps = dispatch => ({
       payload: {
         type,
         list,
-        filters: {
-          minVolume
-        }
+        filters: { minVolume }
       }
     })
   }

--- a/src/pages/assets/assets-overview-constants.js
+++ b/src/pages/assets/assets-overview-constants.js
@@ -36,24 +36,23 @@ export const PUBLIC_WATCHLISTS = [
 
 export const TRENDING_WATCHLIST_NAME = 'Emerging trending assets'
 
-export const WATCHLISTS_BY_FUNCTION = [
+export const WATCHLISTS_BY_SLUG = [
   {
     name: 'Top 50 ERC20',
     assetType: 'top 50 erc20',
     to: '/assets/list?name=top%2050%20erc20#shared',
-    byFunction:
-      '{"args":{"ignored_projects":["dadi","data","enigma","fusion","holo","iostoken","iotex","kin","next-exchange","pundi-x","quarkchain","rchain","seele","waltonchain","wax","tether","usd-coin","trueusd","paxos-standard-token","dai","stasis-eurs","gemini-dollar","bitcny","steem-dollars","stableusd","digix-gold-token","bitusd","susd","1sg","x8x-token","nubits","stronghold-usd","constant","ckusd","usdcoin","sdusd","qusd","okb","verasity","gifto","pchain","mvl","dock"],"size":50},"name":"top_erc20_projects"}'
+    bySlug: 'Top_50_ERC20'
   },
   {
     name: TRENDING_WATCHLIST_NAME,
     assetType: 'trending assets',
     to: '/assets/list?name=trending%20assets#shared',
-    byFunction: '{"name":"trending_projects"}'
+    bySlug: 'trending_assets'
   }
 ]
 
 export const CATEGORIES = [
   ...BASIC_CATEGORIES,
-  ...WATCHLISTS_BY_FUNCTION,
+  ...WATCHLISTS_BY_SLUG,
   ...PUBLIC_WATCHLISTS
 ]

--- a/src/pages/assets/assets-overview-constants.js
+++ b/src/pages/assets/assets-overview-constants.js
@@ -13,27 +13,6 @@ export const BASIC_CATEGORIES = [
   }
 ]
 
-export const PUBLIC_WATCHLISTS = [
-  {
-    name: 'Stablecoins',
-    assetType: 'stablecoins',
-    to: '/assets/list?name=stablecoins@86#shared',
-    id: '86'
-  },
-  {
-    name: 'Decentralized Exchanges',
-    assetType: 'decentralized exchanges',
-    to: '/assets/list?name=decentralized%20exchanges@127#shared',
-    id: '127'
-  },
-  {
-    name: 'Centralized Exchanges',
-    assetType: 'centralized exchanges',
-    to: '/assets/list?name=centralized%20exchanges@272#shared',
-    id: '272'
-  }
-]
-
 export const TRENDING_WATCHLIST_NAME = 'Emerging trending assets'
 
 export const WATCHLISTS_BY_SLUG = [
@@ -44,6 +23,24 @@ export const WATCHLISTS_BY_SLUG = [
     bySlug: 'Top_50_ERC20'
   },
   {
+    name: 'Stablecoins',
+    assetType: 'stablecoins',
+    to: '/assets/list?name=stablecoins#shared',
+    bySlug: 'stablecoins'
+  },
+  {
+    name: 'Centralized Exchanges',
+    assetType: 'centralized exchanges',
+    to: '/assets/list?name=centralized%20exchanges#shared',
+    bySlug: 'centalized_exchanges'
+  },
+  {
+    name: 'Decentralized Exchanges',
+    assetType: 'decentralized exchanges',
+    to: '/assets/list?name=decentralized%20exchanges#shared',
+    bySlug: 'decentalized_exchanges'
+  },
+  {
     name: TRENDING_WATCHLIST_NAME,
     assetType: 'trending assets',
     to: '/assets/list?name=trending%20assets#shared',
@@ -51,8 +48,4 @@ export const WATCHLISTS_BY_SLUG = [
   }
 ]
 
-export const CATEGORIES = [
-  ...BASIC_CATEGORIES,
-  ...WATCHLISTS_BY_SLUG,
-  ...PUBLIC_WATCHLISTS
-]
+export const CATEGORIES = [...BASIC_CATEGORIES, ...WATCHLISTS_BY_SLUG]

--- a/src/pages/assets/utils.js
+++ b/src/pages/assets/utils.js
@@ -1,13 +1,10 @@
 import qs from 'query-string'
-import {
-  PUBLIC_WATCHLISTS,
-  WATCHLISTS_BY_SLUG
-} from './assets-overview-constants'
+import { WATCHLISTS_BY_SLUG } from './assets-overview-constants'
 
 const getListName = name => {
-  const isPublic =
-    PUBLIC_WATCHLISTS.find(({ assetType }) => assetType === name) ||
-    WATCHLISTS_BY_SLUG.find(({ assetType }) => assetType === name)
+  const isPublic = WATCHLISTS_BY_SLUG.find(
+    ({ assetType }) => assetType === name
+  )
   return isPublic ? isPublic.name : name
 }
 

--- a/src/pages/assets/utils.js
+++ b/src/pages/assets/utils.js
@@ -1,13 +1,13 @@
 import qs from 'query-string'
 import {
   PUBLIC_WATCHLISTS,
-  WATCHLISTS_BY_FUNCTION
+  WATCHLISTS_BY_SLUG
 } from './assets-overview-constants'
 
 const getListName = name => {
   const isPublic =
     PUBLIC_WATCHLISTS.find(({ assetType }) => assetType === name) ||
-    WATCHLISTS_BY_FUNCTION.find(({ assetType }) => assetType === name)
+    WATCHLISTS_BY_SLUG.find(({ assetType }) => assetType === name)
   return isPublic ? isPublic.name : name
 }
 

--- a/src/queries/WatchlistGQL.js
+++ b/src/queries/WatchlistGQL.js
@@ -48,21 +48,46 @@ export const PUBLIC_WATCHLIST_QUERY = gql`
   ${listShortItems}
 `
 
-export const PROJECTS_BY_FUNCTION_SHORT_QUERY = gql`
-  query allProjectsByFunction($function: json!) {
-    allProjectsByFunction(function: $function) {
-      slug
+export const WATCHLIST_BY_SLUG_SHORT_QUERY = gql`
+  query watchlistBySlug($slug: String!) {
+    watchlistBySlug(slug: $slug) {
+      ...generalListData
+      listItems {
+        project {
+          ...generalData
+          ...project
+        }
+      }
     }
   }
+  ${generalListData}
+  ${generalData}
+  ${project}
 `
 
-export const PROJECTS_BY_FUNCTION_BIG_QUERY = gql`
-  query allProjectsByFunction($function: json!) {
-    allProjectsByFunction(function: $function) {
-      ...generalData
-      ...project
+export const WATCHLIST_BY_SLUG_BIG_QUERY = gql`
+  query watchlistBySlug($slug: String!) {
+    watchlistBySlug(slug: $slug) {
+      ...generalListData
+      stats {
+        trendingProjects {
+          ...generalData
+          ...project
+        }
+      }
+      settings {
+        pageSize
+        tableColumns
+      }
+      listItems {
+        project {
+          ...generalData
+          ...project
+        }
+      }
     }
   }
+  ${generalListData}
   ${generalData}
   ${project}
 `

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -33,6 +33,11 @@ export default (state = initialState, action) => {
       return {
         ...state,
         isCurrentUserTheAuthor: false,
+        isLoading: false,
+        error: false,
+        items: [],
+        trendingAssets: [],
+        isPublicWatchlist: false,
         ...action.payload,
         timestamp: Date.now()
       }


### PR DESCRIPTION
**Summary**
- replaced `projectsByFunction` -> `watchlistBySlug`
- made `Stablecoins`, `Centralized exchanges`, `Decentralized exchanges` as dynamic watchlists. 
But they don't work on stage (work on prod)
