### PR TITLE
add usd formatter for volume metric

### DIFF
--- a/src/ducks/SANCharts/utils.js
+++ b/src/ducks/SANCharts/utils.js
@@ -60,7 +60,8 @@ export const Metrics = {
     fill: true,
     dataKey: 'volume',
     color: 'waterloo',
-    opacity: 0.4
+    opacity: 0.4,
+    formatter: val => formatNumber(val, { currency: 'USD' })
   },
   socialVolume: {
     category: 'Social',


### PR DESCRIPTION
Summary: 
* added usd formatter for volume metric

Screenshots:
![image](https://user-images.githubusercontent.com/14061779/64073017-05c35880-cca1-11e9-9c76-f22dbd5fbe23.png)
