### PR TITLE
enhance/buidl-page

### DIFF
--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -301,7 +301,8 @@ class ChartPage extends Component {
         metrics: metrics.map(metricObjToQSMapper),
         events: events.map(metricObjToQSMapper),
         marketSegments: marketSegments.map(metricObjToQSMapper)
-      })
+      }),
+      state: location.state
     })
   }
 

--- a/src/ducks/SANCharts/utils.js
+++ b/src/ducks/SANCharts/utils.js
@@ -327,7 +327,7 @@ export const getMarketSegment = key => {
     type: 'marketSegments',
     category: 'Development',
     node: Line,
-    label: `"${key}" Market Dev.Activity`,
+    label: `Dev. Activity (${key})`,
     yAxisId: 'axis-activity',
     reqMeta: {
       transform: 'movingAverage',

--- a/src/pages/Detailed/Detailed.js
+++ b/src/pages/Detailed/Detailed.js
@@ -50,7 +50,7 @@ Breadcrumbs.defaultProps = {
 export const Detailed = ({
   match,
   history,
-  location,
+  location = {},
   Project = {
     project: undefined,
     loading: true,

--- a/src/pages/Detailed/Detailed.js
+++ b/src/pages/Detailed/Detailed.js
@@ -30,17 +30,22 @@ const propTypes = {
   match: PropTypes.object.isRequired
 }
 
-export const Breadcrumbs = ({ slug, name }) => (
+export const Breadcrumbs = ({ from, slug, name }) => (
   <div className={styles.breadcrumbs}>
-    <Link to='/assets' className={styles.breadcrumbs__root}>
-      Assets
-    </Link>
+    <Link {...from} className={styles.breadcrumbs__root} />
     <Icon type='arrow-right' className={styles.breadcrumbs__arrow} />
     <Link className={styles.breadcrumbs__project} to={`/projects/${slug}`}>
       {name}
     </Link>
   </div>
 )
+
+Breadcrumbs.defaultProps = {
+  from: {
+    to: '/assets',
+    children: 'Assets'
+  }
+}
 
 export const Detailed = ({
   match,
@@ -60,6 +65,7 @@ export const Detailed = ({
 }) => {
   const project = Project.project || {}
 
+  const { from } = location.state || {}
   const { id } = project
 
   if (/not found/.test(Project.errorMessage)) {
@@ -80,7 +86,7 @@ export const Detailed = ({
 
   const projectContainerChart = project && project.id && (
     <>
-      <Breadcrumbs slug={project.slug} name={project.name} />
+      <Breadcrumbs from={from} slug={project.slug} name={project.name} />
       <Query query={USER_SUBSCRIPTIONS_QUERY}>
         {({ data: { currentUser } = {} }) => {
           const subscription = getCurrentSanbaseSubscription(currentUser)

--- a/src/pages/Detailed/__snapshots__/Detailed.spec.js.snap
+++ b/src/pages/Detailed/__snapshots__/Detailed.spec.js.snap
@@ -30,6 +30,12 @@ exports[`Project detail page container it should render correctly 1`] = `
       padding={false}
     >
       <Breadcrumbs
+        from={
+          Object {
+            "children": "Assets",
+            "to": "/assets",
+          }
+        }
         name="Aragorn"
       />
       <Query

--- a/src/pages/MarketSegments/index.js
+++ b/src/pages/MarketSegments/index.js
@@ -21,6 +21,16 @@ const SEGMENTS = [
 ]
 
 const TABS = ['Ethereum', 'DeFi', 'EOS']
+const PROJECT_LINK_PROPS = {
+  projectLink: {
+    state: {
+      from: {
+        to: '/labs/buidl-heroes',
+        children: 'Buidl heroes'
+      }
+    }
+  }
+}
 
 const MarketSegmentsPage = ({
   assets,
@@ -83,6 +93,7 @@ const MarketSegmentsPage = ({
             showCollumnsToggle={false}
             refetchAssets={refetchAssets}
             className={styles.table}
+            columnProps={PROJECT_LINK_PROPS}
           />
         </div>
       </div>

--- a/src/pages/MarketSegments/queries.js
+++ b/src/pages/MarketSegments/queries.js
@@ -7,6 +7,7 @@ export const PROJECTS_QUERY = gql`
       ticker
       name
       infrastructure
+      priceUsd
       devActivity7: averageDevActivity(days: 7)
       devActivity30: averageDevActivity
     }

--- a/src/pages/assets/AssetsTable.js
+++ b/src/pages/assets/AssetsTable.js
@@ -53,7 +53,8 @@ const AssetsTable = ({
   settings,
   setHiddenColumns,
   showCollumnsToggle = true,
-  className
+  className,
+  columnProps
 }) => {
   const { isLoading, error, timestamp, typeInfo } = Assets
   const key = typeInfo.listId || listName
@@ -104,7 +105,9 @@ const AssetsTable = ({
     return changeColumns(toggledColumns)
   }
 
-  const shownColumns = COLUMNS(preload).filter(({ id }) => columns[id].show)
+  const shownColumns = COLUMNS(preload, columnProps).filter(
+    ({ id }) => columns[id].show
+  )
 
   return (
     <>

--- a/src/pages/assets/AssetsTable.module.scss
+++ b/src/pages/assets/AssetsTable.module.scss
@@ -8,6 +8,7 @@
 
 .assetsTable:global(.ReactTable) {
   margin-bottom: 20px;
+  color: var(--mirage);
 
   :global {
     .overview-name {
@@ -70,7 +71,7 @@
         & .heading {
           &::before,
           &::after {
-            content: "";
+            content: '';
             position: absolute;
             right: 0;
             border: 4px solid transparent;

--- a/src/pages/assets/asset-columns.js
+++ b/src/pages/assets/asset-columns.js
@@ -231,7 +231,7 @@ export const COLUMNS = (preload, props = {}) => [
   }),
   constructColumn({
     id: COLUMNS_NAMES.devActivity7,
-    heading: 'Dev. activity (7d)',
+    heading: 'Average Dev. Activity (7d)',
     accessor: 'devActivity7',
     Cell: ({ value }) => (
       <div className='overview-activeaddresses'>
@@ -242,7 +242,7 @@ export const COLUMNS = (preload, props = {}) => [
   }),
   constructColumn({
     id: COLUMNS_NAMES.devActivity30,
-    heading: 'Dev. activity (30d)',
+    heading: 'Average Dev. Activity (30d)',
     accessor: 'devActivity30',
     Cell: ({ value }) => (
       <div className='overview-activeaddresses'>
@@ -253,7 +253,7 @@ export const COLUMNS = (preload, props = {}) => [
   }),
   constructColumn({
     id: COLUMNS_NAMES.devActivityChange30d,
-    heading: 'Dev. act. % change (30d)',
+    heading: 'Dev. Act. % change (30d)',
     accessor: 'devActChange30d',
     Cell: ({ value }) =>
       isValidValue(value) ? <PercentChanges changes={value} /> : NO_DATA,

--- a/src/pages/assets/asset-columns.js
+++ b/src/pages/assets/asset-columns.js
@@ -48,7 +48,7 @@ const constructColumn = ({
   }
 }
 
-export const COLUMNS = preload => [
+export const COLUMNS = (preload, props = {}) => [
   constructColumn({
     id: COLUMNS_NAMES.index,
     heading: '#',
@@ -61,15 +61,21 @@ export const COLUMNS = preload => [
     minWidth: 200,
     maxWidth: 280,
     resizable: true,
-    Cell: ({ original }) => (
-      <Link
-        onMouseOver={preload}
-        to={`/projects/${original.slug}`}
-        className='overview-name'
-      >
-        <ProjectLabel {...original} />
-      </Link>
-    ),
+    Cell: ({ original }) => {
+      const { state } = props.projectLink || {}
+      return (
+        <Link
+          onMouseOver={preload}
+          to={{
+            pathname: `/projects/${original.slug}`,
+            state
+          }}
+          className='overview-name'
+        >
+          <ProjectLabel {...original} />
+        </Link>
+      )
+    },
     filterMethod: (filter, row) => {
       const name = row[filter.id].name || ''
       const ticker = row[filter.id].ticker || ''

--- a/src/pages/assets/asset-columns.js
+++ b/src/pages/assets/asset-columns.js
@@ -62,13 +62,15 @@ export const COLUMNS = (preload, props = {}) => [
     maxWidth: 280,
     resizable: true,
     Cell: ({ original }) => {
+      const { slug, priceUsd } = original
       const { state } = props.projectLink || {}
       return (
         <Link
           onMouseOver={preload}
           to={{
-            pathname: `/projects/${original.slug}`,
-            state
+            state,
+            pathname: `/projects/${slug}`,
+            search: priceUsd === null ? 'metrics=devActivity' : ''
           }}
           className='overview-name'
         >


### PR DESCRIPTION
### Summary
- Market segment metric label changed to `Dev. Activity (%segment%)`;
- Buidl heroes dev.activity column prepended with an `Average` label;
- Breadcrumbs root is changed to `buidl-heroes` if user came from there;
- Projects without price lead to the chart with only `Dev. Activity` as a metric
### Screenshots
![image](https://user-images.githubusercontent.com/25135650/65772590-303eef00-e143-11e9-8656-fe227476538a.png)
![image](https://user-images.githubusercontent.com/25135650/65772616-3cc34780-e143-11e9-9190-4230f72446fc.png)
