### PR TITLE
add link to etherscan for wallet balance page

### DIFF
--- a/src/components/WalletLink/ViewBalanceDialog.js
+++ b/src/components/WalletLink/ViewBalanceDialog.js
@@ -7,15 +7,11 @@ import HistoricalBalancePage, {
 import styles from './WalletLink.module.scss'
 import dialogStyles from './ViewBalanceDialog.module.scss'
 
-const ViewBalanceDialog = ({ isDesktop, address, assets }) => {
+const ViewBalanceDialog = ({ isDesktop, address, assets, trigger }) => {
   return (
     <Dialog
       title={<BalancePageTitle classes={styles} />}
-      trigger={
-        <div>
-          <BalancePageLink link='#' />
-        </div>
-      }
+      trigger={<div>{trigger || <BalancePageLink link='#' />}</div>}
       classes={dialogStyles}
     >
       <Dialog.ScrollContent>

--- a/src/components/WalletLink/WalletLink.js
+++ b/src/components/WalletLink/WalletLink.js
@@ -19,49 +19,77 @@ const WalletLink = ({
   isTx = false,
   isExchange = false,
   isDesktop
-}) => (
-  <SmoothDropdownItem
-    trigger={<Address address={address} isTx={isTx} isExchange={isExchange} />}
-  >
-    <ul className={styles.wrapper}>
-      {!isTx && (
-        <li>
-          <ViewBalanceDialog
-            assets={assets}
-            address={address}
-            isDesktop={isDesktop}
-          />
-        </li>
-      )}
-      <li>
-        <EtherscanLink address={address} isTx={isTx} className={styles.link}>
-          Open Etherscan
-        </EtherscanLink>
-      </li>
-    </ul>
-  </SmoothDropdownItem>
-)
+}) => {
+  const trigger = (
+    <Address
+      address={address}
+      isTx={isTx}
+      isExchange={isExchange}
+      asLink={isTx}
+    />
+  )
 
-const EtherscanLink = ({ address = '', isTx, isExchange, children }) => {
-  const addressShort =
-    (children || address).slice(0, isExchange ? 7 : 16) + '...'
+  if (isTx) {
+    return (
+      <SmoothDropdownItem trigger={trigger}>
+        <ul className={styles.wrapper}>
+          <li>
+            <EtherscanLink
+              address={address}
+              isTx={isTx}
+              className={styles.link}
+            >
+              Open Etherscan
+            </EtherscanLink>
+          </li>
+        </ul>
+      </SmoothDropdownItem>
+    )
+  } else {
+    return (
+      <ViewBalanceDialog
+        assets={assets}
+        address={address}
+        isDesktop={isDesktop}
+        trigger={trigger}
+      />
+    )
+  }
+}
+
+const EtherscanLink = ({
+  address = '',
+  isTx,
+  isExchange,
+  label,
+  isFull,
+  asLink = true,
+  children
+}) => {
+  const link = children || address
+  const addressShort = isFull
+    ? link
+    : link.slice(0, isExchange ? 7 : 16) + '...'
   return (
     <a
-      href={`https://etherscan.io/${isTx ? 'tx' : 'address'}/${address}`}
+      href={
+        asLink
+          ? `https://etherscan.io/${isTx ? 'tx' : 'address'}/${address}`
+          : '#'
+      }
       className={cx(styles.etherscanLink, styles.link)}
     >
-      {children || addressShort}
+      {label || children || addressShort}
     </a>
   )
 }
 
-const Address = ({ isExchange, ...rest }) => (
+export const Address = ({ isExchange, ...rest }) => (
   <>
     <EtherscanLink {...rest} isExchange={isExchange} />
     {isExchange && <Label className={styles.exchange}>exchange</Label>}
   </>
 )
-
 WalletLink.propTypes = propTypes
 
 export default WalletLink

--- a/src/ducks/HistoricalBalance/balanceView/BalanceView.js
+++ b/src/ducks/HistoricalBalance/balanceView/BalanceView.js
@@ -14,9 +14,10 @@ import GetTimeSeries from '../../GetTimeSeries/GetTimeSeries'
 import { Metrics } from '../../SANCharts/utils'
 import PageLoader from '../../../components/Loader/PageLoader'
 import BalanceViewWalletAssets from './BalanceViewWalletAssets'
-import styles from './BalanceView.module.scss'
 import { Area } from 'recharts'
 import { simpleSortStrings } from '../../../utils/sortMethods'
+import { Address } from '../../../components/WalletLink/WalletLink'
+import styles from './BalanceView.module.scss'
 
 const LoadableChartSettings = Loadable({
   loader: () => import('./BalanceViewChartSettings'),
@@ -152,6 +153,7 @@ const BalanceView = ({
         handleWalletChange={handleWalletChange}
         classes={classes}
       />
+
       <div className={cx(styles.chart, classes.balanceViewChart)}>
         <BalanceChartHeader assets={stateAssets} address={stateAddress}>
           <LoadableChartSettings

--- a/src/ducks/HistoricalBalance/balanceView/BalanceView.module.scss
+++ b/src/ducks/HistoricalBalance/balanceView/BalanceView.module.scss
@@ -101,6 +101,10 @@
   color: var(--waterloo);
 }
 
+.etherscan {
+  margin-top: 4px;
+}
+
 .InputWithAction input {
   margin-top: 0;
   border: none;

--- a/src/ducks/HistoricalBalance/balanceView/BalanceViewWalletAssets.js
+++ b/src/ducks/HistoricalBalance/balanceView/BalanceViewWalletAssets.js
@@ -4,6 +4,7 @@ import Input from '@santiment-network/ui/Input'
 import { isPossibleEthAddress } from '../../Signals/utils/utils'
 import AssetsField from '../AssetsField'
 import styles from './BalanceView.module.scss'
+import { Address } from '../../../components/WalletLink/WalletLink'
 
 const BalanceViewWalletAssets = ({
   address,
@@ -29,6 +30,16 @@ const BalanceViewWalletAssets = ({
           placeholder='Paste the address'
           onChange={handleWalletChange}
         />
+        {address && (
+          <div className={styles.etherscan}>
+            <Address
+              address={address}
+              isTx={false}
+              isFull
+              label='Open Etherscan'
+            />
+          </div>
+        )}
       </div>
       <div className={cx(styles.InputWrapper, styles.address)}>
         <label className={styles.label} htmlFor='slug'>


### PR DESCRIPTION
Summary:
* moved link into etherscan into wallet balance loading page

Screenshots:
![image](https://user-images.githubusercontent.com/14061779/64342531-64ffd080-cff3-11e9-8ca6-76a5ad1f9d53.png)
![image](https://user-images.githubusercontent.com/14061779/64342564-7943cd80-cff3-11e9-8ba2-63125ce990aa.png)
