### PR TITLE
add filter for historicalBalance(always return 1 year data)

### DIFF
--- a/src/ducks/Signals/chart/preview/SignalPreview.js
+++ b/src/ducks/Signals/chart/preview/SignalPreview.js
@@ -22,7 +22,8 @@ import {
   cleanByDatakeys,
   mapWithTimeseries,
   mapWithTimeseriesAndYCoord,
-  mapToRequestedMetrics
+  mapToRequestedMetrics,
+  makeSameRange
 } from './utils'
 import { DAILY_ACTIVE_ADDRESSES } from '../../utils/constants'
 import styles from './SignalPreview.module.scss'
@@ -44,7 +45,7 @@ const SignalPreviewChart = ({
   showTitle,
   interval
 }) => {
-  const triggeredSignals = points.filter(point => point['triggered?'])
+  let triggeredSignals = points.filter(point => point['triggered?'])
   const metricsTypes = getMetricsByType(type)
   const { metrics, triggersBy } = metricsTypes
 
@@ -80,6 +81,8 @@ const SignalPreviewChart = ({
 
         const data = mapWithTimeseries(timeseries)
         const merged = cleanByDatakeys(data, triggersBy.dataKey)
+
+        triggeredSignals = makeSameRange(triggeredSignals, merged)
 
         const signals = mapWithTimeseriesAndYCoord(
           triggeredSignals,

--- a/src/ducks/Signals/chart/preview/utils.js
+++ b/src/ducks/Signals/chart/preview/utils.js
@@ -34,6 +34,11 @@ export const cleanByDatakeys = (timeseries, dataKey) => {
   return timeseries.filter(item => item[dataKey] !== undefined)
 }
 
+export const makeSameRange = (points, base) => {
+  const date = base[0].datetime
+  return points.filter(({ datetime }) => +new Date(datetime) > date)
+}
+
 export const mapToRequestedMetrics = (
   metrics,
   { interval, slug, from, to, timeRange, address }


### PR DESCRIPTION
**Summary**

Query 'historicalTriggerPoints' always returns data 1 year for hist.balance. Add filter by 'time_range' of main metrics