### PR TITLE
fix: signal preview

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,7 @@ import { getConsentUrl } from './utils/utils'
 import CookiePopup from './components/CookiePopup/CookiePopup'
 import LogoutPage from './pages/Logout/Logout'
 import LabsPage from './pages/Labs'
+import { mapSizesToProps } from './utils/withSizes'
 import './App.scss'
 
 const LoadableLoginPage = Loadable({
@@ -367,12 +368,6 @@ const mapStateToProps = state => {
     hasMetamask: ethAccounts.length > 0 && ethAccounts[0].address
   }
 }
-
-export const mapSizesToProps = ({ width }) => ({
-  isDesktop: width > 768,
-  isTablet: width <= 992 && width > 768,
-  isPhone: width <= 768
-})
 
 const enchance = compose(
   connect(mapStateToProps),

--- a/src/components/Insight/InsightCardWithMarketcap.js
+++ b/src/components/Insight/InsightCardWithMarketcap.js
@@ -2,10 +2,10 @@ import React from 'react'
 import { Panel } from '@santiment-network/ui'
 import cx from 'classnames'
 import withSizes from 'react-sizes'
-import { mapSizesToProps } from '../../App'
 import InsightCardInternals from './InsightCardInternals'
 import MarketcapChangeWidget from '../PostVisualBacktest'
 import { noTrendTagsFilter } from './utils'
+import { mapSizesToProps } from '../../utils/withSizes'
 import styles from './InsightCard.module.scss'
 
 const InsightCard = ({ className, tags, isDesktop, ...insight }) => {

--- a/src/components/Insight/InsightsWrap.js
+++ b/src/components/Insight/InsightsWrap.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import withSizes from 'react-sizes'
-import { mapSizesToProps } from '../../App'
 import InsightCard from './InsightCard'
+import { mapSizesToProps } from '../../utils/withSizes'
 import styles from './InsightsWrap.module.scss'
 
 const InsightsWrap = ({ insights, isDesktop }) => {

--- a/src/components/Responsive/index.js
+++ b/src/components/Responsive/index.js
@@ -1,6 +1,6 @@
 import withSizes from 'react-sizes'
 import PropTypes from 'prop-types'
-import { mapSizesToProps } from '../../App'
+import { mapSizesToProps } from '../../utils/withSizes'
 
 const enhance = withSizes(mapSizesToProps)
 

--- a/src/components/Trends/TrendsReChart.js
+++ b/src/components/Trends/TrendsReChart.js
@@ -18,8 +18,8 @@ import { mergeTimeseriesByKey } from './../../utils/utils'
 import mixWithPaywallArea from './../PaywallArea/PaywallArea'
 import UpgradeBtn from './../UpgradeBtn/UpgradeBtn'
 import { sourcesMeta as chartsMeta } from './trendsUtils'
-import { mapSizesToProps } from '../../App'
 import { getDateFormats } from '../../utils/dates'
+import { mapSizesToProps } from '../../utils/withSizes'
 import styles from './TrendsReChart.module.scss'
 
 const toggleCharts = Object.keys(chartsMeta).filter(key => key !== 'total')

--- a/src/components/formik-santiment-ui/FormikSelect.scss
+++ b/src/components/formik-santiment-ui/FormikSelect.scss
@@ -1,6 +1,8 @@
 @import "~@santiment-network/ui/mixins";
 
 $select-line-height: 30px;
+$select-width: 200px;
+$select-height: 330px;
 
 .Select--single {
   .Select-control {
@@ -90,9 +92,11 @@ $select-line-height: 30px;
 }
 
 .Select-menu-outer {
-  max-height: 330px;
+  max-height: $select-height;
+  min-width: $select-width;
 }
 
 .Select-menu {
-  max-height: 330px;
+  max-height: $select-height;
+  min-width: $select-width;
 }

--- a/src/ducks/Signals/chart/SignalPreview.js
+++ b/src/ducks/Signals/chart/SignalPreview.js
@@ -1,12 +1,15 @@
 import React, { useState } from 'react'
 import { connect } from 'react-redux'
 import { ReferenceLine } from 'recharts'
+import Loader from '@santiment-network/ui/Loader/Loader'
 import { getMetricsByType, getTimeRangeForChart } from '../utils/utils'
 import { Metrics } from '../../SANCharts/utils'
 import GetTimeSeries from '../../GetTimeSeries/GetTimeSeries'
 import ChartWidget from '../../SANCharts/ChartPage'
 import VisualBacktestChart from './VisualBacktestChart'
 import { ChartExpandView } from './ChartExpandView'
+import { DesktopOnly } from './../../../components/Responsive'
+import styles from './SignalPreview.module.scss'
 
 const SignalPreviewChart = ({
   type,
@@ -35,14 +38,14 @@ const SignalPreviewChart = ({
   return (
     <GetTimeSeries
       metrics={requestedMetrics}
-      render={({
-        timeseries,
-        errorMetrics = {},
-        isError,
-        errorType,
-        ...rest
-      }) => {
-        if (!timeseries) return 'Loading...'
+      render={({ timeseries }) => {
+        if (!timeseries) {
+          return (
+            <div className={styles.loaderWrapper}>
+              <Loader className={styles.loader} />
+            </div>
+          )
+        }
 
         return (
           <VisualBacktestChart
@@ -71,26 +74,29 @@ const SignalPreview = ({ type, points = [], target: slug, height }) => {
         height={height}
         triggeredSignals={triggeredSignals}
       />
-      <ChartExpandView>
-        <ChartWidget
-          timeRange={timeRange}
-          slug={slug}
-          interval='1d'
-          title={slug}
-          hideSettings={{
-            header: true,
-            sidecar: true
-          }}
-        >
-          {triggeredSignals.map(({ datetime }) => (
-            <ReferenceLine
-              key={datetime}
-              stroke='var(--persimmon)'
-              x={+new Date(datetime)}
-            />
-          ))}
-        </ChartWidget>
-      </ChartExpandView>
+
+      <DesktopOnly>
+        <ChartExpandView>
+          <ChartWidget
+            timeRange={timeRange}
+            slug={slug}
+            interval='1d'
+            title={slug}
+            hideSettings={{
+              header: true,
+              sidecar: true
+            }}
+          >
+            {triggeredSignals.map(({ datetime }) => (
+              <ReferenceLine
+                key={datetime}
+                stroke='var(--persimmon)'
+                x={+new Date(datetime)}
+              />
+            ))}
+          </ChartWidget>
+        </ChartExpandView>
+      </DesktopOnly>
     </>
   )
 }

--- a/src/ducks/Signals/chart/SignalPreview.module.scss
+++ b/src/ducks/Signals/chart/SignalPreview.module.scss
@@ -65,3 +65,14 @@
   top: -5px !important;
   right: -10px !important;
 }
+
+.loaderWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 150px;
+}
+
+.loader {
+  font-size: 5px;
+}

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.js
@@ -261,7 +261,7 @@ export const TriggerForm = ({
                   )}
 
                   {showChart && (
-                    <Fragment>
+                    <>
                       {(showTypes || metricValueBlocks) && (
                         <TriggerFormBlockDivider />
                       )}
@@ -271,7 +271,7 @@ export const TriggerForm = ({
                           type={metric.value}
                         />
                       </div>
-                    </Fragment>
+                    </>
                   )}
                 </TriggerFormBlock>
               )}

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.module.scss
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.module.scss
@@ -291,7 +291,6 @@ a {
 
 .fieldTimeWindow {
   @include responsive('phone', 'phone-xs') {
-    margin-top: $trigger-form-field-margin;
     padding: 0;
   }
 }

--- a/src/pages/Insights/InsightsAllFeedPage.js
+++ b/src/pages/Insights/InsightsAllFeedPage.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import InfiniteScroll from 'react-infinite-scroller'
 import withSizes from 'react-sizes'
-import { mapSizesToProps } from '../../App'
 import { client } from '../../index'
 import { ALL_INSIGHTS_BY_PAGE_QUERY } from './../../queries/InsightsGQL'
 import InsightsFeed from '../../components/Insight/InsightsFeed'
 import InsightsScrollable from '../../components/Insight/InsightsScrollable'
+import { mapSizesToProps } from '../../utils/withSizes'
 import styles from './InsightsAllFeedPage.module.scss'
 
 class InsightsAllFeedPage extends React.PureComponent {

--- a/src/utils/withSizes.js
+++ b/src/utils/withSizes.js
@@ -1,0 +1,5 @@
+export const mapSizesToProps = ({ width }) => ({
+  isDesktop: width > 768,
+  isTablet: width <= 992 && width > 768,
+  isPhone: width <= 768
+})


### PR DESCRIPTION
Summary:
1. add loader
2. fixed imports on mapSizesToProps
3. hide smart chart button for mobile(show only in desktops)

Screenshots:
![image](https://user-images.githubusercontent.com/14061779/63839413-efa75680-c987-11e9-8fec-696142128f94.png)
![image](https://user-images.githubusercontent.com/14061779/63839483-106fac00-c988-11e9-98b6-918d7380ac24.png)
