### PR TITLE
enhance/chart-metric-complexity-info

### DIFF
--- a/src/ducks/SANCharts/ChartMetricSelector.js
+++ b/src/ducks/SANCharts/ChartMetricSelector.js
@@ -16,13 +16,6 @@ import styles from './ChartMetricSelector.module.scss'
 
 const NO_GROUP = '_'
 
-Events.trendPositionHistory.note = (
-  <p className={styles.note}>
-    <span className={styles.warning}>Important!</span>
-    <span className={styles.text}>It will disable Anomalies</span>
-  </p>
-)
-
 const addItemToGraph = (categories, metricCategories, metrics) => {
   ;(typeof metricCategories === 'string'
     ? [metricCategories]
@@ -111,7 +104,10 @@ const getMetricSuggestions = categories => {
   return suggestions
 }
 
-const ActionBtn = ({ metric, children, isActive, isDisabled, ...props }) => {
+const ActionBtn = ({ metric, children, isActive, error = '', ...props }) => {
+  const isComplexityError = error.includes('complexity')
+  const noData = error && !isComplexityError
+
   return (
     <Button
       variant='ghost'
@@ -119,11 +115,11 @@ const ActionBtn = ({ metric, children, isActive, isDisabled, ...props }) => {
       className={styles.btn}
       classes={styles}
       isActive={isActive}
-      disabled={isDisabled}
+      disabled={error}
       {...props}
     >
       <div className={styles.btn__left}>
-        {isDisabled ? (
+        {noData ? (
           <span className={styles.btn_disabled}>no data</span>
         ) : (
           <ExplanationTooltip
@@ -143,7 +139,7 @@ const ActionBtn = ({ metric, children, isActive, isDisabled, ...props }) => {
         )}{' '}
         {children}
       </div>
-      <MetricExplanation {...metric}>
+      <MetricExplanation {...metric} isComplexityError={isComplexityError}>
         <Icon type='info-round' className={styles.info} />
       </MetricExplanation>
     </Button>
@@ -232,15 +228,17 @@ const ChartMetricSelector = ({
                     )}
                     {categories[activeCategory][group].map(metric => {
                       const isActive = actives.includes(metric)
-                      const isDisabled = disabledMetrics.includes(metric.key)
+                      const error = disabledMetrics[metric.key]
 
                       return (
                         <ActionBtn
                           key={metric.label}
                           metric={metric}
-                          onClick={() => toggleMetric(metric)}
+                          onClick={
+                            error ? undefined : () => toggleMetric(metric)
+                          }
                           isActive={isActive}
-                          isDisabled={isDisabled}
+                          error={error}
                         >
                           {metric.label}
                         </ActionBtn>

--- a/src/ducks/SANCharts/ChartMetricSelector.module.scss
+++ b/src/ducks/SANCharts/ChartMetricSelector.module.scss
@@ -99,6 +99,11 @@
 
   .disabled {
     background: transparent !important;
+    pointer-events: all !important;
+
+    .btn__action {
+      background: var(--porcelain);
+    }
   }
 }
 
@@ -142,25 +147,6 @@
   align-items: center;
   justify-content: center;
   font-size: 7px;
-}
-
-.note {
-  padding: 8px;
-  margin: 9px 0;
-  color: var(--fiord);
-  background-color: var(--athens);
-
-  @include text('caption');
-
-  & .warning {
-    color: var(--persimmon);
-    font-weight: bold;
-    margin-right: 5px;
-  }
-
-  & .text {
-    margin-right: 5px;
-  }
 }
 
 .search {

--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -560,7 +560,7 @@ class ChartPage extends Component {
                           classes={styles}
                           slug={slug}
                           toggleMetric={this.toggleMetric}
-                          disabledMetrics={errors}
+                          disabledMetrics={errorMetrics}
                           activeMetrics={finalMetrics}
                           activeEvents={events}
                           showToggleAnomalies={showToggleAnomalies}

--- a/src/ducks/SANCharts/ChartSettings.js
+++ b/src/ducks/SANCharts/ChartSettings.js
@@ -30,7 +30,7 @@ const ChartSettings = ({
   onScaleChange,
   chartData
 }) => {
-  const shareLink = generateShareLink(disabledMetrics)
+  const shareLink = generateShareLink(Object.keys(disabledMetrics))
 
   const notAdvancedView = !isAdvancedView
   return (

--- a/src/ducks/SANCharts/ChartSettings.js
+++ b/src/ducks/SANCharts/ChartSettings.js
@@ -30,7 +30,7 @@ const ChartSettings = ({
   onScaleChange,
   chartData
 }) => {
-  const shareLink = generateShareLink(Object.keys(disabledMetrics))
+  const shareLink = generateShareLink(disabledMetrics)
 
   const notAdvancedView = !isAdvancedView
   return (

--- a/src/ducks/SANCharts/MetricExplanation.js
+++ b/src/ducks/SANCharts/MetricExplanation.js
@@ -1,7 +1,20 @@
 import React from 'react'
 import Tooltip from '@santiment-network/ui/Tooltip'
 import Button from '@santiment-network/ui/Button'
+import { Events } from './data'
 import styles from './MetricExplanation.module.scss'
+
+const Note = ({ children }) => (
+  <p className={styles.note}>
+    <span className={styles.warning}>Important!</span>
+    <span className={styles.text}>{children}</span>
+  </p>
+)
+
+Events.trendPositionHistory.note = <Note>It will disable Anomalies</Note>
+
+const COMPLEXITY_NOTE =
+  'The requested period is outside of your plan boundaries'
 
 const MetricExplanation = ({
   children,
@@ -9,8 +22,19 @@ const MetricExplanation = ({
   description,
   video,
   note,
-  withChildren = false
+  withChildren = false,
+  isComplexityError
 }) => {
+  if (!description && isComplexityError) {
+    return (
+      <Tooltip className={styles.explanation} trigger={children}>
+        <div className={styles.explanation__content}>
+          <Note>{COMPLEXITY_NOTE}</Note>
+        </div>
+      </Tooltip>
+    )
+  }
+
   return description ? (
     <Tooltip className={styles.explanation} trigger={children}>
       <div className={styles.explanation__content}>
@@ -49,6 +73,7 @@ const MetricExplanation = ({
             <span className={styles.button__text}>Watch how to use it</span>
           </Button>
         )}
+        {isComplexityError && <Note>{COMPLEXITY_NOTE}</Note>}
       </div>
     </Tooltip>
   ) : withChildren ? (

--- a/src/ducks/SANCharts/MetricExplanation.module.scss
+++ b/src/ducks/SANCharts/MetricExplanation.module.scss
@@ -40,3 +40,22 @@
     @include text('body-3');
   }
 }
+
+.note {
+  padding: 8px;
+  margin: 9px 0;
+  color: var(--fiord);
+  background-color: var(--athens);
+
+  @include text('caption');
+
+  & .warning {
+    color: var(--persimmon);
+    font-weight: bold;
+    margin-right: 5px;
+  }
+
+  & .text {
+    margin-right: 5px;
+  }
+}


### PR DESCRIPTION
### Summary
Treating `complexity error` as an error related to the user's plan and displaying note inside the metric's explanation tooltip.

### Screenshot
![image](https://user-images.githubusercontent.com/25135650/69323099-1c050300-0c57-11ea-98ce-47a1e8c8cea3.png)
