### PR TITLE
add crown for paywalled insights on feed

### DIFF
--- a/src/components/Insight/InsightCard.module.scss
+++ b/src/components/Insight/InsightCard.module.scss
@@ -80,6 +80,7 @@
 .bottom {
   display: flex;
   flex-direction: row;
+  align-items: center;
   padding-top: 20px;
   margin-top: auto;
   border-top: 1px solid var(--porcelain);
@@ -195,4 +196,11 @@
 
 .date {
   margin-bottom: 12px !important;
+}
+
+.crown {
+  width: 12px;
+  height: 9px;
+  fill: var(--texas-rose);
+  margin-left: 20px;
 }

--- a/src/components/Insight/InsightCardInternals.js
+++ b/src/components/Insight/InsightCardInternals.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import cx from 'classnames'
+import Icon from '@santiment-network/ui/Icon'
 import InsightTags from './InsightTags'
 import ProfileInfo, { InsightDate } from './ProfileInfo'
 import MultilineText from '../MultilineText/MultilineText'
@@ -35,6 +36,7 @@ const InsightCardInternals = ({
   isDesktop,
   showIcon = false,
   showDate = false,
+  isPaywallRequired,
   children
 }) => {
   const linkToInsight = makeLinkToInsight(id, title)
@@ -96,6 +98,7 @@ const InsightCardInternals = ({
           <div className={styles.tags}>
             <InsightTags tags={tags} isDesktop={isDesktop} />
           </div>
+          {isPaywallRequired && <Icon type='crown' className={styles.crown} />}
         </div>
       </div>
     </div>

--- a/src/queries/InsightsGQL.js
+++ b/src/queries/InsightsGQL.js
@@ -22,6 +22,7 @@ export const INSIGHT_COMMON_FRAGMENT = gql`
     }
     shortDesc
     commentsCount
+    isPaywallRequired
     __typename
   }
 `


### PR DESCRIPTION
**Summary**
Crown icon for paywalled insights on feed

**Screenshots**
![image](https://user-images.githubusercontent.com/14061779/78176810-c858c080-7465-11ea-9827-7cea6354b124.png)
