### PR TITLE
fix/insight-link-bug

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -45,22 +45,29 @@ const getConsentUrl = () => {
   )
 }
 
+// NOTE(haritonasty): added additional function after sanitize due to bug with double encoding some symbols in links.
+// regexp finds links (<a>) and removes inside tag and in href repetitions
+const removeAmpersandRepetitions = str =>
+  str.replace(/(?!<a(.*)>(.*))(&amp;)(?=(.*)<\/a>)/gi, '&')
+
 const sanitizeMediumDraftHtml = html =>
-  sanitizeHtml(html, {
-    allowedTags: [
-      ...sanitizeHtml.defaults.allowedTags,
-      'figure',
-      'figcaption',
-      'img',
-      'h1',
-      'h2',
-      'u'
-    ],
-    allowedAttributes: {
-      ...sanitizeHtml.defaults.allowedAttributes,
-      '*': ['class', 'id']
-    }
-  })
+  removeAmpersandRepetitions(
+    sanitizeHtml(html, {
+      allowedTags: [
+        ...sanitizeHtml.defaults.allowedTags,
+        'figure',
+        'figcaption',
+        'img',
+        'h1',
+        'h2',
+        'u'
+      ],
+      allowedAttributes: {
+        ...sanitizeHtml.defaults.allowedAttributes,
+        '*': ['class', 'id']
+      }
+    })
+  )
 
 const filterProjectsByMarketSegment = (projects, categories) => {
   if (projects === undefined || Object.keys(categories).length === 0) {


### PR DESCRIPTION
**Summary**
add regexp that find repetitions inside links
**Screenshots**
before: 
![image](https://user-images.githubusercontent.com/24521041/63620955-6ac0e380-c5fb-11e9-9e6d-5a2e94087347.png)
now:
![image](https://user-images.githubusercontent.com/24521041/63620991-84622b00-c5fb-11e9-9958-2ca2338dac40.png)
