### PR TITLE
feature/chart-csv

### DIFF
--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -561,6 +561,7 @@ class ChartPage extends Component {
                           activeMetrics={finalMetrics}
                           title={title}
                           chartRef={this.chartRef}
+                          chartData={timeseries}
                         />
                         <LoadableChartMetricsTool
                           classes={styles}

--- a/src/ducks/SANCharts/ChartSettings.js
+++ b/src/ducks/SANCharts/ChartSettings.js
@@ -27,7 +27,8 @@ const ChartSettings = ({
   scale,
   onMultiChartsChange,
   isMultiChartsActive,
-  onScaleChange
+  onScaleChange,
+  chartData
 }) => {
   const shareLink = generateShareLink(disabledMetrics)
 
@@ -64,6 +65,7 @@ const ChartSettings = ({
           chartRef={chartRef}
           scale={scale}
           onScaleChange={onScaleChange}
+          chartData={chartData}
         />
       </div>
     </div>

--- a/src/ducks/SANCharts/ChartSettingsContextMenu.js
+++ b/src/ducks/SANCharts/ChartSettingsContextMenu.js
@@ -5,6 +5,7 @@ import Button from '@santiment-network/ui/Button'
 import Icon from '@santiment-network/ui/Icon'
 import Panel from '@santiment-network/ui/Panel/Panel'
 import ChartDownloadBtn from './ChartDownloadBtn'
+import DownloadCSVBtn from './DownloadCSVBtn'
 import ShareModalTrigger from '../../components/Share/ShareModalTrigger'
 import styles from './ChartPage.module.scss'
 
@@ -36,7 +37,8 @@ const ChartSettingsContextMenu = ({
   onScaleChange,
   isMultiChartsActive,
   onMultiChartsChange,
-  children
+  children,
+  chartData
 }) => {
   return (
     <ContextMenu
@@ -100,16 +102,28 @@ const ChartSettingsContextMenu = ({
           )}
         />
         {showDownload && (
-          <ChartDownloadBtn
-            fluid
-            variant='ghost'
-            metrics={activeMetrics}
-            title={title}
-            chartRef={chartRef}
-          >
-            <Icon type='save' className={styles.icon} />
-            Download as PNG
-          </ChartDownloadBtn>
+          <>
+            <DownloadCSVBtn
+              fluid
+              variant='ghost'
+              title={title}
+              chartData={chartData}
+              metrics={activeMetrics}
+            >
+              <Icon type='save' className={styles.icon} />
+              Download as CSV
+            </DownloadCSVBtn>
+            <ChartDownloadBtn
+              fluid
+              variant='ghost'
+              metrics={activeMetrics}
+              title={title}
+              chartRef={chartRef}
+            >
+              <Icon type='save' className={styles.icon} />
+              Download as PNG
+            </ChartDownloadBtn>
+          </>
         )}
         {children}
       </Panel>

--- a/src/ducks/SANCharts/DownloadCSVBtn.js
+++ b/src/ducks/SANCharts/DownloadCSVBtn.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { CSVLink } from 'react-csv'
+import Button from '@santiment-network/ui/Button'
+import PropTypes from 'prop-types'
+import { getDateFormats, getTimeFormats } from '../../utils/dates'
+// import styles from './DownloadCSVBtn.module.scss';
+
+const DownloadCSVBtn = ({ metrics, chartData, title, ...props }) => {
+  const date = new Date()
+  const { DD, MMM, YYYY } = getDateFormats(date)
+  const { HH, mm, ss } = getTimeFormats(date)
+  const filename = `${title} [${HH}.${mm}.${ss}, ${DD} ${MMM}, ${YYYY}].csv`
+
+  const headers = [
+    { label: 'Date', key: 'datetime' },
+    ...metrics.map(({ label, key, dataKey = key }) => ({
+      label,
+      key: dataKey
+    }))
+  ]
+  console.log(headers)
+
+  return (
+    <Button
+      filename={filename}
+      headers={headers}
+      data={chartData}
+      {...props}
+      as={CSVLink}
+    />
+  )
+}
+
+DownloadCSVBtn.defaultProps = {
+  title: '',
+  metrics: [],
+  chartData: []
+}
+
+DownloadCSVBtn.propTypes = {
+  metrics: PropTypes.array,
+  chartData: PropTypes.array
+}
+
+export default DownloadCSVBtn

--- a/src/ducks/SANCharts/DownloadCSVBtn.js
+++ b/src/ducks/SANCharts/DownloadCSVBtn.js
@@ -3,7 +3,6 @@ import { CSVLink } from 'react-csv'
 import Button from '@santiment-network/ui/Button'
 import PropTypes from 'prop-types'
 import { getDateFormats, getTimeFormats } from '../../utils/dates'
-// import styles from './DownloadCSVBtn.module.scss';
 
 const DownloadCSVBtn = ({ metrics, chartData, title, ...props }) => {
   const date = new Date()
@@ -18,7 +17,6 @@ const DownloadCSVBtn = ({ metrics, chartData, title, ...props }) => {
       key: dataKey
     }))
   ]
-  console.log(headers)
 
   return (
     <Button
@@ -38,6 +36,7 @@ DownloadCSVBtn.defaultProps = {
 }
 
 DownloadCSVBtn.propTypes = {
+  title: PropTypes.string,
   metrics: PropTypes.array,
   chartData: PropTypes.array
 }


### PR DESCRIPTION
### Summary
Allowing to download chart data as the `.csv` file.

If the metrics are: `Price`, `Social Volume`,`Token Age Consumed`, 
then the `.csv` headers will be `"Date","Price","Social Volume","Token Age Consumed"`. `"Date"` will be written in the `ISO` format.


### Screenshots
![image](https://user-images.githubusercontent.com/25135650/68303550-218a1700-00b5-11ea-9a15-dd12fe9d5bff.png)
