### PR TITLE
fix: empty title on anonymous signal popup

### DIFF
--- a/src/ducks/Signals/signalModal/SignalMasterModalForm.js
+++ b/src/ducks/Signals/signalModal/SignalMasterModalForm.js
@@ -167,6 +167,15 @@ const MainDialog = ({
   const [dialogTitle, onSetDialogTitle] = useState('')
   const { variant, border } = buttonParams
 
+  useEffect(
+    () => {
+      if (!isLoggedIn) {
+        onSetDialogTitle('Create signal')
+      }
+    },
+    [isLoggedIn]
+  )
+
   return (
     <Dialog
       open={dialogOpenState}


### PR DESCRIPTION
Summary:
* fixed empty title on signal creation popup

Screenshots:
![image](https://user-images.githubusercontent.com/14061779/63913878-59803880-ca3a-11e9-963d-c17a9fdc7b42.png)
