### PR TITLE
enhance/studio-chart-colors

### DIFF
--- a/src/ducks/SANCharts/Chart/Synchronizer.js
+++ b/src/ducks/SANCharts/Chart/Synchronizer.js
@@ -92,8 +92,6 @@ const Synchronizer = ({ children, metrics, isMultiChartsActive, events }) => {
   const [hasPriceMetric, setHasPriceMetric] = useState()
   const [isValidMulti, setIsValidMulti] = useState()
 
-  const syncedColors = getSyncedColors(metrics)
-
   useEffect(
     () => {
       const noPriceMetrics = metrics.filter(metric => metric !== price_usd)
@@ -142,7 +140,6 @@ const Synchronizer = ({ children, metrics, isMultiChartsActive, events }) => {
         index: i,
         isMultiChartsActive,
         syncedTooltipDate,
-        syncedColors,
         syncTooltips,
         hasPriceMetric,
         tooltipKey,
@@ -153,7 +150,6 @@ const Synchronizer = ({ children, metrics, isMultiChartsActive, events }) => {
     : React.cloneElement(children, {
       ...syncedCategories[0],
       isMultiChartsActive: false,
-      syncedColors,
       hasPriceMetric,
       events: syncedEvents,
       tooltipKey: getValidTooltipKey(

--- a/src/ducks/SANCharts/Chart/colors.js
+++ b/src/ducks/SANCharts/Chart/colors.js
@@ -47,7 +47,6 @@ export function useChartColors (metrics) {
           MetricColorMap.get(metric) || COLORS[freeColorIndex++]
       }
 
-      console.log(newColors)
       setChartColors(newColors)
     },
     [metrics]

--- a/src/ducks/SANCharts/Chart/colors.js
+++ b/src/ducks/SANCharts/Chart/colors.js
@@ -8,7 +8,7 @@ const VIOLET = '#8358FF'
 const ORANGE = '#FFAD4D'
 const GRAY = '#D2D6E7'
 
-const COLORS = [
+export const COLORS = [
   '#5275FF', // BLUE
   '#FF5B5B', // RED
   '#FFCB47', // YELLOW
@@ -41,9 +41,8 @@ export function useChartColors (metrics) {
 
       for (let i = 0; i < length; i++) {
         const metric = metrics[i]
-        const { key, dataKey = key } = metric
 
-        newColors[dataKey] =
+        newColors[metric.key] =
           MetricColorMap.get(metric) || COLORS[freeColorIndex++]
       }
 

--- a/src/ducks/SANCharts/Chart/colors.js
+++ b/src/ducks/SANCharts/Chart/colors.js
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react'
+import { Metrics } from '../data'
+
+// RESERVED COLORS
+const GREEN = '#26C953'
+const CYAN = '#68DBF4'
+const VIOLET = '#8358FF'
+const ORANGE = '#FFAD4D'
+const GRAY = '#D2D6E7'
+
+const COLORS = [
+  '#5275FF', // BLUE
+  '#FF5B5B', // RED
+  '#FFCB47', // YELLOW
+  '#D4E763', // YELLOW-GREEN
+  '#F47BF7', // PURPLE
+  '#785549', // BROWN
+  '#AC948C', // BROWN-GRAY
+  '#37D7BA', // AQUAMARINE
+  '#FF8450', // SALMON
+  '#FFDAC5' // PEACH
+]
+
+const MetricColorMap = new Map()
+MetricColorMap.set(Metrics.price_usd, GREEN)
+MetricColorMap.set(Metrics.volume_usd, GRAY)
+MetricColorMap.set(Metrics.marketcap_usd, CYAN)
+MetricColorMap.set(Metrics.social_volume_total, CYAN)
+MetricColorMap.set(Metrics.daily_active_addresses, ORANGE)
+MetricColorMap.set(Metrics.dev_activity, VIOLET)
+
+const INITIAL_STATE = {}
+export function useChartColors (metrics) {
+  const [chartColors, setChartColors] = useState(INITIAL_STATE)
+
+  useEffect(
+    () => {
+      const { length } = metrics
+      const newColors = {}
+      let freeColorIndex = 0
+
+      for (let i = 0; i < length; i++) {
+        const metric = metrics[i]
+        const { key, dataKey = key } = metric
+
+        newColors[dataKey] =
+          MetricColorMap.get(metric) || COLORS[freeColorIndex++]
+      }
+
+      console.log(newColors)
+      setChartColors(newColors)
+    },
+    [metrics]
+  )
+
+  return chartColors
+}

--- a/src/ducks/SANCharts/Chart/index.js
+++ b/src/ducks/SANCharts/Chart/index.js
@@ -44,7 +44,7 @@ const Chart = ({
   rightBoundaryDate,
   tooltipKey,
   lastDayPrice,
-  syncedColors,
+  MetricColor,
   syncedTooltipDate,
   syncTooltips = () => {},
   onPointHover = () => {},
@@ -129,10 +129,11 @@ const Chart = ({
 
   useEffect(
     () => {
-      chart.colors = syncedColors
+      chart.colors = MetricColor
     },
-    [syncedColors]
+    [MetricColor]
   )
+
   useEffect(
     () => {
       if (data.length === 0 || !brush) return
@@ -160,6 +161,7 @@ const Chart = ({
       data,
       scale,
       events,
+      MetricColor,
       lastDayPrice,
       isNightModeEnabled,
       isCartesianGridActive
@@ -217,18 +219,18 @@ const Chart = ({
   }
 
   function plotBrushData () {
-    plotDayBars(brush, data, daybars, syncedColors, scale)
-    plotBars(brush, data, bars, syncedColors, scale)
-    plotLines(brush, data, lines, syncedColors, scale)
+    plotDayBars(brush, data, daybars, MetricColor, scale)
+    plotBars(brush, data, bars, MetricColor, scale)
+    plotLines(brush, data, lines, MetricColor, scale)
   }
 
   function plotChart (data) {
     drawWatermark(chart)
-    plotDayBars(chart, data, daybars, syncedColors, scale)
-    plotBars(chart, data, bars, syncedColors, scale)
+    plotDayBars(chart, data, daybars, MetricColor, scale)
+    plotBars(chart, data, bars, MetricColor, scale)
 
     chart.ctx.lineWidth = 1.5
-    plotLines(chart, data, lines, syncedColors, scale)
+    plotLines(chart, data, lines, MetricColor, scale)
 
     if (isCartesianGridActive) {
       drawCartesianGrid(chart, chart.axesColor)

--- a/src/ducks/SANCharts/ChartPage.js
+++ b/src/ducks/SANCharts/ChartPage.js
@@ -6,7 +6,7 @@ import Loadable from 'react-loadable'
 import { linearScale, logScale } from '@santiment-network/chart/scales'
 import GetTimeSeries from '../../ducks/GetTimeSeries/GetTimeSeries'
 import Chart from './Chart'
-import Synchronizer from './Chart/Synchronizer'
+import Synchronizer, { getSyncedColors } from './Chart/Synchronizer'
 import Header from './Header'
 import { getMarketSegment, mapDatetimeToNumber } from './utils'
 import { Metrics, Events, compatabilityMap, ASSETS_SIDEBAR } from './data'
@@ -508,6 +508,8 @@ class ChartPage extends Component {
             .concat(marketSegments)
             .filter(({ key }) => !errors.includes(key))
 
+          const MetricColor = getSyncedColors(finalMetrics)
+
           // NOTE(haritonasty): we don't show anomalies when trendPositionHistory is in activeMetrics
           const isTrendsShowing = trendPositionHistory !== undefined
           const eventsFiltered = isTrendsShowing
@@ -603,6 +605,7 @@ class ChartPage extends Component {
                         to={to}
                         metrics={finalMetrics}
                         data={mapDatetimeToNumber(timeseries)}
+                        MetricColor={MetricColor}
                         chartRef={this.chartRef}
                         scale={isLogScale ? logScale : linearScale}
                         leftBoundaryDate={!hasPremium && leftBoundaryDate}
@@ -612,6 +615,7 @@ class ChartPage extends Component {
                         isLoading={isParentLoading || isLoading}
                         isWideChart={isWideChart}
                         onPointHover={this.getSocialContext}
+                        resizeDependencies={[]}
                       />
                     </Synchronizer>
 

--- a/src/ducks/SANCharts/data.js
+++ b/src/ducks/SANCharts/data.js
@@ -41,7 +41,6 @@ export const Metrics = {
   price_usd: {
     node: 'line',
     Component: Line,
-    color: 'jungle-green',
     label: 'Price',
     category: 'Financial',
     formatter: usdFormatter,
@@ -76,7 +75,6 @@ export const Metrics = {
     node: 'line',
     Component: Line,
     label: 'Marketcap',
-    color: 'malibu',
     formatter: usdFormatter
   },
   volume_usd: {
@@ -85,7 +83,6 @@ export const Metrics = {
     Component: Bar,
     label: 'Volume',
     fill: true,
-    color: 'mystic',
     formatter: usdFormatter
   },
   social_volume_total: {
@@ -95,7 +92,6 @@ export const Metrics = {
     label: 'Social Volume',
     shortLabel: 'Soc. Volume',
     anomalyKey: 'SOCIAL_VOLUME',
-    color: 'malibu',
     description: (
       <>
         Shows the amount of mentions of the coin on 1000+ crypto social media
@@ -187,7 +183,6 @@ export const Metrics = {
       </>
     ),
 
-    color: 'texas-rose',
     historicalTriggersDataKey: 'active_addresses',
     minInterval: '1d'
   },
@@ -324,7 +319,6 @@ export const Metrics = {
     category: 'Development',
     node: 'line',
     Component: Line,
-    color: 'heliotrope',
     label: 'Development Activity',
     shortLabel: 'Dev. Activity',
     anomalyKey: 'DEV_ACTIVITY',

--- a/src/ducks/Studio/Chart/ActiveMetrics.js
+++ b/src/ducks/Studio/Chart/ActiveMetrics.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import cx from 'classnames'
 import Icon from '@santiment-network/ui/Icon'
 import Button from '@santiment-network/ui/Button'
 import MetricExplanation from '../../SANCharts/MetricExplanation'
@@ -9,6 +10,7 @@ import styles from './ActiveMetrics.module.scss'
 const { trendPositionHistory } = Events
 
 const MetricButton = ({
+  className,
   metric,
   colors,
   isLoading,
@@ -32,7 +34,7 @@ const MetricButton = ({
       closeTimeout={22}
       offsetX={8}
     >
-      <Button border className={styles.btn}>
+      <Button border className={cx(styles.btn, className)}>
         {isLoading ? (
           <div className={styles.loader} />
         ) : (
@@ -63,7 +65,8 @@ export default ({
   loadings,
   toggleMetric,
   eventLoadings,
-  isMultiChartsActive
+  isMultiChartsActive,
+  className
 }) => {
   const isMoreThanOneMetric = activeMetrics.length > 1 || isMultiChartsActive
 
@@ -72,6 +75,7 @@ export default ({
       {activeMetrics.map((metric, i) => (
         <MetricButton
           key={metric.key}
+          className={className}
           metric={metric}
           colors={MetricColor}
           isLoading={loadings.includes(metric)}
@@ -82,6 +86,7 @@ export default ({
       {activeEvents.includes(trendPositionHistory) && (
         <MetricButton
           isRemovable
+          className={className}
           metric={trendPositionHistory}
           colors={MetricColor}
           toggleMetric={toggleMetric}

--- a/src/ducks/Studio/Chart/ActiveMetrics.js
+++ b/src/ducks/Studio/Chart/ActiveMetrics.js
@@ -4,7 +4,6 @@ import Button from '@santiment-network/ui/Button'
 import MetricExplanation from '../../SANCharts/MetricExplanation'
 import MetricIcon from '../../SANCharts/MetricIcon'
 import { Events } from '../../SANCharts/data'
-import { getSyncedColors } from '../../SANCharts/Chart/Synchronizer'
 import styles from './ActiveMetrics.module.scss'
 
 const { trendPositionHistory } = Events
@@ -58,6 +57,7 @@ const MetricButton = ({
 }
 
 export default ({
+  MetricColor,
   activeMetrics,
   activeEvents,
   loadings,
@@ -65,8 +65,6 @@ export default ({
   eventLoadings,
   isMultiChartsActive
 }) => {
-  const actives = activeMetrics.concat(activeEvents)
-  const colors = getSyncedColors(actives)
   const isMoreThanOneMetric = activeMetrics.length > 1 || isMultiChartsActive
 
   return (
@@ -75,7 +73,7 @@ export default ({
         <MetricButton
           key={metric.key}
           metric={metric}
-          colors={colors}
+          colors={MetricColor}
           isLoading={loadings.includes(metric)}
           isRemovable={isMoreThanOneMetric}
           toggleMetric={toggleMetric}
@@ -85,7 +83,7 @@ export default ({
         <MetricButton
           isRemovable
           metric={trendPositionHistory}
-          colors={colors}
+          colors={MetricColor}
           toggleMetric={toggleMetric}
           isLoading={eventLoadings.length}
         />

--- a/src/ducks/Studio/Chart/ActiveMetrics.module.scss
+++ b/src/ducks/Studio/Chart/ActiveMetrics.module.scss
@@ -14,7 +14,7 @@
   }
 
   &:last-child {
-    margin: 0;
+    margin-left: 0;
   }
 }
 

--- a/src/ducks/Studio/Chart/MetricsExplanation/index.js
+++ b/src/ducks/Studio/Chart/MetricsExplanation/index.js
@@ -5,7 +5,6 @@ import Dropdown from '@santiment-network/ui/Dropdown'
 import Explanations from './Explanations'
 import DataInfo from './DataInfo'
 import MetricIcon from '../../../SANCharts/MetricIcon'
-import { getSyncedColors } from '../../../SANCharts/Chart/Synchronizer'
 import styles from './index.module.scss'
 
 const OPTIONS = []
@@ -54,13 +53,13 @@ const CloseButton = props => {
   )
 }
 
-const MetricsExplanation = ({ metrics, onClose, ...rest }) => {
+const MetricsExplanation = ({ metrics, MetricColor, onClose, ...rest }) => {
   const [options, setOptions] = useState(OPTIONS)
   const [selected, setSelected] = useState(SELECTED)
 
   useEffect(
     () => {
-      const newOptions = buildOptions(metrics, getSyncedColors(metrics))
+      const newOptions = buildOptions(metrics, MetricColor)
       const newSelected = newOptions[0]
 
       setOptions(newOptions)

--- a/src/ducks/Studio/Chart/MetricsExplanation/index.module.scss
+++ b/src/ducks/Studio/Chart/MetricsExplanation/index.module.scss
@@ -4,6 +4,7 @@
   padding: 26px 28px;
   max-height: 100%;
   overflow-y: auto;
+  height: 100%;
 
   @include text('body-3');
 }

--- a/src/ducks/Studio/Chart/index.js
+++ b/src/ducks/Studio/Chart/index.js
@@ -72,6 +72,7 @@ const Canvas = ({
       <div className={cx(styles.top, isBlurred && styles.blur)}>
         <div className={styles.metrics}>
           <ChartActiveMetrics
+            className={styles.metric}
             MetricColor={MetricColor}
             activeMetrics={metrics}
             activeEvents={activeEvents}

--- a/src/ducks/Studio/Chart/index.js
+++ b/src/ducks/Studio/Chart/index.js
@@ -12,6 +12,7 @@ import ChartMetricsExplanation, {
 import IcoPrice from './IcoPrice'
 import Chart from '../../SANCharts/Chart'
 import Synchronizer from '../../SANCharts/Chart/Synchronizer'
+import { useChartColors } from '../../SANCharts/Chart/colors'
 import { checkIsLoggedIn } from '../../../pages/UserSelectors'
 import styles from './index.module.scss'
 
@@ -37,6 +38,8 @@ const Canvas = ({
   ...props
 }) => {
   const [isExplained, setIsExplained] = useState()
+  const MetricColor = useChartColors(metrics)
+
   const isBlurred = isAnon && index > 1
   const hasExplanaibles = filterExplainableMetrics(metrics).length > 0
   const scale = options.isLogScale ? logScale : linearScale
@@ -69,6 +72,7 @@ const Canvas = ({
       <div className={cx(styles.top, isBlurred && styles.blur)}>
         <div className={styles.metrics}>
           <ChartActiveMetrics
+            MetricColor={MetricColor}
             activeMetrics={metrics}
             activeEvents={activeEvents}
             toggleMetric={toggleMetric}
@@ -82,14 +86,15 @@ const Canvas = ({
           <ChartPaywallInfo boundaries={boundaries} metrics={metrics} />
           {hasExplanaibles && (
             <ChartMetricsExplanation.Button
-              onClick={toggleExplanation}
               className={styles.explain}
+              onClick={toggleExplanation}
             />
           )}
           <ChartFullscreenBtn
             {...props}
             options={options}
             settings={settings}
+            MetricColor={MetricColor}
             metrics={metrics}
             activeEvents={activeEvents}
             scale={scale}
@@ -100,14 +105,16 @@ const Canvas = ({
         {...options}
         {...settings}
         {...props}
-        className={cx(styles.chart, isBlurred && styles.blur)}
-        isMultiChartsActive={isMultiChartsActive}
-        metrics={metrics}
         chartRef={chartRef}
+        className={cx(styles.chart, isBlurred && styles.blur)}
+        MetricColor={MetricColor}
+        metrics={metrics}
         scale={scale}
-        onPointHover={advancedView ? changeHoveredDate : undefined}
+        isMultiChartsActive={isMultiChartsActive}
         syncedTooltipDate={isBlurred || syncedTooltipDate}
+        onPointHover={advancedView ? changeHoveredDate : undefined}
         resizeDependencies={[
+          MetricColor,
           isMultiChartsActive,
           advancedView,
           isExplained,
@@ -138,6 +145,7 @@ const Canvas = ({
           <ChartMetricsExplanation
             {...settings}
             metrics={metrics}
+            MetricColor={MetricColor}
             onClose={closeExplanation}
           />
         </div>

--- a/src/ducks/Studio/Chart/index.module.scss
+++ b/src/ducks/Studio/Chart/index.module.scss
@@ -20,6 +20,11 @@
 .metrics {
   display: flex;
   flex-wrap: wrap;
+  margin-bottom: -4px;
+}
+
+.metric {
+  margin-bottom: 4px;
 }
 
 .meta {

--- a/src/ducks/Studio/Compare/Comparable/Metric.js
+++ b/src/ducks/Studio/Compare/Comparable/Metric.js
@@ -4,7 +4,10 @@ import Icon from '@santiment-network/ui/Icon'
 import withMetrics from '../../withMetrics'
 import Search, { getMetricSuggestions } from '../../Sidebar/Search'
 import MetricIcon from '../../../SANCharts/MetricIcon'
+import { COLORS } from '../../../SANCharts/Chart/colors'
 import styles from './Metric.module.scss'
+
+const DEFAULT_COLOR = '#9faac4'
 
 const MetricSearch = withMetrics(
   ({ categories, loading, className, ...rest }) => (
@@ -20,23 +23,31 @@ const MetricSearch = withMetrics(
   )
 )
 
-const Label = ({ comparable, editMetric, colors }) => {
+const Label = ({ comparable, editMetric, colors, options }) => {
   const { node, label } = comparable.metric
+  const color = options.isMultiChartsActive ? COLORS[0] : colors[comparable.key]
 
   return (
-    <div className={styles.selected}>
+    <div className={styles.selected} onClick={editMetric}>
       <MetricIcon
         node={node}
-        color={colors[comparable.key]}
+        color={color || DEFAULT_COLOR}
         className={styles.label}
       />
       {label}
-      <Icon type='edit' className={styles.edit} onClick={editMetric} />
+      <Icon type='edit' className={styles.edit} />
     </div>
   )
 }
 
-export default ({ comparable, slug, colors, hiddenMetrics, onSelect }) => {
+export default ({
+  comparable,
+  slug,
+  colors,
+  hiddenMetrics,
+  onSelect,
+  ...rest
+}) => {
   const [isEditing, setEditing] = useState()
   const metricSelectorRef = useRef(null)
 
@@ -69,6 +80,7 @@ export default ({ comparable, slug, colors, hiddenMetrics, onSelect }) => {
       {isEditing ||
         (comparable && (
           <Label
+            {...rest}
             comparable={comparable}
             editMetric={editMetric}
             colors={colors}

--- a/src/ducks/Studio/Compare/Comparable/Metric.module.scss
+++ b/src/ducks/Studio/Compare/Comparable/Metric.module.scss
@@ -6,11 +6,6 @@
   width: 14px;
   fill: var(--waterloo);
   margin-left: auto;
-  cursor: pointer;
-
-  &:hover {
-    fill: var(--jungle-green);
-  }
 }
 
 .selected {
@@ -27,6 +22,11 @@
   display: flex;
   padding: 0 12px;
   user-select: none;
+  cursor: pointer;
+
+  &:hover .edit {
+    fill: var(--jungle-green);
+  }
 }
 
 .metric {

--- a/src/ducks/Studio/Compare/Comparable/index.js
+++ b/src/ducks/Studio/Compare/Comparable/index.js
@@ -14,7 +14,8 @@ export default ({
   projects,
   colors,
   hiddenMetricsMap,
-  setComparables
+  setComparables,
+  ...rest
 }) => {
   const [selectedProject, setSelectedProject] = useState(project || projects[0])
   const [selectedMetric, setSelectedMetric] = useState(metric)
@@ -81,6 +82,7 @@ export default ({
         onSelect={selectProject}
       />
       <ComparableMetric
+        {...rest}
         comparable={comparable}
         slug={slug}
         colors={colors}

--- a/src/ducks/Studio/Compare/index.js
+++ b/src/ducks/Studio/Compare/index.js
@@ -7,12 +7,12 @@ import Panel from '@santiment-network/ui/Panel'
 import Comparable from './Comparable'
 import withProjects from './withProjects'
 import { projectSorter, hashComparable, buildHiddenMetrics } from './utils'
-import { getSyncedColors } from '../../SANCharts/Chart/Synchronizer'
+import { MAX_METRICS_AMOUNT } from '../constraints'
+import { useChartColors } from '../../SANCharts/Chart/colors'
 import styles from './index.module.scss'
 
 const Compare = ({
   slug,
-  title,
   allProjects,
   comparables,
   activeMetrics,
@@ -20,48 +20,64 @@ const Compare = ({
   ...rest
 }) => {
   const [projects, setProjects] = useState(allProjects)
+  const MetricColor = useChartColors(activeMetrics)
 
   useEffect(
     () => {
       setProjects(
-        allProjects.filter(project => project.slug !== slug).sort(projectSorter)
+        allProjects
+          .filter(project => project.slug !== slug)
+          .sort(projectSorter)
       )
     },
     [allProjects, slug]
   )
 
-  const array = activeMetrics.length < 5 ? [...comparables, null] : comparables
-  const colors = getSyncedColors(activeMetrics)
+  const canSelectMoreMetrics =
+    rest.options.isMultiChartsActive ||
+    activeMetrics.length < MAX_METRICS_AMOUNT
+
   const hiddenMetricsMap = buildHiddenMetrics(comparables)
+
   return (
-    <>
-      <ContextMenu
-        passOpenStateAs='isActive'
-        position='bottom'
-        align='start'
-        trigger={
-          <Button border className={cx(styles.btn, className)} classes={styles}>
-            <Icon type='compare' className={styles.icon} />
-            Compare
-          </Button>
-        }
-      >
-        <Panel variant='modal' padding>
-          <div>Compare {title} with</div>
-          {array.map((comparable, i) => (
-            <Comparable
-              {...rest}
-              {...comparable}
-              key={comparable ? hashComparable(comparable) : i}
-              projects={projects}
-              comparable={comparable}
-              colors={colors}
-              hiddenMetricsMap={hiddenMetricsMap}
-            />
-          ))}
-        </Panel>
-      </ContextMenu>
-    </>
+    <ContextMenu
+      passOpenStateAs='isActive'
+      position='bottom'
+      align='start'
+      trigger={
+        <Button border className={cx(styles.btn, className)} classes={styles}>
+          <Icon type='compare' className={styles.icon} />
+          Compare
+        </Button>
+      }
+    >
+      <Panel variant='modal' padding>
+        <div>Compare with</div>
+        {comparables.map(comparable => (
+          <Comparable
+            {...rest}
+            {...comparable}
+            key={hashComparable(comparable)}
+            projects={projects}
+            comparable={comparable}
+            colors={MetricColor}
+            hiddenMetricsMap={hiddenMetricsMap}
+          />
+        ))}
+        {canSelectMoreMetrics ? (
+          <Comparable
+            {...rest}
+            projects={projects}
+            colors={MetricColor}
+            hiddenMetricsMap={hiddenMetricsMap}
+          />
+        ) : (
+          <div className={styles.info}>
+            You have selected the maximum amount of metrics
+          </div>
+        )}
+      </Panel>
+    </ContextMenu>
   )
 }
 

--- a/src/ducks/Studio/Compare/index.module.scss
+++ b/src/ducks/Studio/Compare/index.module.scss
@@ -17,3 +17,8 @@
   color: var(--jungle-green);
   fill: var(--jungle-green);
 }
+
+.info {
+  margin-top: 8px;
+  color: var(--casper);
+}

--- a/src/ducks/Studio/Sidebar/index.js
+++ b/src/ducks/Studio/Sidebar/index.js
@@ -4,8 +4,9 @@ import Loader from '@santiment-network/ui/Loader/Loader'
 import Icon from '@santiment-network/ui/Icon'
 import MetricSelector from './MetricSelector'
 import Search from './Search'
-import AnomaliesToggle from '../../../components/AnomaliesToggle/AnomaliesToggle'
 import withMetrics from '../withMetrics'
+import { MAX_METRICS_AMOUNT } from '../constraints'
+import AnomaliesToggle from '../../../components/AnomaliesToggle/AnomaliesToggle'
 import { saveToggle } from '../../../utils/localStorage'
 import styles from './index.module.scss'
 
@@ -31,7 +32,12 @@ const Header = ({ activeMetrics, ...rest }) => {
   return (
     <div className={styles.header}>
       <h2 className={styles.title}>
-        Metrics <span className={styles.count}>({activeMetrics.length}/5)</span>
+        Metrics{' '}
+        {rest.options.isMultiChartsActive || (
+          <span className={styles.count}>
+            ({activeMetrics.length}/{MAX_METRICS_AMOUNT})
+          </span>
+        )}
       </h2>
       <Search {...rest} />
       <Anomalies {...rest} />

--- a/src/ducks/Studio/constraints.js
+++ b/src/ducks/Studio/constraints.js
@@ -1,0 +1,1 @@
+export const MAX_METRICS_AMOUNT = 10

--- a/src/ducks/Studio/index.js
+++ b/src/ducks/Studio/index.js
@@ -7,6 +7,7 @@ import StudioAdvancedView from './AdvancedView'
 import StudioInfo from '../SANCharts/Header'
 import { Events } from '../SANCharts/data'
 import { DEFAULT_SETTINGS, DEFAULT_OPTIONS, DEFAULT_METRICS } from './defaults'
+import { MAX_METRICS_AMOUNT } from './constraints'
 import { generateShareLink, updateHistory } from './url'
 import { buildComparedMetric } from './Compare/utils'
 import { useTimeseries } from './timeseries/hooks'
@@ -61,6 +62,26 @@ const Studio = ({
 
   useEffect(
     () => {
+      const activeLength = activeMetrics.length
+      if (!options.isMultiChartsActive && activeLength > MAX_METRICS_AMOUNT) {
+        const diff = activeLength - MAX_METRICS_AMOUNT
+
+        if (diff >= comparables.length) {
+          setComparables([])
+        } else {
+          setComparables(comparables.slice(0, diff))
+        }
+
+        if (metrics.length >= MAX_METRICS_AMOUNT) {
+          setMetrics(metrics.slice(0, MAX_METRICS_AMOUNT))
+        }
+      }
+    },
+    [options.isMultiChartsActive]
+  )
+
+  useEffect(
+    () => {
       const { slug } = defaultSettings
       if (slug && slug !== settings.slug) {
         setSettings(state => ({ ...state, slug }))
@@ -111,7 +132,13 @@ const Studio = ({
       metricSet.delete(metric)
       trackMetricState(metric, false)
     } else {
-      if (activeMetrics.length === 5) return
+      if (
+        !options.isMultiChartsActive &&
+        activeMetrics.length === MAX_METRICS_AMOUNT
+      ) {
+        return
+      }
+
       metricSet.add(metric)
       trackMetricState(metric, true)
     }

--- a/src/ducks/Studio/index.js
+++ b/src/ducks/Studio/index.js
@@ -69,7 +69,7 @@ const Studio = ({
         if (diff >= comparables.length) {
           setComparables([])
         } else {
-          setComparables(comparables.slice(0, diff))
+          setComparables(comparables.slice(0, -diff))
         }
 
         if (metrics.length >= MAX_METRICS_AMOUNT) {


### PR DESCRIPTION
## Summary
- Updated chart colors;
- Removed active metrics number restriction in `Multi-Chart` mode;
-  Allowing up to `10` active metrics on a single chart.

## Screenshots
![image](https://user-images.githubusercontent.com/25135650/76855260-d1d90a80-6861-11ea-8d6f-7dd638606f10.png)
