### PR TITLE
fix problem with reset of asset's field after DAA selection

### DIFF
--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricTypes/TriggerFormMetricTypes.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricTypes/TriggerFormMetricTypes.js
@@ -48,15 +48,11 @@ export const TriggerFormMetricTypes = ({
 
     if (newMetric) {
       if (newMetric.value !== TRENDING_WORDS) {
-        if (newMetric.value === DAILY_ACTIVE_ADDRESSES) {
-          setFieldValue('target', [])
-        } else {
-          checkPossibleTarget({
-            metaFormSettings,
-            setFieldValue,
-            target
-          })
-        }
+        checkPossibleTarget({
+          metaFormSettings,
+          setFieldValue,
+          target
+        })
       }
     } else {
       if (target) {


### PR DESCRIPTION
**Summary**

Fixed reset of asset's field on trigger form selection.

**Screenshots**
![image](https://user-images.githubusercontent.com/14061779/67682768-2528ea00-f9a1-11e9-8b85-8bf8f9c8818f.png)
