### PR TITLE
feature/sentiment-metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@apollo/react-testing": "^3.1.3",
-    "@santiment-network/chart": "^0.4.0",
+    "@santiment-network/chart": "^0.5.0",
     "@santiment-network/ui": "^0.5.167",
     "@trainline/react-skeletor": "^1.0.2",
     "apollo-cache-inmemory": "^1.6.3",

--- a/src/components/AdvancedCalendar/index.module.scss
+++ b/src/components/AdvancedCalendar/index.module.scss
@@ -11,6 +11,7 @@
 
   width: 100%;
   outline: none;
+  color: var(--rhino);
   background: var(--white);
   border: 1px solid var(--porcelain);
   box-shadow: 0 2px 8px rgba(59, 84, 106, 0.03),

--- a/src/ducks/Chart/Synchronizer.js
+++ b/src/ducks/Chart/Synchronizer.js
@@ -9,6 +9,7 @@ const cache = new Map()
 export function metricsToPlotCategories (metrics) {
   const requestedData = {
     lines: [],
+    filledLines: [],
     daybars: [],
     bars: [],
     joinedCategories: [],

--- a/src/ducks/Chart/index.js
+++ b/src/ducks/Chart/index.js
@@ -4,7 +4,7 @@ import cx from 'classnames'
 import COLOR from '@santiment-network/ui/variables.scss'
 import { initChart, updateChartState } from '@santiment-network/chart'
 import { initTooltip } from '@santiment-network/chart/tooltip'
-import { plotLines } from '@santiment-network/chart/lines'
+import { plotLines, plotFilledLines } from '@santiment-network/chart/lines'
 import { plotDayBars, plotBars } from '@santiment-network/chart/bars'
 import { linearScale } from '@santiment-network/chart/scales'
 import { drawReferenceDot } from '@santiment-network/chart/references'
@@ -38,6 +38,7 @@ const Chart = ({
   data,
   brushData = data,
   lines,
+  filledLines,
   bars,
   daybars,
   chartHeight = CHART_HEIGHT,
@@ -298,9 +299,10 @@ const Chart = ({
   }
 
   function plotBrushData () {
-    plotDayBars(brush, brushData, daybars, MetricColor, scale)
-    plotBars(brush, brushData, bars, MetricColor, scale)
-    plotLines(brush, brushData, lines, MetricColor, scale)
+    plotDayBars(brush, brushData, daybars, scale, MetricColor)
+    plotBars(brush, brushData, bars, scale, MetricColor)
+    plotLines(brush, brushData, lines, scale, MetricColor)
+    plotFilledLines(brush, brushData, filledLines, scale, MetricColor)
   }
 
   function plotChart (data) {
@@ -308,11 +310,12 @@ const Chart = ({
       drawWatermark(chart, isNightModeEnabled)
     }
 
-    plotDayBars(chart, data, daybars, MetricColor, scale)
-    plotBars(chart, data, bars, MetricColor, scale)
+    plotDayBars(chart, data, daybars, scale, MetricColor)
+    plotBars(chart, data, bars, scale, MetricColor)
 
     chart.ctx.lineWidth = 1.5
-    plotLines(chart, data, lines, MetricColor, scale)
+    plotLines(chart, data, lines, scale, MetricColor)
+    plotFilledLines(chart, data, filledLines, scale, MetricColor)
 
     if (isCartesianGridActive) {
       drawCartesianGrid(chart, chart.axesColor)

--- a/src/ducks/Studio/Chart/index.js
+++ b/src/ducks/Studio/Chart/index.js
@@ -83,10 +83,11 @@ const Canvas = ({
   }
 
   function onBrushChangeEnd (startIndex, endIndex) {
-    changeTimePeriod(
-      new Date(allTimeData[startIndex].datetime),
-      new Date(allTimeData[endIndex].datetime)
-    )
+    const start = allTimeData[startIndex]
+    const end = allTimeData[endIndex]
+    if (start && end) {
+      changeTimePeriod(new Date(start.datetime), new Date(end.datetime))
+    }
   }
 
   return (

--- a/src/ducks/Studio/index.js
+++ b/src/ducks/Studio/index.js
@@ -102,7 +102,9 @@ const Studio = ({
 
   useEffect(
     () => {
-      setMetrics(metrics.filter(({ key }) => !ErrorMsg[key]))
+      if (Object.keys(ErrorMsg).length > 0) {
+        setMetrics(metrics.filter(({ key }) => !ErrorMsg[key]))
+      }
     },
     [ErrorMsg]
   )

--- a/src/ducks/Studio/timeseries/metrics.js
+++ b/src/ducks/Studio/timeseries/metrics.js
@@ -177,5 +177,21 @@ export const METRICS = [
   'dev_activity',
   'dev_activity_contributors_count',
   'github_activity',
-  'github_activity_contributors_count'
+  'github_activity_contributors_count',
+  'sentiment_positive_total',
+  'sentiment_positive_telegram',
+  'sentiment_positive_reddit',
+  'sentiment_positive_twitter',
+  'sentiment_negative_total',
+  'sentiment_negative_telegram',
+  'sentiment_negative_reddit',
+  'sentiment_negative_twitter',
+  'sentiment_balance_total',
+  'sentiment_balance_telegram',
+  'sentiment_balance_reddit',
+  'sentiment_balance_twitter',
+  'sentiment_volume_consumed_total',
+  'sentiment_volume_consumed_telegram',
+  'sentiment_volume_consumed_reddit',
+  'sentiment_volume_consumed_twitter'
 ]

--- a/src/ducks/dataHub/metrics/index.js
+++ b/src/ducks/dataHub/metrics/index.js
@@ -386,25 +386,25 @@ export const Metric = {
   },
   sentiment_volume_consumed_total: {
     node: 'filledLine',
-    label: 'Sentiment Volume Consumed Total',
+    label: 'Weighted Social Sentiment Total',
     category: 'Social',
     group: 'Sentiment'
   },
   sentiment_volume_consumed_telegram: {
     node: 'filledLine',
-    label: 'Sentiment Volume Consumed Telegram',
+    label: 'Weighted Social Sentiment Telegram',
     category: 'Social',
     group: 'Sentiment'
   },
   sentiment_volume_consumed_reddit: {
     node: 'filledLine',
-    label: 'Sentiment Volume Consumed Reddit',
+    label: 'Weighted Social Sentiment Reddit',
     category: 'Social',
     group: 'Sentiment'
   },
   sentiment_volume_consumed_twitter: {
     node: 'filledLine',
-    label: 'Sentiment Volume Consumed Twitter',
+    label: 'Weighted Social Sentiment Twitter',
     category: 'Social',
     group: 'Sentiment'
   }

--- a/src/ducks/dataHub/metrics/index.js
+++ b/src/ducks/dataHub/metrics/index.js
@@ -311,6 +311,102 @@ export const Metric = {
     label: 'Amount held by top non-exchange addresses',
     category: 'On-chain',
     group: 'Top Holders'
+  },
+  sentiment_positive_total: {
+    node: 'line',
+    label: 'Sentiment Positive Total',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_positive_telegram: {
+    node: 'line',
+    label: 'Sentiment Positive Telegram',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_positive_reddit: {
+    node: 'line',
+    label: 'Sentiment Positive Reddit',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_positive_twitter: {
+    node: 'line',
+    label: 'Sentiment Positive Twitter',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_negative_total: {
+    node: 'line',
+    label: 'Sentiment Negative Total',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_negative_telegram: {
+    node: 'line',
+    label: 'Sentiment Negative Telegram',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_negative_reddit: {
+    node: 'line',
+    label: 'Sentiment Negative Reddit',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_negative_twitter: {
+    node: 'line',
+    label: 'Sentiment Negative Twitter',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_balance_total: {
+    node: 'filledLine',
+    label: 'Sentiment Balance Total',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_balance_reddit: {
+    node: 'filledLine',
+    label: 'Sentiment Balance Reddit',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_balance_telegram: {
+    node: 'filledLine',
+    label: 'Sentiment Balance Telegram',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_balance_twitter: {
+    node: 'filledLine',
+    label: 'Sentiment Balance Twitter',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_volume_consumed_total: {
+    node: 'filledLine',
+    label: 'Sentiment Volume Consumed Total',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_volume_consumed_telegram: {
+    node: 'filledLine',
+    label: 'Sentiment Volume Consumed Telegram',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_volume_consumed_reddit: {
+    node: 'filledLine',
+    label: 'Sentiment Volume Consumed Reddit',
+    category: 'Social',
+    group: 'Sentiment'
+  },
+  sentiment_volume_consumed_twitter: {
+    node: 'filledLine',
+    label: 'Sentiment Volume Consumed Twitter',
+    category: 'Social',
+    group: 'Sentiment'
   }
 }
 

--- a/src/ducks/dataHub/metrics/index.js
+++ b/src/ducks/dataHub/metrics/index.js
@@ -316,97 +316,97 @@ export const Metric = {
     node: 'line',
     label: 'Sentiment Positive Total',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Total'
   },
   sentiment_positive_telegram: {
     node: 'line',
     label: 'Sentiment Positive Telegram',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Telegram'
   },
   sentiment_positive_reddit: {
     node: 'line',
     label: 'Sentiment Positive Reddit',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Reddit'
   },
   sentiment_positive_twitter: {
     node: 'line',
     label: 'Sentiment Positive Twitter',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Twitter'
   },
   sentiment_negative_total: {
     node: 'line',
     label: 'Sentiment Negative Total',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Total'
   },
   sentiment_negative_telegram: {
     node: 'line',
     label: 'Sentiment Negative Telegram',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Telegram'
   },
   sentiment_negative_reddit: {
     node: 'line',
     label: 'Sentiment Negative Reddit',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Reddit'
   },
   sentiment_negative_twitter: {
     node: 'line',
     label: 'Sentiment Negative Twitter',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Twitter'
   },
   sentiment_balance_total: {
     node: 'filledLine',
     label: 'Sentiment Balance Total',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Total'
   },
   sentiment_balance_reddit: {
     node: 'filledLine',
     label: 'Sentiment Balance Reddit',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Reddit'
   },
   sentiment_balance_telegram: {
     node: 'filledLine',
     label: 'Sentiment Balance Telegram',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Telegram'
   },
   sentiment_balance_twitter: {
     node: 'filledLine',
     label: 'Sentiment Balance Twitter',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Twitter'
   },
   sentiment_volume_consumed_total: {
     node: 'filledLine',
     label: 'Weighted Social Sentiment Total',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Total'
   },
   sentiment_volume_consumed_telegram: {
     node: 'filledLine',
     label: 'Weighted Social Sentiment Telegram',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Telegram'
   },
   sentiment_volume_consumed_reddit: {
     node: 'filledLine',
     label: 'Weighted Social Sentiment Reddit',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Reddit'
   },
   sentiment_volume_consumed_twitter: {
     node: 'filledLine',
     label: 'Weighted Social Sentiment Twitter',
     category: 'Social',
-    group: 'Sentiment'
+    group: 'Sentiment Twitter'
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1567,10 +1567,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@santiment-network/chart@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@santiment-network/chart/-/chart-0.4.0.tgz#c524cc8e38c9bcf43242bee738983c0f88f654ea"
-  integrity sha512-6d1Vdr9AyYLLMAah4IARnF5Oh0bfojXCY9seh6rbTpQ8f0UCdKWcz3qfNR/FMOOBUO5kyTZpjfn9HuUeHdFXfw==
+"@santiment-network/chart@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@santiment-network/chart/-/chart-0.5.0.tgz#c10ea35d2e5711c6e41ac43d8980df7c924bb3d6"
+  integrity sha512-V8CzByvpKiv+qD071MtHEGyv7o9QVF42WOFFs85yAVLttcCtyka/V0tl4bOmU/14ROgB6P6JPsE9/tr1sRritA==
 
 "@santiment-network/ui@^0.5.150":
   version "0.5.158"


### PR DESCRIPTION
## Summary
Following metrics were added to the studio's `Social` category in the `Sentiment` group:
- Sentiment Positive (total, telegram, reddit, twitter);
- Sentiment Negative (total, telegram, reddit, twitter);
- Sentiment Balance (total, telegram, reddit, twitter);
  - Visualized as filled line.
- Weighted Social Sentiment (total, telegram, reddit, twitter);
  - Visualized as filled line.

## Screenshots
<img width="1505" alt="image" src="https://user-images.githubusercontent.com/25135650/84135758-06b8c000-aa53-11ea-9c76-2a42449c527d.png">
<img width="248" alt="image" src="https://user-images.githubusercontent.com/25135650/84192379-9043ae80-aaa2-11ea-9f8d-271f2030be46.png">


