### PR TITLE
handle api backtesting errors

### DIFF
--- a/src/ducks/Signals/chart/SignalPreview.js
+++ b/src/ducks/Signals/chart/SignalPreview.js
@@ -10,6 +10,13 @@ import VisualBacktestChart from './VisualBacktestChart'
 import { ChartExpandView } from './ChartExpandView'
 import { DesktopOnly } from './../../../components/Responsive'
 import styles from './SignalPreview.module.scss'
+import { Message } from 'semantic-ui-react'
+
+const PreviewLoader = (
+  <div className={styles.loaderWrapper}>
+    <Loader className={styles.loader} />
+  </div>
+)
 
 const SignalPreviewChart = ({
   type,
@@ -40,11 +47,7 @@ const SignalPreviewChart = ({
       metrics={requestedMetrics}
       render={({ timeseries }) => {
         if (!timeseries) {
-          return (
-            <div className={styles.loaderWrapper}>
-              <Loader className={styles.loader} />
-            </div>
-          )
+          return PreviewLoader
         }
 
         return (
@@ -60,7 +63,28 @@ const SignalPreviewChart = ({
   )
 }
 
-const SignalPreview = ({ type, points = [], target: slug, height }) => {
+const SignalPreview = ({
+  isError,
+  isLoading,
+  type,
+  points = [],
+  target: slug,
+  height
+}) => {
+  if (isLoading) {
+    return PreviewLoader
+  }
+
+  if (isError) {
+    return (
+      <div className={styles.loaderWrapper}>
+        Something's gone wrong.
+        <br />
+        Backtesting chart is unavailable.
+      </div>
+    )
+  }
+
   const { label, value: timeRange } = getTimeRangeForChart(type)
   const triggeredSignals = points.filter(point => point['triggered?'])
 

--- a/src/ducks/Signals/chart/SignalPreview.module.scss
+++ b/src/ducks/Signals/chart/SignalPreview.module.scss
@@ -68,6 +68,7 @@
 
 .loaderWrapper {
   display: flex;
+  text-align: center;
   align-items: center;
   justify-content: center;
   min-height: 150px;


### PR DESCRIPTION
**Summary**
1. Show loader for loading new points
2. Show error message if api returned 500 error

**Screenshots**
![image](https://user-images.githubusercontent.com/14061779/64529186-faaca000-d312-11e9-873d-21bb81671727.png)
![image](https://user-images.githubusercontent.com/14061779/64529206-08622580-d313-11e9-9877-a35b94aec835.png)
