### PR TITLE
fix/history-stats

### DIFF
--- a/src/components/RecentlyWatched/RecentlyWatched.js
+++ b/src/components/RecentlyWatched/RecentlyWatched.js
@@ -17,7 +17,7 @@ import { getWatchlistLink } from '../../ducks/Watchlists/watchlistUtils'
 import styles from './RecentlyWatched.module.scss'
 
 export const Asset = ({ project, classes = {}, onClick }) => {
-  const { name, ticker, priceUsd, percentChange24h, slug } = project
+  const { name, ticker, priceUsd, percentChange7d, slug } = project
   const res = onClick
     ? { Component: 'div', props: { onClick: () => onClick(project) } }
     : { Component: Link, props: { to: `/projects/${slug}` } }
@@ -33,7 +33,7 @@ export const Asset = ({ project, classes = {}, onClick }) => {
         <h4 className={styles.price}>
           {priceUsd ? formatNumber(priceUsd, { currency: 'USD' }) : 'No data'}
         </h4>
-        <PercentChanges changes={percentChange24h} className={styles.change} />
+        <PercentChanges changes={percentChange7d} className={styles.change} />
       </div>
     </res.Component>
   )

--- a/src/components/WatchlistOverview/WatchlistHistory/GetWatchlistHistory.js
+++ b/src/components/WatchlistOverview/WatchlistHistory/GetWatchlistHistory.js
@@ -7,7 +7,6 @@ import {
 } from './WatchlistHistoryGQL'
 import { BASIC_CATEGORIES } from '../../../pages/assets/assets-overview-constants'
 import WatchlistHistoryWidget from './WatchlistHistoryWidget'
-import { filterEmptyStats } from './utils'
 
 const getHistoryQuery = ({ projects, interval, method, slug }) => {
   const { from, to } = method
@@ -22,7 +21,7 @@ const getHistoryQuery = ({ projects, interval, method, slug }) => {
       }
     }),
     props: ({ data: { historyPrice = [], loading: isLoading } }) => ({
-      historyPrice: filterEmptyStats(historyPrice),
+      historyPrice,
       isLoading
     })
   })
@@ -41,7 +40,7 @@ const getHistoryQuery = ({ projects, interval, method, slug }) => {
     props: ({
       data: { projectsListHistoryStats = [], loading: isLoading }
     }) => ({
-      historyPrice: filterEmptyStats(projectsListHistoryStats),
+      historyPrice: projectsListHistoryStats,
       isLoading
     })
   })

--- a/src/components/WatchlistOverview/WatchlistHistory/utils.js
+++ b/src/components/WatchlistOverview/WatchlistHistory/utils.js
@@ -8,9 +8,6 @@ const currencyFormatOptions = {
   style: 'decimal'
 }
 
-export const filterEmptyStats = arr =>
-  arr.filter(({ marketcap, volume }) => !!marketcap && !!volume)
-
 export const statsForGraphics = arr => {
   const minMarketcap = Math.min(...arr.map(({ marketcap }) => marketcap))
   const minVolume = Math.min(...arr.map(({ volume }) => volume))

--- a/src/components/Watchlists/WatchlistCard.js
+++ b/src/components/Watchlists/WatchlistCard.js
@@ -19,7 +19,6 @@ import { TRENDING_WATCHLIST_NAME } from '../../pages/assets/assets-overview-cons
 import { DAY, getTimeIntervalFromToday } from '../../utils/dates'
 import { calcPercentageChange } from '../../utils/utils'
 import { millify } from '../../utils/formatting'
-import { filterEmptyStats } from '../WatchlistOverview/WatchlistHistory/utils'
 import styles from './WatchlistCard.module.scss'
 
 const INTERVAL = '6h'
@@ -147,7 +146,7 @@ const enhance = compose(
     }),
     skip: ({ slugs }) => !slugs || !slugs.length,
     props: ({ data: { projectsListHistoryStats = [], loading, error } }) => ({
-      stats: filterEmptyStats(projectsListHistoryStats),
+      stats: projectsListHistoryStats,
       isLoading: loading,
       isError: error
     })
@@ -162,7 +161,7 @@ const enhance = compose(
     }),
     skip: ({ slug }) => !slug,
     props: ({ data: { historyPrice = [], loading, error } }) => ({
-      stats: filterEmptyStats(historyPrice),
+      stats: historyPrice,
       isLoading: loading,
       isError: error
     })
@@ -177,10 +176,7 @@ const enhance = compose(
     }),
     skip: ({ bySlug }) => !bySlug,
     props: ({ data: { watchlistBySlug = {}, loading, error } }) => ({
-      stats:
-        watchlistBySlug && watchlistBySlug.historicalStats
-          ? filterEmptyStats(watchlistBySlug.historicalStats)
-          : [],
+      stats: watchlistBySlug.historicalStats || [],
       isLoading: loading,
       isError: error
     })
@@ -195,10 +191,7 @@ const enhance = compose(
     }),
     skip: ({ id }) => !id,
     props: ({ data: { watchlist = {}, loading, error } }) => ({
-      stats:
-        watchlist && watchlist.historicalStats
-          ? filterEmptyStats(watchlist.historicalStats)
-          : [],
+      stats: watchlist.historicalStats || [],
       isLoading: loading,
       isError: error
     })

--- a/src/components/Watchlists/WatchlistCard.js
+++ b/src/components/Watchlists/WatchlistCard.js
@@ -22,6 +22,7 @@ import { millify } from '../../utils/formatting'
 import styles from './WatchlistCard.module.scss'
 
 const INTERVAL = '6h'
+const RANGE = 7
 
 const WatchlistCard = ({
   name,
@@ -140,7 +141,7 @@ const enhance = compose(
     options: ({ slugs = [] }) => ({
       variables: {
         slugs,
-        ...getTimeIntervalFromToday(-6, DAY),
+        ...getTimeIntervalFromToday(-RANGE, DAY),
         interval: INTERVAL
       }
     }),
@@ -155,7 +156,7 @@ const enhance = compose(
     options: ({ slug }) => ({
       variables: {
         slug,
-        ...getTimeIntervalFromToday(-6, DAY),
+        ...getTimeIntervalFromToday(-RANGE, DAY),
         interval: INTERVAL
       }
     }),
@@ -170,7 +171,7 @@ const enhance = compose(
     options: ({ bySlug }) => ({
       variables: {
         slug: bySlug,
-        ...getTimeIntervalFromToday(-6, DAY),
+        ...getTimeIntervalFromToday(-RANGE, DAY),
         interval: INTERVAL
       }
     }),
@@ -185,7 +186,7 @@ const enhance = compose(
     options: ({ id }) => ({
       variables: {
         id,
-        ...getTimeIntervalFromToday(-6, DAY),
+        ...getTimeIntervalFromToday(-RANGE, DAY),
         interval: INTERVAL
       }
     }),

--- a/src/epics/fetchRecentsEpic.js
+++ b/src/epics/fetchRecentsEpic.js
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs'
-import { projectBySlugGQL } from '../pages/Projects/allProjectsGQL'
+import { RECENT_ASSET_QUERY } from '../pages/Projects/allProjectsGQL'
 import { WATCHLIST_QUERY } from '../queries/WatchlistGQL'
 import { getRecentAssets, getRecentWatchlists } from '../utils/recent'
 import { handleErrorAndTriggerAction } from './utils'
@@ -14,10 +14,8 @@ export const fetchRecentAssets = (action$, store, { client }) =>
         .map(slug =>
           Observable.from(
             client.query({
-              query: projectBySlugGQL,
-              variables: {
-                slug
-              }
+              query: RECENT_ASSET_QUERY,
+              variables: { slug }
             })
           )
         )

--- a/src/pages/Projects/allProjectsGQL.js
+++ b/src/pages/Projects/allProjectsGQL.js
@@ -68,6 +68,17 @@ export const projectBySlugGQL = gql`
   ${project}
 `
 
+export const RECENT_ASSET_QUERY = gql`
+  query projectBySlugGQL($slug: String!) {
+    projectBySlug(slug: $slug) {
+      ...generalData
+      percentChange7d
+      priceUsd
+    }
+  }
+  ${generalData}
+`
+
 export const allProjectsForSearchGQL = gql`
   query allProjects($minVolume: Int!) {
     allProjects(minVolume: $minVolume) {

--- a/src/pages/Projects/allProjectsGQL.js
+++ b/src/pages/Projects/allProjectsGQL.js
@@ -35,6 +35,13 @@ export const project = gql`
   }
 `
 
+export const PROJECT_RECENT_DATA_FRAGMENT = gql`
+  fragment recentProjectData on Project {
+    priceUsd
+    percentChange7d
+  }
+`
+
 export const allProjectsGQL = gql`
   query allProjects($minVolume: Int!) {
     allProjects(minVolume: $minVolume) {
@@ -72,11 +79,11 @@ export const RECENT_ASSET_QUERY = gql`
   query projectBySlugGQL($slug: String!) {
     projectBySlug(slug: $slug) {
       ...generalData
-      percentChange7d
-      priceUsd
+      ...recentProjectData
     }
   }
   ${generalData}
+  ${PROJECT_RECENT_DATA_FRAGMENT}
 `
 
 export const allProjectsForSearchGQL = gql`

--- a/src/queries/ProfileGQL.js
+++ b/src/queries/ProfileGQL.js
@@ -2,7 +2,7 @@ import gql from 'graphql-tag'
 import { INSIGHT_COMMON_FRAGMENT } from './InsightsGQL'
 import { TRIGGERS_COMMON_FRAGMENT } from '../ducks/Signals/common/queries'
 import {
-  WATHCLIST_GENERAL_FRAGMENT,
+  WATCHLIST_GENERAL_FRAGMENT,
   PROJECT_ITEM_FRAGMENT
 } from './WatchlistGQL'
 
@@ -36,13 +36,13 @@ export const PUBLIC_USER_DATA_QUERY = gql`
   }
   ${INSIGHT_COMMON_FRAGMENT}
   ${TRIGGERS_COMMON_FRAGMENT}
-  ${WATHCLIST_GENERAL_FRAGMENT}
+  ${WATCHLIST_GENERAL_FRAGMENT}
   ${PROJECT_ITEM_FRAGMENT}
 `
 
 export const FOLLOW_MUTATION = gql(`
-  mutation follow($id: ID!) 
-  {  
+  mutation follow($id: ID!)
+  {
     follow(userId: $id) {
         id
     }

--- a/src/queries/WatchlistGQL.js
+++ b/src/queries/WatchlistGQL.js
@@ -1,5 +1,9 @@
 import gql from 'graphql-tag'
-import { generalData, project } from '../pages/Projects/allProjectsGQL'
+import {
+  generalData,
+  project,
+  PROJECT_RECENT_DATA_FRAGMENT
+} from '../pages/Projects/allProjectsGQL'
 
 export const WATHCLIST_GENERAL_FRAGMENT = gql`
   fragment generalListData on UserList {
@@ -56,14 +60,14 @@ export const WATCHLIST_BY_SLUG_SHORT_QUERY = gql`
       listItems {
         project {
           ...generalData
-          ...project
+          ...recentProjectData
         }
       }
     }
   }
   ${WATHCLIST_GENERAL_FRAGMENT}
   ${generalData}
-  ${project}
+  ${PROJECT_RECENT_DATA_FRAGMENT}
 `
 
 export const WATCHLIST_BY_SLUG_BIG_QUERY = gql`
@@ -111,14 +115,14 @@ export const WATCHLIST_QUERY = gql`
       listItems {
         project {
           ...generalData
-          ...project
+          ...recentProjectData
         }
       }
     }
   }
   ${WATHCLIST_GENERAL_FRAGMENT}
   ${generalData}
-  ${project}
+  ${PROJECT_RECENT_DATA_FRAGMENT}
 `
 
 export const WATCHLIST_WITH_TRENDING_ASSETS_QUERY = gql`

--- a/src/queries/WatchlistGQL.js
+++ b/src/queries/WatchlistGQL.js
@@ -5,7 +5,7 @@ import {
   PROJECT_RECENT_DATA_FRAGMENT
 } from '../pages/Projects/allProjectsGQL'
 
-export const WATHCLIST_GENERAL_FRAGMENT = gql`
+export const WATCHLIST_GENERAL_FRAGMENT = gql`
   fragment generalListData on UserList {
     id
     color
@@ -38,7 +38,7 @@ export const ALL_WATCHLISTS_QUERY = gql`
       ...listShortItems
     }
   }
-  ${WATHCLIST_GENERAL_FRAGMENT}
+  ${WATCHLIST_GENERAL_FRAGMENT}
   ${PROJECT_ITEM_FRAGMENT}
 `
 
@@ -49,7 +49,7 @@ export const PUBLIC_WATCHLIST_QUERY = gql`
       ...listShortItems
     }
   }
-  ${WATHCLIST_GENERAL_FRAGMENT}
+  ${WATCHLIST_GENERAL_FRAGMENT}
   ${PROJECT_ITEM_FRAGMENT}
 `
 
@@ -65,7 +65,7 @@ export const WATCHLIST_BY_SLUG_SHORT_QUERY = gql`
       }
     }
   }
-  ${WATHCLIST_GENERAL_FRAGMENT}
+  ${WATCHLIST_GENERAL_FRAGMENT}
   ${generalData}
   ${PROJECT_RECENT_DATA_FRAGMENT}
 `
@@ -92,7 +92,7 @@ export const WATCHLIST_BY_SLUG_BIG_QUERY = gql`
       }
     }
   }
-  ${WATHCLIST_GENERAL_FRAGMENT}
+  ${WATCHLIST_GENERAL_FRAGMENT}
   ${generalData}
   ${project}
 `
@@ -104,7 +104,7 @@ export const FEATURED_WATCHLIST_QUERY = gql`
       ...listShortItems
     }
   }
-  ${WATHCLIST_GENERAL_FRAGMENT}
+  ${WATCHLIST_GENERAL_FRAGMENT}
   ${PROJECT_ITEM_FRAGMENT}
 `
 
@@ -120,7 +120,7 @@ export const WATCHLIST_QUERY = gql`
       }
     }
   }
-  ${WATHCLIST_GENERAL_FRAGMENT}
+  ${WATCHLIST_GENERAL_FRAGMENT}
   ${generalData}
   ${PROJECT_RECENT_DATA_FRAGMENT}
 `
@@ -143,7 +143,7 @@ export const WATCHLIST_WITH_TRENDING_ASSETS_QUERY = gql`
       }
     }
   }
-  ${WATHCLIST_GENERAL_FRAGMENT}
+  ${WATCHLIST_GENERAL_FRAGMENT}
   ${generalData}
   ${project}
 `
@@ -182,7 +182,7 @@ export const WATCHLIST_WITH_TRENDS_AND_SETTINGS_QUERY = gql`
       }
     }
   }
-  ${WATHCLIST_GENERAL_FRAGMENT}
+  ${WATCHLIST_GENERAL_FRAGMENT}
   ${generalData}
   ${project}
 `


### PR DESCRIPTION
**Summary**
- Fix different percent changes inside watchlist and on preview card
- Modify recent and preview watchlists queries for avoid fetching additional unnecessary data
- Change recent assets from `24h` changes to `7d`
- Remove filtering for empty data in `historyPrice` and `projectsListHistoryStats` (now it's doing on backend side)