### PR TITLE
feature/chart-download

### DIFF
--- a/src/ducks/SANCharts/ChartActiveMetrics.js
+++ b/src/ducks/SANCharts/ChartActiveMetrics.js
@@ -7,12 +7,10 @@ import MetricIcon from './MetricIcon'
 import { Metrics, METRIC_COLORS } from './utils'
 import styles from './ChartActiveMetrics.module.scss'
 
-export const CHART_ACTIVE_METRICS_ID = 'SAN-chart-active-metrics'
-
 const ChartActiveMetrics = ({ activeMetrics, toggleMetric }) => {
   let newColorId = 0
   return (
-    <section className={styles.wrapper} data-id={CHART_ACTIVE_METRICS_ID}>
+    <section className={styles.wrapper}>
       {activeMetrics.map(metric => {
         const { node, color, label, description } = Metrics[metric]
         return (

--- a/src/ducks/SANCharts/ChartActiveMetrics.js
+++ b/src/ducks/SANCharts/ChartActiveMetrics.js
@@ -7,10 +7,12 @@ import MetricIcon from './MetricIcon'
 import { Metrics, METRIC_COLORS } from './utils'
 import styles from './ChartActiveMetrics.module.scss'
 
+export const CHART_ACTIVE_METRICS_ID = 'SAN-chart-active-metrics'
+
 const ChartActiveMetrics = ({ activeMetrics, toggleMetric }) => {
   let newColorId = 0
   return (
-    <section className={styles.wrapper}>
+    <section className={styles.wrapper} data-id={CHART_ACTIVE_METRICS_ID}>
       {activeMetrics.map(metric => {
         const { node, color, label, description } = Metrics[metric]
         return (

--- a/src/ducks/SANCharts/ChartDownloadBtn.js
+++ b/src/ducks/SANCharts/ChartDownloadBtn.js
@@ -120,7 +120,7 @@ function downloadChart (metrics, title) {
 
     const date = new Date()
     const { DD, MMM, YYYY } = getDateFormats(date)
-    const { HH, mm } = getTimeFormats(date)
+    const { HH, mm, ss } = getTimeFormats(date)
     const a = document.createElement('a')
     a.download = `${title} [${HH}.${mm}.${ss}, ${DD} ${MMM}, ${YYYY}].png`
     a.href = canvas.toDataURL('image/png', 1)

--- a/src/ducks/SANCharts/ChartDownloadBtn.js
+++ b/src/ducks/SANCharts/ChartDownloadBtn.js
@@ -13,12 +13,15 @@ position: absolute;
 left: 200vw;`
 
 const SVG_STYLES = `
-    --porcelain: #e7eaf3;
-    --malibu: #68dbf4;
-    --heliotrope: #8358ff;
-    --persimmon: #ff5b5b;
-    --texas-rose: #ffad4d;
-    --jungle-green: #14c393;
+    --porcelain: ${colors.porcelain};
+    --malibu: ${colors.malibu};
+    --heliotrope: ${colors.heliotrope};
+    --persimmon: ${colors.persimmon};
+    --texas-rose: ${colors['texas-rose']};
+    --jungle-green: ${colors['jungle-green']};
+    --lima: ${colors.lima};
+    --dodger-blue: ${colors['dodger-blue']};
+    --waterloo: ${colors.waterloo};
     background: white;
   `
 

--- a/src/ducks/SANCharts/ChartDownloadBtn.js
+++ b/src/ducks/SANCharts/ChartDownloadBtn.js
@@ -1,0 +1,96 @@
+import React from 'react'
+import Button from '@santiment-network/ui/Button'
+
+function setStyle (target, styles) {
+  target.setAttribute('style', styles)
+}
+
+const SVG_STYLES = `
+    --porcelain: #e7eaf3;
+    --malibu: #68dbf4;
+    --heliotrope: #8358ff;
+    --persimmon: #ff5b5b;
+    --texas-rose: #ffad4d;
+    --jungle-green: #14c393;
+    background: white;
+  `
+
+const TEXT_STYLES = `
+fill: #9faac4;
+font-family: Rubik, sans-serif;
+font-weight: 400;
+font-size: 12px;
+line-height: 18px;
+`
+
+const AXIS_STYLES = `
+stroke: var(--porcelain);
+stroke-dasharray: 7;
+`
+
+const TICK_STYLES = 'display: none'
+
+function downloadChart () {
+  const svg = document.querySelector('.recharts-surface')
+
+  setStyle(svg, SVG_STYLES)
+
+  const texts = svg.querySelectorAll('text')
+  texts.forEach(text => setStyle(text, TEXT_STYLES))
+
+  const axes = svg.querySelectorAll('.recharts-cartesian-axis-line')
+  axes.forEach(axis => setStyle(axis, AXIS_STYLES))
+
+  const axisTicks = svg.querySelectorAll('.recharts-cartesian-axis-tick-line')
+  axisTicks.forEach(tick => setStyle(tick, TICK_STYLES))
+
+  const brush = svg.querySelector('.recharts-brush')
+  brush.style.display = 'none'
+
+  const svgData = new XMLSerializer().serializeToString(svg)
+  const canvas = document.createElement('canvas')
+  document.body.appendChild(canvas)
+  const img = document.createElement('img')
+
+  const svgSize = svg.getBoundingClientRect()
+  canvas.width = svgSize.width * 2
+  canvas.height = svgSize.height * 2
+  canvas.style.width = svgSize.width
+  canvas.style.height = svgSize.height
+
+  const ctx = canvas.getContext('2d')
+  ctx.scale(2, 2)
+
+  img.setAttribute(
+    'src',
+    'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(svgData)))
+  )
+
+  img.onload = function () {
+    ctx.drawImage(img, 0, 0)
+    const canvasdata = canvas.toDataURL('image/png', 1)
+
+    const pngimg = document.createElement('img')
+    pngimg.src = canvasdata
+    document.body.appendChild(pngimg)
+
+    const a = document.createElement('a')
+    a.download = 'chart' + '.png'
+    a.href = canvasdata
+    document.body.appendChild(a)
+    a.click()
+
+    brush.style.display = ''
+
+    canvas.remove()
+    pngimg.remove()
+    img.remove()
+    a.remove()
+  }
+}
+
+const ChartDownloadBtn = ({ ...props }) => {
+  return <Button {...props} onClick={downloadChart} />
+}
+
+export default ChartDownloadBtn

--- a/src/ducks/SANCharts/ChartDownloadBtn.js
+++ b/src/ducks/SANCharts/ChartDownloadBtn.js
@@ -1,9 +1,14 @@
 import React from 'react'
 import Button from '@santiment-network/ui/Button'
+import { CHART_ACTIVE_METRICS_ID } from './ChartActiveMetrics'
 
 function setStyle (target, styles) {
   target.setAttribute('style', styles)
 }
+
+const HIDDEN_STYLES = `
+position: absolute;
+left: 200vw;`
 
 const SVG_STYLES = `
     --porcelain: #e7eaf3;
@@ -31,8 +36,13 @@ stroke-dasharray: 7;
 const TICK_STYLES = 'display: none'
 
 function downloadChart () {
-  const svg = document.querySelector('.recharts-surface')
+  const div = document.createElement('div')
+  setStyle(div, HIDDEN_STYLES)
+  const svg = document.querySelector('.recharts-surface').cloneNode(true)
+  console.log(document.querySelector(`[data-id="${CHART_ACTIVE_METRICS_ID}"]`))
 
+  div.appendChild(svg)
+  document.body.appendChild(div)
   setStyle(svg, SVG_STYLES)
 
   const texts = svg.querySelectorAll('text')
@@ -48,8 +58,10 @@ function downloadChart () {
   brush.style.display = 'none'
 
   const svgData = new XMLSerializer().serializeToString(svg)
+
   const canvas = document.createElement('canvas')
-  document.body.appendChild(canvas)
+  div.appendChild(canvas)
+
   const img = document.createElement('img')
 
   const svgSize = svg.getBoundingClientRect()
@@ -72,24 +84,19 @@ function downloadChart () {
 
     const pngimg = document.createElement('img')
     pngimg.src = canvasdata
-    document.body.appendChild(pngimg)
+    div.appendChild(pngimg)
 
     const a = document.createElement('a')
-    a.download = 'chart' + '.png'
+    a.download = 'chart.png'
     a.href = canvasdata
-    document.body.appendChild(a)
+    div.appendChild(a)
     a.click()
 
-    brush.style.display = ''
-
-    canvas.remove()
-    pngimg.remove()
-    img.remove()
-    a.remove()
+    div.remove()
   }
 }
 
-const ChartDownloadBtn = ({ ...props }) => {
+const ChartDownloadBtn = props => {
   return <Button {...props} onClick={downloadChart} />
 }
 

--- a/src/ducks/SANCharts/ChartDownloadBtn.js
+++ b/src/ducks/SANCharts/ChartDownloadBtn.js
@@ -122,7 +122,7 @@ function downloadChart (metrics, title) {
     const { DD, MMM, YYYY } = getDateFormats(date)
     const { HH, mm } = getTimeFormats(date)
     const a = document.createElement('a')
-    a.download = `${title} [${HH}-${mm}, ${DD} ${MMM}, ${YYYY}].png`
+    a.download = `${title} [${HH}.${mm}.${ss}, ${DD} ${MMM}, ${YYYY}].png`
     a.href = canvas.toDataURL('image/png', 1)
 
     div.appendChild(a)

--- a/src/ducks/SANCharts/ChartDownloadBtn.js
+++ b/src/ducks/SANCharts/ChartDownloadBtn.js
@@ -47,7 +47,7 @@ function drawAndMeasureText (ctx, text, x, y) {
   return ctx.measureText(text).width
 }
 
-function downloadChart (metrics = ['historyPrice', 'mvrvRatio']) {
+function downloadChart (metrics) {
   const div = document.createElement('div')
   setStyle(div, HIDDEN_STYLES)
   const svg = document.querySelector('.recharts-surface').cloneNode(true)
@@ -93,6 +93,7 @@ function downloadChart (metrics = ['historyPrice', 'mvrvRatio']) {
     const textWidth =
       data.reduce((acc, { label }) => {
         return (
+          acc +
           LEGEND_RECT_SIZE +
           LEGEND_RECT_RIGHT_MARGIN +
           ctx.measureText(label).width
@@ -132,8 +133,8 @@ function downloadChart (metrics = ['historyPrice', 'mvrvRatio']) {
   )
 }
 
-const ChartDownloadBtn = props => {
-  return <Button {...props} onClick={() => downloadChart()} />
+const ChartDownloadBtn = ({ metrics, ...props }) => {
+  return <Button {...props} onClick={() => downloadChart(metrics)} />
 }
 
 export default ChartDownloadBtn

--- a/src/ducks/SANCharts/ChartDownloadBtn.js
+++ b/src/ducks/SANCharts/ChartDownloadBtn.js
@@ -2,6 +2,7 @@ import React from 'react'
 import Button from '@santiment-network/ui/Button'
 import colors from '@santiment-network/ui/variables.scss'
 import { Metrics, setupColorGenerator } from './utils'
+import { getDateFormats, getTimeFormats } from '../../utils/dates'
 
 function setStyle (target, styles) {
   target.setAttribute('style', styles)
@@ -47,7 +48,7 @@ function drawAndMeasureText (ctx, text, x, y) {
   return ctx.measureText(text).width
 }
 
-function downloadChart (metrics) {
+function downloadChart (metrics, title) {
   const div = document.createElement('div')
   setStyle(div, HIDDEN_STYLES)
   const svg = document.querySelector('.recharts-surface').cloneNode(true)
@@ -117,8 +118,11 @@ function downloadChart (metrics) {
       textX += drawAndMeasureText(ctx, label, textX, textY) + TEXT_RIGHT_MARGIN
     })
 
+    const date = new Date()
+    const { DD, MMM, YYYY } = getDateFormats(date)
+    const { HH, mm } = getTimeFormats(date)
     const a = document.createElement('a')
-    a.download = 'chart.png'
+    a.download = `${title} [${HH}-${mm}, ${DD} ${MMM}, ${YYYY}].png`
     a.href = canvas.toDataURL('image/png', 1)
 
     div.appendChild(a)
@@ -133,8 +137,8 @@ function downloadChart (metrics) {
   )
 }
 
-const ChartDownloadBtn = ({ metrics, ...props }) => {
-  return <Button {...props} onClick={() => downloadChart(metrics)} />
+const ChartDownloadBtn = ({ metrics, title, ...props }) => {
+  return <Button {...props} onClick={() => downloadChart(metrics, title)} />
 }
 
 export default ChartDownloadBtn

--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -341,9 +341,9 @@ class ChartPage extends Component {
                         to={to}
                         interval={interval}
                         hideSettings={hideSettings}
-                        title={title}
                         isAdvancedView={isAdvancedView}
                         classes={classes}
+                        activeMetrics={finalMetrics}
                       />
                     )}
                     {!viewOnly && (

--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -312,11 +312,13 @@ class ChartPage extends Component {
 
           return (
             <>
-              <Header
-                slug={slug}
-                isLoggedIn={isLoggedIn}
-                onSlugSelect={this.onSlugSelect}
-              />
+              {!viewOnly && (
+                <Header
+                  slug={slug}
+                  isLoggedIn={isLoggedIn}
+                  onSlugSelect={this.onSlugSelect}
+                />
+              )}
               <div className={styles.wrapper}>
                 <div
                   className={cx(
@@ -344,6 +346,7 @@ class ChartPage extends Component {
                         isAdvancedView={isAdvancedView}
                         classes={classes}
                         activeMetrics={finalMetrics}
+                        title={title}
                       />
                     )}
                     {!viewOnly && (

--- a/src/ducks/SANCharts/ChartSettings.js
+++ b/src/ducks/SANCharts/ChartSettings.js
@@ -25,7 +25,7 @@ const ChartSettings = ({
   to,
   hideSettings = {},
   isAdvancedView,
-  title
+  activeMetrics
 }) => {
   const shareLink = generateShareLink(disabledMetrics)
 
@@ -62,6 +62,7 @@ const ChartSettings = ({
           showNightModeToggle={showNightModeToggle}
           onNightModeSelect={onNightModeSelect}
           shareLink={shareLink}
+          activeMetrics={activeMetrics}
         />
       </div>
     </div>

--- a/src/ducks/SANCharts/ChartSettings.js
+++ b/src/ducks/SANCharts/ChartSettings.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Selector from '@santiment-network/ui/Selector/Selector'
 import IntervalSelector from './IntervalSelector'
-import { ShareChart } from './ChartSettingsContextMenu'
+import ChartSettingsContextMenu from './ChartSettingsContextMenu'
 import CalendarBtn from '../../components/Calendar/CalendarBtn'
 import UpgradeBtn from '../../components/UpgradeBtn/UpgradeBtn'
 import { getTimeIntervalFromToday, DAY } from '../../utils/dates'
@@ -57,7 +57,12 @@ const ChartSettings = ({
           interval={interval}
           onIntervalChange={onIntervalChange}
         />
-        <ShareChart asIcon shareLink={shareLink} />
+        <ChartSettingsContextMenu
+          isNightModeActive={isNightModeActive}
+          showNightModeToggle={showNightModeToggle}
+          onNightModeSelect={onNightModeSelect}
+          shareLink={shareLink}
+        />
       </div>
     </div>
   )

--- a/src/ducks/SANCharts/ChartSettings.js
+++ b/src/ducks/SANCharts/ChartSettings.js
@@ -25,7 +25,8 @@ const ChartSettings = ({
   to,
   hideSettings = {},
   isAdvancedView,
-  activeMetrics
+  activeMetrics,
+  title
 }) => {
   const shareLink = generateShareLink(disabledMetrics)
 
@@ -63,6 +64,7 @@ const ChartSettings = ({
           onNightModeSelect={onNightModeSelect}
           shareLink={shareLink}
           activeMetrics={activeMetrics}
+          title={title}
         />
       </div>
     </div>

--- a/src/ducks/SANCharts/ChartSettingsContextMenu.js
+++ b/src/ducks/SANCharts/ChartSettingsContextMenu.js
@@ -4,8 +4,23 @@ import Toggle from '@santiment-network/ui/Toggle'
 import Button from '@santiment-network/ui/Button'
 import Icon from '@santiment-network/ui/Icon'
 import Panel from '@santiment-network/ui/Panel/Panel'
+import ChartDownloadBtn from './ChartDownloadBtn'
 import ShareModalTrigger from '../../components/Share/ShareModalTrigger'
 import styles from './ChartPage.module.scss'
+
+const ShareChart = ({ trigger, shareLink }) => (
+  <ShareModalTrigger
+    trigger={trigger}
+    classes={styles}
+    shareLink={shareLink}
+    extraShare={[
+      {
+        value: `<iframe frameborder="0" height="340" src="${shareLink}"></iframe>`,
+        label: 'Copy iframe'
+      }
+    ]}
+  />
+)
 
 const ChartSettingsContextMenu = ({
   showNightModeToggle = true,
@@ -47,24 +62,12 @@ const ChartSettingsContextMenu = ({
             </Button>
           )}
         />
+        <ChartDownloadBtn fluid variant='ghost'>
+          Save as .png
+        </ChartDownloadBtn>
       </Panel>
     </ContextMenu>
   )
 }
-
-export const ShareChart = ({ trigger, shareLink, asIcon }) => (
-  <ShareModalTrigger
-    trigger={trigger}
-    classes={styles}
-    shareLink={shareLink}
-    asIcon={asIcon}
-    extraShare={[
-      {
-        value: `<iframe frameborder="0" height="340" src="${shareLink}"></iframe>`,
-        label: 'Copy iframe'
-      }
-    ]}
-  />
-)
 
 export default ChartSettingsContextMenu

--- a/src/ducks/SANCharts/ChartSettingsContextMenu.js
+++ b/src/ducks/SANCharts/ChartSettingsContextMenu.js
@@ -26,7 +26,8 @@ const ChartSettingsContextMenu = ({
   showNightModeToggle = true,
   isNightModeActive,
   onNightModeSelect,
-  shareLink
+  shareLink,
+  activeMetrics
 }) => {
   return (
     <ContextMenu
@@ -62,7 +63,7 @@ const ChartSettingsContextMenu = ({
             </Button>
           )}
         />
-        <ChartDownloadBtn fluid variant='ghost'>
+        <ChartDownloadBtn fluid variant='ghost' metrics={activeMetrics}>
           Save as .png
         </ChartDownloadBtn>
       </Panel>

--- a/src/ducks/SANCharts/ChartSettingsContextMenu.js
+++ b/src/ducks/SANCharts/ChartSettingsContextMenu.js
@@ -70,7 +70,7 @@ const ChartSettingsContextMenu = ({
           metrics={activeMetrics}
           title={title}
         >
-          Save as .png
+          Download as PNG
         </ChartDownloadBtn>
       </Panel>
     </ContextMenu>

--- a/src/ducks/SANCharts/ChartSettingsContextMenu.js
+++ b/src/ducks/SANCharts/ChartSettingsContextMenu.js
@@ -27,7 +27,8 @@ const ChartSettingsContextMenu = ({
   isNightModeActive,
   onNightModeSelect,
   shareLink,
-  activeMetrics
+  activeMetrics,
+  title
 }) => {
   return (
     <ContextMenu
@@ -63,7 +64,12 @@ const ChartSettingsContextMenu = ({
             </Button>
           )}
         />
-        <ChartDownloadBtn fluid variant='ghost' metrics={activeMetrics}>
+        <ChartDownloadBtn
+          fluid
+          variant='ghost'
+          metrics={activeMetrics}
+          title={title}
+        >
           Save as .png
         </ChartDownloadBtn>
       </Panel>

--- a/src/ducks/SANCharts/utils.js
+++ b/src/ducks/SANCharts/utils.js
@@ -235,12 +235,20 @@ export const findYAxisMetric = metrics =>
   metrics.find(metric => Metrics[metric].node !== Bar) ||
   metrics[0]
 
+export const setupColorGenerator = () => {
+  let colorIndex = 0
+
+  return function (color) {
+    return color || METRIC_COLORS[colorIndex++]
+  }
+}
+
 export const generateMetricsMarkup = (
   metrics,
   { ref = {}, data = {} } = {}
 ) => {
   const metricWithYAxis = findYAxisMetric(metrics)
-  let colorIndex = 0
+  const generateColor = setupColorGenerator()
 
   return metrics.reduce((acc, metric) => {
     const {
@@ -255,8 +263,7 @@ export const generateMetricsMarkup = (
     } = typeof metric === 'object' ? metric : Metrics[metric]
 
     const rest = {
-      [El === Bar ? 'fill' : 'stroke']: `var(--${color ||
-        METRIC_COLORS[colorIndex++]})`,
+      [El === Bar ? 'fill' : 'stroke']: `var(--${generateColor(color)})`,
       [El === Area && gradientUrl && 'fill']: gradientUrl,
       [El === Area && gradientUrl && 'fillOpacity']: 1
     }


### PR DESCRIPTION
### Summary
Making able to download the chart.
Result filename template: `Name (ticker) [HH.mm.ss, Date Month, Year]`, e.g. `Santiment (SAN) [19.28.33, 27 Aug, 2019]`

### Screenshots
![res](https://media.giphy.com/media/gjftr2yZ0nUw9qH4iw/giphy.gif)


- input 
![image](https://user-images.githubusercontent.com/25135650/63789675-80d2ea80-c900-11e9-9436-7907a49148c9.png)

- output 
![image](https://user-images.githubusercontent.com/25135650/63789693-87616200-c900-11e9-9bc5-77274ad09ecd.png)

