### PR TITLE
add approve/cancel buttons for projects selection popup

### DIFF
--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/projectsSelector/TriggerProjectsSelector.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/projectsSelector/TriggerProjectsSelector.js
@@ -27,29 +27,29 @@ export const TriggerProjectsSelector = ({
   const [opened, setOpened] = useState(false)
   const checkedAssetsAsSet = new Set(listItems)
 
-  function closeDialog () {
+  const closeDialog = () => {
     setOpened(false)
   }
 
-  function openDialog () {
+  const openDialog = () => {
     setOpened(true)
   }
 
-  useEffect(
-    () => {
-      if (listItems.length === 0) {
-        const targetAssets = Array.isArray(target) ? target : [target]
+  const validate = force => {
+    if (force || listItems.length === 0) {
+      const targetAssets = Array.isArray(target) ? target : [target]
 
-        if (targetAssets.length > 0 && projects.length > 0) {
-          const preSelected = projects.filter(({ slug: projectSlug }) =>
-            targetAssets.some(
-              ({ value, slug }) => value === projectSlug || slug === projectSlug
-            )
+      if (targetAssets.length > 0 && projects.length > 0) {
+        const preSelected = projects.filter(({ slug: projectSlug }) =>
+          targetAssets.some(
+            ({ value, slug }) => value === projectSlug || slug === projectSlug
           )
-          setSelectedAssets(preSelected)
-        }
+        )
+        setSelectedAssets(preSelected)
       }
+    }
 
+    if (!force) {
       if (
         Array.isArray(target) &&
         target.length === 0 &&
@@ -57,6 +57,12 @@ export const TriggerProjectsSelector = ({
       ) {
         setSelectedAssets([])
       }
+    }
+  }
+
+  useEffect(
+    () => {
+      validate()
     },
     [target, projects]
   )
@@ -72,9 +78,6 @@ export const TriggerProjectsSelector = ({
     } else if (listItems.length !== newItems.length) {
       setListItems(newItems)
     }
-
-    setFieldValue && setFieldValue(name, newItems)
-    onChange && onChange(newItems, closeDialog)
   }
 
   const toggleAsset = ({ project, listItems: items, isAssetInList }) => {
@@ -83,6 +86,17 @@ export const TriggerProjectsSelector = ({
         ? items.filter(({ id }) => id !== project.id)
         : [...items, project]
     )
+  }
+
+  const cancel = () => {
+    validate(true)
+    setOpened(false)
+  }
+
+  const approve = () => {
+    setFieldValue && setFieldValue(name, listItems)
+    onChange && onChange(listItems, closeDialog)
+    closeDialog()
   }
 
   const onSuggestionSelect = project =>
@@ -96,7 +110,7 @@ export const TriggerProjectsSelector = ({
     <Dialog
       title={title}
       open={opened}
-      onClose={closeDialog}
+      onClose={cancel}
       trigger={
         <div onClick={openDialog}>
           <Trigger
@@ -137,6 +151,21 @@ export const TriggerProjectsSelector = ({
           />
         </div>
       </Dialog.ScrollContent>
+      {!isSingle && (
+        <Dialog.Actions className={styles.actions}>
+          <Dialog.Cancel border={false} accent='grey' onClick={cancel}>
+            Cancel
+          </Dialog.Cancel>
+          <Dialog.Approve
+            disabled={!listItems || listItems.length === 0}
+            variant='flat'
+            onClick={approve}
+            isLoading={isLoading}
+          >
+            Apply
+          </Dialog.Approve>
+        </Dialog.Actions>
+      )}
     </Dialog>
   )
 }

--- a/src/pages/Account/SettingsSonarWebPushNotifications.js
+++ b/src/pages/Account/SettingsSonarWebPushNotifications.js
@@ -8,17 +8,14 @@ import {
 } from '../../serviceWorker'
 import SidecarExplanationTooltip from '../../ducks/SANCharts/SidecarExplanationTooltip'
 import { getAPIUrl, getOrigin } from '../../utils/utils'
-import { hardReloadTabs } from '../../utils/localStorage'
 import styles from './AccountPage.module.scss'
 
 export const getSanSonarSW = registrations => {
   return registrations
     ? registrations
       .filter(({ active }) => !!active)
-      .find(
-        ({ active: { scriptURL, state } = {} } = {}) =>
-          scriptURL.endsWith('san-sonar-service-worker.js') &&
-            state === 'activated'
+      .find(({ active: { scriptURL, state } = {} } = {}) =>
+        scriptURL.endsWith('san-sonar-service-worker.js')
       )
     : undefined
 }
@@ -55,7 +52,6 @@ export const sendParams = () => {
 const SettingsSonarWebPushNotifications = ({
   classes = {},
   className,
-  canReload,
   recheckBrowserNotifications
 }) => {
   const [isActive, setIsActive] = useState(false)
@@ -129,7 +125,6 @@ const SettingsSonarWebPushNotifications = ({
                 requestNotificationPermission(null, noPermissionsCallback)
                 sendParams()
                 toggle(true)
-                canReload && hardReloadTabs()
                 recheckBrowserNotifications && recheckBrowserNotifications()
               }
             })


### PR DESCRIPTION
Summary:

* fix notifications checking (not wait 'activated' state for service worker)
* add apply/cancel buttons for signal projects selector

Screenshots:
![image](https://user-images.githubusercontent.com/14061779/64125665-70fd4f80-cdb3-11e9-8ad8-0b64a1d99574.png)
