### PR TITLE
fix/google-translate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,40 @@ const calculateHeight = () => {
   document.documentElement.style.setProperty('--vh', `${vh}px`)
 }
 
+// NOTE: haritonasty: fix for crash when google translate is turn on
+// https://github.com/facebook/react/issues/11538
+if (typeof Node === 'function' && Node.prototype) {
+  const originalRemoveChild = Node.prototype.removeChild
+  Node.prototype.removeChild = function (child) {
+    if (child.parentNode !== this) {
+      if (console) {
+        console.error(
+          'Cannot remove a child from a different parent',
+          child,
+          this
+        )
+      }
+      return child
+    }
+    return originalRemoveChild.apply(this, arguments)
+  }
+
+  const originalInsertBefore = Node.prototype.insertBefore
+  Node.prototype.insertBefore = function (newNode, referenceNode) {
+    if (referenceNode && referenceNode.parentNode !== this) {
+      if (console) {
+        console.error(
+          'Cannot insert before a reference node from a different parent',
+          referenceNode,
+          this
+        )
+      }
+      return newNode
+    }
+    return originalInsertBefore.apply(this, arguments)
+  }
+}
+
 const main = () => {
   const httpLink = createHttpLink({
     uri: `${getAPIUrl()}/graphql`,


### PR DESCRIPTION
**Summary**
Problem: Google Translate replaces text nodes with <font> tags containing translations while React keeps references to the text nodes that are no longer in the DOM tree.

Notes: 
- this solution can make app a little bit slower (but I didn't notice that)
- This fix can be remove after applying this task https://bugs.chromium.org/p/chromium/issues/detail?id=872770
- also we can remake whole app with this way - https://github.com/facebook/react/issues/11538#issuecomment-390386520. 
Looks like it also will fix the problem