### PR TITLE
fix: add isControlled for default page slug

### DIFF
--- a/src/pages/Chart/index.js
+++ b/src/pages/Chart/index.js
@@ -63,6 +63,7 @@ export default graphql(ALL_INSIGHTS_BY_PAGE_QUERY, {
                 isLoggedIn={isLoggedIn}
                 onSlugSelect={onChangeSlug}
                 AfterHeader={AfterHeader}
+                isControlled
                 {...boundaries}
               />
             </>


### PR DESCRIPTION
Summary:
* add isControlled for selecting asset from props

Screenshot:
default slug is bitcoin:
![image](https://user-images.githubusercontent.com/14061779/64237007-2a6b3a80-cf04-11e9-8f61-f65120a76f29.png)
