### PR TITLE
fix/trend-insight-link

### DIFF
--- a/src/components/Insight/InsightAddBtn.js
+++ b/src/components/Insight/InsightAddBtn.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { Link } from 'react-router-dom'
 import Button from '@santiment-network/ui/Button'
 import Icon from '@santiment-network/ui/Icon'
 import { getInsightTrendTagByDate } from './utils'
 import styles from './Insights.module.scss'
 
 const trendTags = [getInsightTrendTagByDate(new Date())]
+
+const insightsHref = window.location.origin.replace('app', 'insights')
 
 const InsightAddBtn = ({ selectedTrends = [], dispatch, ...props }) => {
   const params = selectedTrends.length
@@ -15,11 +16,11 @@ const InsightAddBtn = ({ selectedTrends = [], dispatch, ...props }) => {
 
   return (
     <Button
-      as={Link}
+      as='a'
       className={styles.btn}
       accent='positive'
       variant='fill'
-      to={`/insights/new?${params}`}
+      href={`${insightsHref}/new?${params}`}
       {...props}
     >
       <Icon className={styles.icon} type='plus-round' />


### PR DESCRIPTION
## Summary
`Add insight` now leads to the `insights(-stage).santiment.net/new?`
## Screenshots
![image](https://user-images.githubusercontent.com/25135650/73368605-55469880-42c2-11ea-8939-d8b61bef31a1.png)
