### PR TITLE
fixed: show notification if not connected TG; showing enabled channels

### DIFF
--- a/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.js
@@ -6,7 +6,7 @@ import { Formik, Form } from 'formik'
 import { connect } from 'react-redux'
 import isEqual from 'lodash.isequal'
 import {
-  selectIsTelegramConnected,
+  isTelegramConnectedAndEnabled,
   selectIsEmailConnected
 } from '../../../../../pages/UserSelectors'
 import {
@@ -411,7 +411,7 @@ TriggerForm.propTypes = propTypes
 
 const mapStateToProps = state => {
   return {
-    isTelegramConnected: selectIsTelegramConnected(state),
+    isTelegramConnected: isTelegramConnectedAndEnabled(state),
     isEmailConnected: selectIsEmailConnected(state),
     lastPriceItem: state.signals.points
       ? state.signals.points[state.signals.points.length - 1]

--- a/src/pages/Account/SettingsNotifications.js
+++ b/src/pages/Account/SettingsNotifications.js
@@ -42,6 +42,10 @@ const channelByTypeLength = (signals, type) => {
 }
 
 const SignalsDescription = (mappedCount, allCount, channel) => {
+  if (mappedCount === 0) {
+    return null
+  }
+
   return (
     <Link
       to={'/sonar/my-signals?channel=' + channel}

--- a/src/pages/SonarFeed/SonarFeedPage.js
+++ b/src/pages/SonarFeed/SonarFeedPage.js
@@ -7,7 +7,7 @@ import Loadable from 'react-loadable'
 import PageLoader from '../../components/Loader/PageLoader'
 import InsightUnAuthPage from './../../pages/Insights/InsightUnAuthPage'
 import MobileHeader from '../../components/MobileHeader/MobileHeader'
-import { selectIsTelegramConnected } from '../../pages/UserSelectors'
+import { isTelegramConnected } from '../../pages/UserSelectors'
 import SonarFeedHeader from './SonarFeedActions/SonarFeedHeader'
 import { showNotification } from '../../actions/rootActions'
 import SignalMasterModalForm from '../../ducks/Signals/signalModal/SignalMasterModalForm'
@@ -156,7 +156,7 @@ const SonarFeed = ({
 const mapStateToProps = state => {
   return {
     isUserLoading: state.user && !!state.user.isLoading,
-    isTelegramConnected: selectIsTelegramConnected(state)
+    isTelegramConnected: isTelegramConnected(state)
   }
 }
 

--- a/src/pages/UserSelectors.js
+++ b/src/pages/UserSelectors.js
@@ -10,7 +10,17 @@ export const checkIsLoggedIn = state => {
   return state.user.data && !!state.user.data.id
 }
 
-export const selectIsTelegramConnected = state => {
+export const isTelegramConnected = state => {
+  if (!state.user.data) {
+    return false
+  }
+  if (!state.user.data.settings) {
+    return false
+  }
+  return state.user.data.settings.hasTelegramConnected
+}
+
+export const isTelegramConnectedAndEnabled = state => {
   if (!state.user.data) {
     return false
   }
@@ -18,8 +28,7 @@ export const selectIsTelegramConnected = state => {
     return false
   }
   return (
-    state.user.data.settings.hasTelegramConnected &&
-    state.user.data.settings.signalNotifyTelegram
+    isTelegramConnected(state) && state.user.data.settings.signalNotifyTelegram
   )
 }
 

--- a/src/pages/UserSelectors.spec.js
+++ b/src/pages/UserSelectors.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { selectIsTelegramConnected } from './UserSelectors'
+import { isTelegramConnectedAndEnabled } from './UserSelectors'
 
 describe('User Selectors', () => {
   it('selectIsTelegramConnected should be falsy', () => {
@@ -10,7 +10,7 @@ describe('User Selectors', () => {
         token: null
       }
     }
-    expect(selectIsTelegramConnected(state)).toBeFalsy()
+    expect(isTelegramConnectedAndEnabled(state)).toBeFalsy()
   })
 
   it('selectIsTelegramConnected should be true', () => {
@@ -24,6 +24,6 @@ describe('User Selectors', () => {
         }
       }
     }
-    expect(selectIsTelegramConnected(state)).toBeTruthy()
+    expect(isTelegramConnectedAndEnabled(state)).toBeTruthy()
   })
 })


### PR DESCRIPTION
**Summary**

1. Changed behavior of showing not connected telegram notification
2. Not show channel's statistic if no triggers with this channel (settings page)