### PR TITLE
fix/metrics-divider

### DIFF
--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -248,7 +248,10 @@ class ChartPage extends Component {
         })
       } else {
         const metricsAmount = state.metrics.length + state.marketSegments.length
-        if (metricsAmount >= MAX_METRICS_PER_CHART) {
+        if (
+          metricsAmount >= MAX_METRICS_PER_CHART &&
+          metric !== Events.trendPositionHistory
+        ) {
           return state
         }
         newMetrics.add(metric)
@@ -511,7 +514,10 @@ class ChartPage extends Component {
           const isTrendsShowing = trendPositionHistory !== undefined
           const eventsFiltered = isTrendsShowing
             ? eventsData.filter(({ metricAnomalyKey }) => !metricAnomalyKey)
-            : eventsData
+            : eventsData.filter(({ metricAnomalyKey }) =>
+            // NOTE: Diplaying anomaly dots only for active metrics [@vanguard | Nov 06, 2019]
+              metrics.some(({ key }) => key === metricAnomalyKey)
+            )
 
           return (
             <>

--- a/src/ducks/SANCharts/TooltipSynchronizer.js
+++ b/src/ducks/SANCharts/TooltipSynchronizer.js
@@ -42,7 +42,7 @@ const TooltipSynchronizer = ({ children, metrics, isMultiChartsActive }) => {
 
   useEffect(() => clearCache, [])
 
-  return isMultiChartsActive
+  return isMultiChartsActive && noPriceMetrics.length > 1
     ? noPriceMetrics.map(metric =>
       React.cloneElement(children, {
         className: chartStyles.multiCharts,

--- a/src/ducks/SANCharts/data.js
+++ b/src/ducks/SANCharts/data.js
@@ -30,19 +30,7 @@ export const Events = {
   metricAnomalyKey: {
     label: 'Anomaly',
     isAnomaly: true,
-    formatter: val => {
-      switch (val) {
-        case 'devActivity':
-          return 'Development Activity'
-        case 'socialVolume':
-          return 'Social Volume'
-        case 'DailyActiveAddresses':
-          return 'Daily Active Addresses'
-
-        default:
-          return `${val}`
-      }
-    }
+    formatter: val => Metrics[val].label
   }
 }
 


### PR DESCRIPTION
### Summary
- Allowing to select `trendPosition` event when 5 metrics are selected;
- Fixed bug when no `trendPosition` was displayed after switching between `Multi charts` and `Single chart` mode
- Displaying multiple charts when there are 2 metrics (excluding `Price`)