### PR TITLE
Feature/san 5471 v2

### DIFF
--- a/src/ducks/Signals/signalFormManager/signalCrudForm/signal/__snapshots__/TriggerForm.spec.js.snap
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/signal/__snapshots__/TriggerForm.spec.js.snap
@@ -91,7 +91,7 @@ exports[`TriggerForm smoke 1`] = `
         "label": "Price",
         "value": "price",
       },
-      "percentThreshold": 25,
+      "percentThreshold": 10,
       "signalType": Object {
         "label": "Assets",
         "value": "assets",
@@ -112,9 +112,9 @@ exports[`TriggerForm smoke 1`] = `
           "timeWindow",
         ],
         "filledField": true,
-        "label": "Moving up %",
+        "label": "Moving down %",
         "metric": "price_percent_change",
-        "value": "percent_up",
+        "value": "percent_down",
       },
     }
   }

--- a/src/ducks/Signals/utils/constants.js
+++ b/src/ducks/Signals/utils/constants.js
@@ -320,11 +320,11 @@ export const METRIC_DEFAULT_VALUES = {
     frequencyType: { ...FREQUENCY_TYPE_ONCEPER_MODEL },
     frequencyTimeType: { ...FREQUENCY_TIME_TYPE_DAILY_MODEL },
     frequencyTimeValue: { ...frequencyTymeValueBuilder(1) },
-    percentThreshold: 25,
+    percentThreshold: 10,
     threshold: BASE_THRESHOLD,
     timeWindow: 1,
     timeWindowUnit: { label: 'Day(s)', value: 'd' },
-    type: PRICE_PERCENT_CHANGE_UP_MODEL,
+    type: PRICE_PERCENT_CHANGE_DOWN_MODEL,
     isRepeating: true,
     channels: ['Telegram'],
     absoluteThreshold: 25,
@@ -384,7 +384,7 @@ export const DEFAULT_FORM_META_SETTINGS = {
   },
   type: {
     isDisabled: false,
-    value: { ...PRICE_PERCENT_CHANGE_UP_MODEL }
+    value: { ...PRICE_PERCENT_CHANGE_DOWN_MODEL }
   },
   frequencyType: {
     isDisabled: false,

--- a/src/ducks/Signals/utils/utils.js
+++ b/src/ducks/Signals/utils/utils.js
@@ -756,7 +756,7 @@ export const getNearestTypeByMetric = metric => {
       return ETH_WALLET_AMOUNT_UP
     }
     case PRICE_METRIC.value: {
-      return PRICE_PERCENT_CHANGE_UP_MODEL
+      return PRICE_PERCENT_CHANGE_DOWN_MODEL
     }
     case DAILY_ACTIVE_ADDRESSES_METRIC.value: {
       return PRICE_PERCENT_CHANGE_UP_MODEL


### PR DESCRIPTION
Summary:
* default signal for 'Price' metric changed to 'moving down 10%'

Screenshots:
![image](https://user-images.githubusercontent.com/14061779/63708418-173dd800-c83d-11e9-877b-cf2fd5d7bf65.png)
