### PR TITLE
enhance/coin-cost-histogram

### DIFF
--- a/src/ducks/Chart/utils.js
+++ b/src/ducks/Chart/utils.js
@@ -6,7 +6,10 @@ import {
 } from '../../utils/dates'
 import { millify } from '../../utils/formatting'
 
-const DEFAULT_DOMAIN_METRIC_KEYS = [Metric.twitter_followers.key]
+const DEFAULT_DOMAIN_METRIC_KEYS = [
+  Metric.twitter_followers.key,
+  Metric.minersBalance.key
+]
 const DAY_INTERVAL = ONE_DAY_IN_MS * 2
 
 export function isDayInterval (chart) {

--- a/src/ducks/Studio/AdvancedView/PriceHistogram/gql.js
+++ b/src/ducks/Studio/AdvancedView/PriceHistogram/gql.js
@@ -2,7 +2,7 @@ import gql from 'graphql-tag'
 
 export const HISTOGRAM_DATA_QUERY = gql`
   query getMetric($slug: String!, $from: DateTime!, $to: DateTime!) {
-    getMetric(metric: "price_histogram") {
+    histogramQuery: getMetric(metric: "price_histogram") {
       histogramData(slug: $slug, from: $from, to: $to, limit: 10) {
         values {
           ... on FloatRangeFloatValueList {
@@ -14,14 +14,14 @@ export const HISTOGRAM_DATA_QUERY = gql`
         }
       }
     }
-  }
-`
 
-export const PROJECT_PRICE_QUERY = gql`
-  query($slug: String!) {
-    project: projectBySlug(slug: $slug) {
-      id
-      priceUsd
+    priceQuery: getMetric(metric: "price_usd") {
+      price: aggregatedTimeseriesData(
+        slug: $slug
+        from: $from
+        to: $to
+        aggregation: LAST
+      )
     }
   }
 `


### PR DESCRIPTION
## Summary
- Showing price for a selected histogram period (not current asset price);
- Buckets are sorted in descending order;
## Screenshots
![image](https://user-images.githubusercontent.com/25135650/78874779-9216d480-7a55-11ea-9565-9eb940755625.png)
