### PR TITLE
fix scale on Y-axis for HB-charts and standart chart

### DIFF
--- a/src/components/SignalCard/controls/MoreSignalActions.js
+++ b/src/components/SignalCard/controls/MoreSignalActions.js
@@ -7,8 +7,7 @@ import Panel from '@santiment-network/ui/Panel/Panel'
 import { RemoveSignalButton } from './SignalControls'
 import ShareModalTrigger from '../../Share/ShareModalTrigger'
 import { mapStateToQS } from '../../../utils/utils'
-import SmoothDropdownItem from '../../SmoothDropdown/SmoothDropdownItem'
-import SmoothDropdown from '../../SmoothDropdown/SmoothDropdown'
+import Tooltip from '@santiment-network/ui/Tooltip'
 import styles from '../SignalCard.module.scss'
 
 const generateShareLink = (id, title) => {
@@ -44,46 +43,43 @@ const MoreSignalActions = ({
   }
 
   return (
-    <SmoothDropdown>
-      <SmoothDropdownItem
-        trigger={
-          <Button className={styles.expandButton}>
-            <Icon type='dots' />
-          </Button>
-        }
-        position='bottom'
-        align='start'
-        classes={styles}
-      >
-        <Panel>
-          <div className={styles.popup}>
-            {isUserTheAuthor && (
-              <div className={cx(styles.popupItem, styles.popupButton)}>
-                <Link
-                  to={`/sonar/signal/${signalId}/edit${window.location.search}`}
-                  className={styles.link}
-                >
-                  Edit signal
-                </Link>
-              </div>
-            )}
+    <Tooltip
+      trigger={
+        <Button className={styles.expandButton}>
+          <Icon type='dots' />
+        </Button>
+      }
+      position='bottom'
+      align='start'
+    >
+      <Panel>
+        <div className={styles.popup}>
+          {isUserTheAuthor && (
+            <div className={cx(styles.popupItem, styles.popupButton)}>
+              <Link
+                to={`/sonar/signal/${signalId}/edit${window.location.search}`}
+                className={styles.link}
+              >
+                Edit signal
+              </Link>
+            </div>
+          )}
 
-            {isPublic && <ShareSignal trigger={SignalShareTrigger} />}
+          {isPublic && <ShareSignal trigger={SignalShareTrigger} />}
 
-            {isUserTheAuthor && deleteEnabled && (
-              <div className={cx(styles.popupItem, styles.popupButton)}>
-                <RemoveSignalButton
-                  id={signalId}
-                  signalTitle={signalTitle}
-                  removeSignal={removeSignal}
-                  trigger={<div className={styles.removeSignal}>Delete</div>}
-                />
-              </div>
-            )}
-          </div>
-        </Panel>
-      </SmoothDropdownItem>
-    </SmoothDropdown>
+          {isUserTheAuthor && deleteEnabled && (
+            <div className={cx(styles.popupItem, styles.popupButton)}>
+              <RemoveSignalButton
+                id={signalId}
+                signalTitle={signalTitle}
+                removeSignal={removeSignal}
+                trigger={<div className={styles.removeSignal}>Delete</div>}
+              />
+            </div>
+          )}
+        </div>
+      </Panel>
+    </Tooltip>
   )
 }
 

--- a/src/ducks/HistoricalBalance/balanceView/BalanceView.js
+++ b/src/ducks/HistoricalBalance/balanceView/BalanceView.js
@@ -143,6 +143,12 @@ const BalanceView = ({
 
   const { timeRange, from, to } = chartSettings
 
+  const [scale, setScale] = useState('time')
+
+  const onScaleChange = () => {
+    setScale(scale === 'time' ? 'log' : 'time')
+  }
+
   return (
     <div className={cx(styles.container, classes.balanceViewContainer)}>
       <BalanceViewWalletAssets
@@ -173,6 +179,8 @@ const BalanceView = ({
             toggleYAxes={toggleYAxes}
             priceMetrics={priceMetrics}
             toggleAsset={togglePriceMetric}
+            onScaleChange={onScaleChange}
+            scale={scale}
           />
         </BalanceChartHeader>
 
@@ -261,6 +269,7 @@ const BalanceView = ({
                 walletsData={data}
                 priceMetricsData={priceMetricTimeseries}
                 priceMetric={CHART_PRICE_METRIC}
+                scale={scale}
               />
             )
           }}

--- a/src/ducks/HistoricalBalance/balanceView/BalanceViewChartSettings.js
+++ b/src/ducks/HistoricalBalance/balanceView/BalanceViewChartSettings.js
@@ -21,7 +21,9 @@ const BalanceViewChartSettings = ({
   toggleYAxes,
   showYAxes,
   priceMetrics = [],
-  toggleAsset
+  toggleAsset,
+  onScaleChange,
+  scale
 }) => {
   return (
     <div className={cx(styles.settings, classes.chartSettings)}>
@@ -44,6 +46,8 @@ const BalanceViewChartSettings = ({
         shareLink={window.location.origin + '/labs/balance' + queryString}
         showDownload={false}
         classes={balanceViewStyles}
+        onScaleChange={onScaleChange}
+        scale={scale}
       >
         <Button
           fluid

--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -8,7 +8,11 @@ import GetTimeSeries from '../../ducks/GetTimeSeries/GetTimeSeries'
 import { ERRORS } from '../GetTimeSeries/reducers'
 import Charts from './Charts'
 import Header from './Header'
-import { getMarketSegment, mapToRequestedMetrics } from './utils'
+import {
+  getMarketSegment,
+  mapDatetimeToNumber,
+  mapToRequestedMetrics
+} from './utils'
 import { Metrics, Events, compatabilityMap } from './data'
 import { getNewInterval, INTERVAL_ALIAS } from './IntervalSelector'
 import UpgradePaywall from './../../components/UpgradePaywall/UpgradePaywall'
@@ -543,10 +547,7 @@ class ChartPage extends Component {
                       isZoomed={zoom}
                       events={eventsFiltered}
                       isTrendsShowing={isTrendsShowing}
-                      chartData={timeseries.map(({ datetime, ...rest }) => ({
-                        ...rest,
-                        datetime: +new Date(datetime)
-                      }))}
+                      chartData={mapDatetimeToNumber(timeseries)}
                       title={title}
                       metrics={finalMetrics}
                       leftBoundaryDate={leftBoundaryDate}

--- a/src/ducks/SANCharts/ChartSettingsContextMenu.js
+++ b/src/ducks/SANCharts/ChartSettingsContextMenu.js
@@ -48,18 +48,20 @@ const ChartSettingsContextMenu = ({
       align='end'
     >
       <Panel variant='modal' className={styles.context}>
-        <Button
-          fluid
-          variant='ghost'
-          onClick={onScaleChange}
-          className={styles.context__btn}
-        >
-          Log scale
-          <Toggle
-            isActive={scale === 'log'}
-            className={styles.context__toggle}
-          />
-        </Button>
+        {onScaleChange && (
+          <Button
+            fluid
+            variant='ghost'
+            onClick={onScaleChange}
+            className={styles.context__btn}
+          >
+            Log scale
+            <Toggle
+              isActive={scale === 'log'}
+              className={styles.context__toggle}
+            />
+          </Button>
+        )}
         {showNightModeToggle && (
           <Button
             fluid

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -395,6 +395,7 @@ class Charts extends React.Component {
       chartRef,
       coordinates: this.xToYCoordinates,
       onYAxesHover: this.onYAxesHover,
+      scale: scale,
       ref: { [tooltipMetric && tooltipMetric.key]: this.metricRef }
     })
 
@@ -527,7 +528,6 @@ class Charts extends React.Component {
             <defs>{isSignalsEnabled && <SignalPointSvg />}</defs>
             <XAxis
               dataKey='datetime'
-              scale={scale}
               tickLine={false}
               minTickGap={100}
               tickFormatter={tickFormatter}

--- a/src/ducks/SANCharts/utils.js
+++ b/src/ducks/SANCharts/utils.js
@@ -4,6 +4,12 @@ import { formatNumber, millify } from './../../utils/formatting'
 import { Metrics, Events } from './data'
 import styles from './Chart.module.scss'
 
+export const mapDatetimeToNumber = timeseries =>
+  timeseries.map(({ datetime, ...rest }) => ({
+    ...rest,
+    datetime: +new Date(datetime)
+  }))
+
 export const usdFormatter = val => formatNumber(val, { currency: 'USD' })
 
 export const getEventsTooltipInfo = events =>
@@ -121,7 +127,8 @@ export const generateMetricsMarkup = (
     data = {},
     chartRef: { current: chartRef } = {},
     coordinates,
-    onYAxesHover
+    onYAxesHover,
+    scale
   } = {}
 ) => {
   const metricWithYAxis = findYAxisMetric(metrics)
@@ -171,6 +178,7 @@ export const generateMetricsMarkup = (
         hide={isHidden}
         tickFormatter={yAxisTickFormatter}
         onMouseMove={onYAxesHover}
+        scale={scale}
       />,
       <El
         key={`line-${dataKey}`}


### PR DESCRIPTION
**Summary**

1. Fix charts scale
2. Change signal smoothdropdown to tooltip

**Screenshots**

Without scale:
![image](https://user-images.githubusercontent.com/14061779/67470286-2d59f000-f656-11e9-80db-1a2726068a84.png)
With 'log' scale:
![image](https://user-images.githubusercontent.com/14061779/67470322-39de4880-f656-11e9-8feb-ac81facfc4fb.png)
