### PR TITLE
add min-width for chart header blocks

### DIFF
--- a/src/ducks/SANCharts/Header.module.scss
+++ b/src/ducks/SANCharts/Header.module.scss
@@ -63,7 +63,7 @@
   justify-content: space-between;
 
   @include responsive('laptop', 'desktop') {
-    min-width: 315px;
+    min-width: 365px;
   }
 
   @include responsive('tablet') {
@@ -109,6 +109,10 @@
 .actions {
   display: flex;
 
+  @include responsive('desktop', 'laptop') {
+    min-width: 280px;
+  }
+
   @include responsive('tablet', 'laptop') {
     flex-direction: column;
   }
@@ -121,12 +125,13 @@
 .btn {
   color: var(--mirage);
   background: inherit;
+  margin-left: auto;
 
   &.signal {
-    margin: 0 16px 0 0;
+    margin: 0 16px 0 auto;
 
     @include responsive('tablet', 'laptop') {
-      margin: 0 0 6px;
+      margin: 0 0 6px auto;
     }
   }
 


### PR DESCRIPTION
**Summary**

Fix header of chart for assets with long description

**Screenshots**
![image](https://user-images.githubusercontent.com/14061779/67005639-c08da580-f0eb-11e9-9262-742839d6f440.png)
