### PR TITLE
enhance/studio-metrics-rearranged

### DIFF
--- a/src/ducks/Studio/Sidebar/MetricSelector/Settings.js
+++ b/src/ducks/Studio/Sidebar/MetricSelector/Settings.js
@@ -42,7 +42,7 @@ const Setting = ({ settings, metric, setMetricSettingMap }) => {
     setLastValidValue(value)
 
     setMetricSettingMap(state => {
-      const prevSettings = state.get(metric)
+      const prevSettings = state.get(metric) || {}
       const newState = new Map(state)
 
       newState.set(

--- a/src/ducks/Studio/defaults.js
+++ b/src/ducks/Studio/defaults.js
@@ -14,7 +14,7 @@ export const DEFAULT_SETTINGS = {
   interval: getNewInterval(FROM, TO),
   from: FROM.toISOString(),
   to: TO.toISOString(),
-  timeRange: DEFAULT_TIME_RANGE
+  timeRange: DEFAULT_TIME_RANGE,
 }
 
 export const DEFAULT_OPTIONS = {
@@ -23,7 +23,7 @@ export const DEFAULT_OPTIONS = {
   isAnomalyActive: getSavedToggle('isAnomalyActive'),
   isMultiChartsActive: getSavedMulticharts(),
   isCartesianGridActive: getSavedToggle('isCartesianGridActive', true),
-  isClosestDataActive: getSavedToggle('isClosestDataActive', true)
+  isClosestDataActive: getSavedToggle('isClosestDataActive', true),
 }
 
 export const DEFAULT_METRICS = [Metric.price_usd]
@@ -32,7 +32,19 @@ export const DEFAULT_METRIC_SETTINGS_MAP = new Map([
   [
     Metric.amount_in_top_holders,
     {
-      holdersCount: 10
-    }
-  ]
+      holdersCount: 10,
+    },
+  ],
+  [
+    Metric.amount_in_exchange_top_holders,
+    {
+      holdersCount: 10,
+    },
+  ],
+  [
+    Metric.amount_in_non_exchange_top_holders,
+    {
+      holdersCount: 10,
+    },
+  ],
 ])

--- a/src/ducks/dataHub/metrics/index.js
+++ b/src/ducks/dataHub/metrics/index.js
@@ -262,17 +262,20 @@ export const Metric = {
   amount_in_top_holders: {
     node: 'line',
     label: 'Amount in Top Holders',
-    category: 'On-chain'
+    category: 'On-chain',
+    group: 'Top Holders'
   },
   amount_in_exchange_top_holders: {
     node: 'line',
     label: 'Amount in Exchange Top Holders',
-    category: 'On-chain'
+    category: 'On-chain',
+    group: 'Top Holders'
   },
   amount_in_non_exchange_top_holders: {
     node: 'line',
     label: 'Amount in Non Exchange Top Holders',
-    category: 'On-chain'
+    category: 'On-chain',
+    group: 'Top Holders'
   }
 }
 

--- a/src/ducks/dataHub/metrics/index.js
+++ b/src/ducks/dataHub/metrics/index.js
@@ -252,12 +252,14 @@ export const Metric = {
   supply_on_exchanges: {
     node: 'line',
     label: 'Supply On Exchanges',
-    category: 'On-chain'
+    category: 'On-chain',
+    group: 'Exchange Flow'
   },
   supply_outside_exchanges: {
     node: 'line',
     label: 'Supply Outside Exchanges',
-    category: 'On-chain'
+    category: 'On-chain',
+    group: 'Exchange Flow'
   },
   amount_in_top_holders: {
     node: 'line',

--- a/src/ducks/dataHub/metrics/settings.js
+++ b/src/ducks/dataHub/metrics/settings.js
@@ -1,15 +1,18 @@
 import { Metric } from './index'
 
-export const MetricSettings = Object.assign(Object.create(null), {
-  [Metric.amount_in_top_holders.key]: [
-    {
-      key: 'holdersCount',
-      label: 'Top Holders',
-      defaultValue: 10,
-      constraints: {
-        min: 1,
-        max: 1000000
-      }
-    }
-  ]
-})
+// NOTE: It's safe to pass it as reference, because it will not be modified [@vanguard | May12, 2020]
+const TOP_HOLDERS = {
+  key: 'holdersCount',
+  label: 'Top Holders',
+  defaultValue: 10,
+  constraints: {
+    min: 1,
+    max: 1000000,
+  },
+}
+
+export const MetricSettings = {
+  [Metric.amount_in_top_holders.key]: [TOP_HOLDERS],
+  [Metric.amount_in_exchange_top_holders.key]: [TOP_HOLDERS],
+  [Metric.amount_in_non_exchange_top_holders.key]: [TOP_HOLDERS],
+}


### PR DESCRIPTION
## Summary
- Adding top holders selector input for `Amount in Exchange Top Holders` and `Amount in Non Exchange Top Holders` metrics;
- Grouping top holders metrics inside the `Top Holders` block;
- `Supply On Exchanges` and `Supply Outside Exchanges` added to the `Exchange Flow` group;