### PR TITLE
feature/chart-day-ref-line

### DIFF
--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -461,6 +461,9 @@ class ChartPage extends Component {
                       chartRef={this.chartRef}
                       isLoading={isLoading}
                       onZoom={this.onZoom}
+                      from={from}
+                      to={to}
+                      slug={slug}
                       onZoomOut={this.onZoomOut}
                       isZoomed={zoom}
                       events={eventsFiltered}

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -8,6 +8,7 @@ import {
   Line,
   ResponsiveContainer,
   ComposedChart,
+  Label,
   XAxis,
   YAxis,
   Brush,
@@ -134,7 +135,7 @@ class Charts extends React.Component {
 
         const { metricAnomalyKey: anomaly } = rest
         const result = value || chartData[index]
-        let eventsData = getEventsTooltipInfo(rest)
+        const eventsData = getEventsTooltipInfo(rest)
         eventsData.map(event => {
           // NOTE(haritonasty): target metric for anomalies and tooltipMetricKey for other
           const key = event.isAnomaly
@@ -304,7 +305,11 @@ class Charts extends React.Component {
       ({ value, isAnomaly }) => metrics.includes(value) || !isAnomaly
     )
 
-    console.log(priceRefLineData)
+    const lastDayPrice =
+      priceRefLineData &&
+      `Last day price ${Metrics.historyPrice.formatter(
+        priceRefLineData.priceUsd
+      )}`
 
     return (
       <div className={styles.wrapper + ' ' + sharedStyles.chart} ref={chartRef}>
@@ -405,13 +410,15 @@ class Charts extends React.Component {
               />
             )}
 
-            {priceRefLineData && (
+            {lastDayPrice && (
               <ReferenceLine
                 y={priceRefLineData.priceUsd}
                 yAxisId='axis-priceUsd'
                 stroke='var(--jungle-green-hover)'
                 strokeDasharray='7'
-              />
+              >
+                <Label position='insideBottomRight'>{lastDayPrice}</Label>
+              </ReferenceLine>
             )}
 
             {metrics.includes(tooltipMetric) &&

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -409,8 +409,8 @@ class Charts extends React.Component {
               <ReferenceLine
                 y={priceRefLineData.priceUsd}
                 yAxisId='axis-priceUsd'
-                stroke='red'
-                strokeDasharray='3 3'
+                stroke='var(--jungle-green-hover)'
+                strokeDasharray='7'
               />
             )}
 

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -1,5 +1,8 @@
 import React from 'react'
+import gql from 'graphql-tag'
+import { graphql } from 'react-apollo'
 import cx from 'classnames'
+import { compose } from 'redux'
 import { connect } from 'react-redux'
 import {
   Line,
@@ -9,14 +12,19 @@ import {
   YAxis,
   Brush,
   ReferenceArea,
-  ReferenceDot
+  ReferenceDot,
+  ReferenceLine
 } from 'recharts'
 import throttle from 'lodash.throttle'
 import debounce from 'lodash.debounce'
 import Button from '@santiment-network/ui/Button'
 import Loader from '@santiment-network/ui/Loader/Loader'
 import { millify } from './../../utils/formatting'
-import { getDateFormats, getTimeFormats } from '../../utils/dates'
+import {
+  getDateFormats,
+  getTimeFormats,
+  ONE_DAY_IN_MS
+} from '../../utils/dates'
 import {
   getEventsTooltipInfo,
   Metrics,
@@ -29,6 +37,8 @@ import displayPaywall, { MOVE_CLB, CHECK_CLB } from './Paywall'
 import { binarySearch } from '../../pages/Trends/utils'
 import sharedStyles from './ChartPage.module.scss'
 import styles from './Chart.module.scss'
+
+const DAY_INTERVAL = ONE_DAY_IN_MS * 2
 
 const EMPTY_FORMATTER = () => {}
 const CHART_MARGINS = {
@@ -263,7 +273,8 @@ class Charts extends React.Component {
       leftBoundaryDate,
       rightBoundaryDate,
       children,
-      isLoading
+      isLoading,
+      priceRefLineData
     } = this.props
     const {
       refAreaLeft,
@@ -292,6 +303,8 @@ class Charts extends React.Component {
     events = events.filter(
       ({ value, isAnomaly }) => metrics.includes(value) || !isAnomaly
     )
+
+    console.log(priceRefLineData)
 
     return (
       <div className={styles.wrapper + ' ' + sharedStyles.chart} ref={chartRef}>
@@ -383,11 +396,21 @@ class Charts extends React.Component {
             <YAxis hide />
             {bars}
             {lines}
+
             {refAreaLeft && refAreaRight && (
               <ReferenceArea
                 x1={refAreaLeft}
                 x2={refAreaRight}
                 strokeOpacity={0.3}
+              />
+            )}
+
+            {priceRefLineData && (
+              <ReferenceLine
+                y={priceRefLineData.priceUsd}
+                yAxisId='axis-priceUsd'
+                stroke='red'
+                strokeDasharray='3 3'
               />
             )}
 
@@ -445,4 +468,42 @@ const mapStateToProps = state => ({
   hasPremium: checkHasPremium(state)
 })
 
-export default connect(mapStateToProps)(Charts)
+export const HISTORY_PRICE_QUERY = gql`
+  query historyPrice($slug: String, $from: DateTime, $to: DateTime) {
+    historyPrice(slug: $slug, from: $from, to: $to, interval: "1d") {
+      priceUsd
+      datetime
+    }
+  }
+`
+
+const enhance = compose(
+  connect(mapStateToProps),
+
+  graphql(HISTORY_PRICE_QUERY, {
+    skip: ({ metrics, from, to }) =>
+      !metrics.includes('historyPrice') ||
+      new Date(to) - new Date(from) > DAY_INTERVAL,
+    props: ({ data: { historyPrice = [] } }) => {
+      return { priceRefLineData: historyPrice[0] }
+    },
+    options: ({ slug, from }) => {
+      const newFrom = new Date(from)
+      newFrom.setHours(0, 0, 0, 0)
+
+      const to = new Date(newFrom)
+      to.setHours(1)
+
+      return {
+        variables: {
+          from: newFrom.toISOString(),
+          to: to.toISOString(),
+          slug,
+          interval: '1d'
+        }
+      }
+    }
+  })
+)
+
+export default enhance(Charts)


### PR DESCRIPTION
### Summary
Displaying end of the last day project price if the interval is smaller than 1 day. Reference line is showed only if the `price` metric is on.
### Screenshot
![image](https://user-images.githubusercontent.com/25135650/65026098-88564400-d940-11e9-90ed-6a856cf36ea0.png)

