### PR TITLE
restrict HB signal creation if wallet address empty

### DIFF
--- a/src/ducks/HistoricalBalance/balanceView/BalanceChartHeader.js
+++ b/src/ducks/HistoricalBalance/balanceView/BalanceChartHeader.js
@@ -13,7 +13,7 @@ const BalanceChartHeader = ({ address, assets, children }) => {
       <div className={styles.addTrigger}>
         <SignalMasterModalForm
           label='Generate signal'
-          enabled={!!address || (assets && assets.length > 0)}
+          enabled={!!address && (assets && assets.length > 0)}
           canRedirect={false}
           metaFormSettings={{
             target: {

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/TriggerFormHistoricalBalance.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/TriggerFormHistoricalBalance.js
@@ -153,6 +153,7 @@ const TriggerFormHistoricalBalance = ({
   useEffect(
     () => {
       validateAddressField(target)
+      setFieldValue('isEthOrErc20', isErc20Assets(target, erc20List))
     },
     [target]
   )

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/projectsSelector/TriggerProjectsSelector.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/projectsSelector/TriggerProjectsSelector.js
@@ -116,11 +116,12 @@ export const TriggerProjectsSelector = ({
   }
 
   const onSuggestionSelect = ({ item: project }) => {
-    toggleAsset({
-      project,
-      listItems,
-      isAssetInList: hasAssetById({ listItems, id: project.id })
-    })
+    project &&
+      toggleAsset({
+        project,
+        listItems,
+        isAssetInList: hasAssetById({ listItems, id: project.id })
+      })
   }
 
   return (

--- a/src/ducks/Signals/utils/utils.js
+++ b/src/ducks/Signals/utils/utils.js
@@ -874,6 +874,7 @@ export const metricTypesBlockErrors = values => {
   const {
     type,
     ethAddress,
+    isEthOrErc20,
     metric,
     target,
     targetWatchlist,
@@ -895,6 +896,10 @@ export const metricTypesBlockErrors = values => {
         if (!isPossibleEthAddress(ethAddress)) {
           errors.ethAddress = NOT_VALID_ETH_ADDRESS
         }
+      }
+    } else {
+      if (isEthOrErc20) {
+        errors.ethAddress = NOT_VALID_ETH_ADDRESS
       }
     }
   } else if (metric && metric.value === TRENDING_WORDS) {


### PR DESCRIPTION
**Summary**

Task san-6196. Restrict "Historical balance" signal creation if wallet address is empty

**Screenshots**
![image](https://user-images.githubusercontent.com/14061779/69035368-8bc78380-09f4-11ea-9c5c-d4233ffc4137.png)
![image](https://user-images.githubusercontent.com/14061779/69035378-93872800-09f4-11ea-92f4-da62a8d46282.png)
