### PR TITLE
fix error on updating data for not loaded query after email login

### DIFF
--- a/src/epics/handleGDPR.js
+++ b/src/epics/handleGDPR.js
@@ -2,7 +2,7 @@ import gql from 'graphql-tag'
 import { Observable } from 'rxjs'
 import { showNotification } from './../actions/rootActions'
 import { handleErrorAndTriggerAction } from './utils'
-import { userGQL } from './handleLaunch'
+import { USER_EMAIL_LOGIN_QEURY } from './handleLaunch'
 import Raven from 'raven-js'
 import * as actions from './../actions/types'
 
@@ -51,12 +51,12 @@ const privacyGQLHelper = (user, type) => {
     },
     update: (proxy, newData) => {
       try {
-        let data = proxy.readQuery({ query: userGQL })
+        let data = proxy.readQuery({ query: USER_EMAIL_LOGIN_QEURY })
         data.currentUser.privacyPolicyAccepted =
           newData.data.updateTermsAndConditions.privacyPolicyAccepted
         data.currentUser.marketingAccepted =
           newData.data.updateTermsAndConditions.marketingAccepted
-        proxy.writeQuery({ query: userGQL, data })
+        proxy.writeQuery({ query: USER_EMAIL_LOGIN_QEURY, data })
       } catch (e) {
         Raven.captureException(
           'Updating GDPR apollo cache error: ' + JSON.stringify(e)

--- a/src/epics/handleLaunch.js
+++ b/src/epics/handleLaunch.js
@@ -15,6 +15,7 @@ export const USER_GQL_FRAGMENT = gql`
     sanBalance
     privacyPolicyAccepted
     marketingAccepted
+    consent_id
     ethAccounts {
       address
       sanBalance
@@ -40,7 +41,7 @@ export const USER_GQL_FRAGMENT = gql`
     }
   }
 `
-export const userGQL = gql`
+export const USER_EMAIL_LOGIN_QEURY = gql`
   query {
     currentUser 
       ${USER_GQL_FRAGMENT}
@@ -53,7 +54,7 @@ const handleLaunch = (action$, store, { client }) =>
     mergeMap(() => {
       const queryPromise = client.query({
         options: { fetchPolicy: 'network-only' },
-        query: userGQL
+        query: USER_EMAIL_LOGIN_QEURY
       })
       return Observable.from(queryPromise)
         .map(({ data }) => {

--- a/src/pages/Account/epics.js
+++ b/src/pages/Account/epics.js
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag'
 import { Observable } from 'rxjs'
-import { userGQL } from './../../epics/handleLaunch'
+import { USER_EMAIL_LOGIN_QEURY } from './../../epics/handleLaunch'
 import { handleErrorAndTriggerAction } from './../../epics/utils'
 import { showNotification } from './../../actions/rootActions'
 import * as actions from './../../actions/types'
@@ -113,6 +113,21 @@ export const generateTelegramDeepLinkEpic = (action$, store, { client }) =>
         })
     })
 
+function tryUpdateUserProxyData (proxy, query, action) {
+  try {
+    let data = proxy.readQuery({ query })
+
+    data.currentUser.settings = {
+      ...data.currentUser.settings,
+      ...action.payload
+    }
+
+    proxy.writeQuery({ query, data })
+  } catch (e) {
+    // pass
+  }
+}
+
 export const toggleNotificationChannelEpic = (action$, store, { client }) =>
   action$
     .ofType(actions.SETTINGS_TOGGLE_NOTIFICATION_CHANNEL)
@@ -132,12 +147,7 @@ export const toggleNotificationChannelEpic = (action$, store, { client }) =>
           }
         },
         update: proxy => {
-          let data = proxy.readQuery({ query: userGQL })
-          data.currentUser.settings = {
-            ...data.currentUser.settings,
-            ...action.payload
-          }
-          proxy.writeQuery({ query: userGQL, data })
+          tryUpdateUserProxyData(proxy, USER_EMAIL_LOGIN_QEURY, action)
         },
         context: { isRetriable: true }
       })


### PR DESCRIPTION
**Summary**

Fixed bug with updating data for not loaded user query after email login. San-6590

Reproduced by Maxim T.
1) Email/telegram notifications turn off after logout (at least in UI)
2) Double notification toggle:
a) log in
b) toggle Beta mode
c) toggle the top notification 

Observed: two notification switches toggle at the same time instead of one. And errors in console