### PR TITLE
fix problem with wrong 'time' scale for Y-axis

### DIFF
--- a/src/ducks/HistoricalBalance/balanceView/BalanceView.js
+++ b/src/ducks/HistoricalBalance/balanceView/BalanceView.js
@@ -143,10 +143,10 @@ const BalanceView = ({
 
   const { timeRange, from, to } = chartSettings
 
-  const [scale, setScale] = useState('time')
+  const [scale, setScale] = useState('auto')
 
   const onScaleChange = () => {
-    setScale(scale === 'time' ? 'log' : 'time')
+    setScale(scale === 'auto' ? 'log' : 'auto')
   }
 
   return (

--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -27,7 +27,7 @@ const { from: FROM, to: TO } = getIntervalByTimeRange(DEFAULT_TIME_RANGE)
 const MAX_METRICS_PER_CHART = 5
 
 const DEFAULT_STATE = {
-  scale: 'time',
+  scale: 'auto',
   timeRange: DEFAULT_TIME_RANGE,
   from: FROM.toISOString(),
   to: TO.toISOString(),
@@ -265,7 +265,7 @@ class ChartPage extends Component {
 
   onScaleChange = () => {
     this.setState(
-      ({ scale }) => ({ scale: scale === 'time' ? 'log' : 'time' }),
+      ({ scale }) => ({ scale: scale === 'auto' ? 'log' : 'auto' }),
       this.updateSearchQuery
     )
   }

--- a/src/ducks/SANCharts/Charts.js
+++ b/src/ducks/SANCharts/Charts.js
@@ -413,7 +413,7 @@ class Charts extends React.Component {
       children,
       isLoading,
       priceRefLineData,
-      scale = 'time',
+      scale,
       signals = [],
       slug
     } = this.props


### PR DESCRIPTION
**Summary**

Yesterday I fixed problem with scale functionality for charts. And there was wrong scale 'time' for X-axis(because 'log' scale using only for Y-axis values, not X-axis).
 And I missed this 'time' scale it for Y-axis. Fixed it by adding default 'auto' scale and optional 'log' scale for Y-axis