### PR TITLE
fix help popup after removed semantic

### DIFF
--- a/src/components/HelpPopup/HelpPopup.js
+++ b/src/components/HelpPopup/HelpPopup.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import Icon from '@santiment-network/ui/Icon'
 import Tooltip from '@santiment-network/ui/Tooltip'
+import Panel from '@santiment-network/ui/Panel'
+import styles from './HelpPopup.module.scss'
 
 export const style = {
   maxWidth: 465,
@@ -28,7 +30,7 @@ const HelpPopup = ({
       on='hover'
       style={style}
     >
-      {render}
+      <Panel className={styles.panel}>{render}</Panel>
     </Tooltip>
   )
 }

--- a/src/components/HelpPopup/HelpPopup.module.scss
+++ b/src/components/HelpPopup/HelpPopup.module.scss
@@ -1,0 +1,7 @@
+@import '~@santiment-network/ui/mixins';
+
+.panel {
+  max-width: 465px;
+  padding: 24px;
+  border-radius: $border-radius;
+}

--- a/src/pages/Detailed/generalInfo/GeneralInfoBlock.js
+++ b/src/pages/Detailed/generalInfo/GeneralInfoBlock.js
@@ -60,7 +60,11 @@ const GeneralInfoBlock = ({
       title={
         <span>
           ROI since ICO{' '}
-          <HelpPopup content='This ROI takes into account pre-sales, the token price during all sales and the amount of tokens distributed in each sale. Example: SAN had a pre-sale when around ~15m (12k ETH) tokens were distributed at a much lower price, and an ICO where the equivalent of 33k ETH were distributed. Both these sales are taken into account for this ROI, while most aggregators calculate ROI based only on the ICO’s price.' />
+          <HelpPopup
+            position='top'
+            align='start'
+            content='This ROI takes into account pre-sales, the token price during all sales and the amount of tokens distributed in each sale. Example: SAN had a pre-sale when around ~15m (12k ETH) tokens were distributed at a much lower price, and an ICO where the equivalent of 33k ETH were distributed. Both these sales are taken into account for this ROI, while most aggregators calculate ROI based only on the ICO’s price.'
+          />
         </span>
       }
     />


### PR DESCRIPTION
**Summary**

Fix help popup styles after removed semantic

**Screenshots**
![image](https://user-images.githubusercontent.com/14061779/69643896-f885f200-1074-11ea-8779-d3c8608bdb93.png)
