### PR TITLE
enhance/studio-chart

### DIFF
--- a/src/ducks/Chart/axes.js
+++ b/src/ducks/Chart/axes.js
@@ -47,9 +47,7 @@ function yFormatter (value) {
 const selectYFormatter = metricKey =>
   mirroredMetrics.includes(metricKey)
     ? value => yFormatter(Math.abs(value))
-    : metricKey === Metric.mvrv_long_short_diff_usd.key
-      ? v => `${Math.trunc(v * 100)}%`
-      : yFormatter
+    : (Metric[metricKey] && Metric[metricKey].axisFormatter) || yFormatter
 
 export function plotAxes (chart, scale) {
   const {

--- a/src/ducks/Chart/index.js
+++ b/src/ducks/Chart/index.js
@@ -185,11 +185,17 @@ const Chart = ({
 
         const scale = length / (endTimestamp - startTimestamp)
 
-        if (fromTimestamp !== brushData[startIndex].datetime) {
+        if (
+          !brushData[startIndex] ||
+          fromTimestamp !== brushData[startIndex].datetime
+        ) {
           startIndex = Math.trunc(scale * (fromTimestamp - startTimestamp))
         }
 
-        if (toTimestamp !== brushData[endIndex].datetime) {
+        if (
+          !brushData[endIndex] ||
+          toTimestamp !== brushData[endIndex].datetime
+        ) {
           endIndex = Math.trunc(scale * (toTimestamp - startTimestamp))
         }
 

--- a/src/ducks/Chart/index.js
+++ b/src/ducks/Chart/index.js
@@ -177,6 +177,7 @@ const Chart = ({
     () => {
       const { length } = brushData
       if (brush && length) {
+        let { startIndex = 0, endIndex = length - 1 } = brush
         const [{ datetime: startTimestamp }] = brushData
         const { datetime: endTimestamp } = brushData[length - 1]
         const fromTimestamp = +new Date(from)
@@ -184,8 +185,14 @@ const Chart = ({
 
         const scale = length / (endTimestamp - startTimestamp)
 
-        let startIndex = Math.trunc(scale * (fromTimestamp - startTimestamp))
-        let endIndex = Math.trunc(scale * (toTimestamp - startTimestamp))
+        if (fromTimestamp !== brushData[startIndex].datetime) {
+          startIndex = Math.trunc(scale * (fromTimestamp - startTimestamp))
+        }
+
+        if (toTimestamp !== brushData[endIndex].datetime) {
+          endIndex = Math.trunc(scale * (toTimestamp - startTimestamp))
+        }
+
         startIndex = startIndex > 0 ? startIndex : 0
         endIndex = endIndex < length ? endIndex : length - 1
 

--- a/src/ducks/Chart/utils.js
+++ b/src/ducks/Chart/utils.js
@@ -39,8 +39,8 @@ export function getDateHoursMinutes (date) {
 }
 
 export function yBubbleFormatter (value, metricKey) {
-  if (metricKey === 'mvrv_long_short_diff_usd') {
-    return `${Math.trunc(value * 100)}%`
+  if (Metric[metricKey].axisFormatter) {
+    return Metric[metricKey].axisFormatter(value)
   }
 
   if (!value) {

--- a/src/ducks/Studio/Chart/ActiveMetrics.js
+++ b/src/ducks/Studio/Chart/ActiveMetrics.js
@@ -86,7 +86,7 @@ export default ({
           isLoading={loadings.includes(metric)}
           isRemovable={isMoreThanOneMetric && toggleMetric}
           toggleMetric={toggleMetric}
-          onMouseEnter={onMetricHover && (() => onMetricHover(metric))}
+          onMouseEnter={onMetricHover && (e => onMetricHover(metric, e))}
           onMouseLeave={onMetricHoverEnd && (() => onMetricHoverEnd(metric))}
         />
       ))}

--- a/src/ducks/Studio/Chart/ChartFullscreenBtn.js
+++ b/src/ducks/Studio/Chart/ChartFullscreenBtn.js
@@ -6,7 +6,11 @@ import { extractMirrorMetricsDomainGroups } from '../utils'
 import Chart from '../../Chart'
 import Settings from '../Header/Settings'
 import { MirroredMetric } from '../../dataHub/metrics/mirrored'
-import { useDomainGroups, useAxesMetricsKey } from '../../Chart/hooks'
+import {
+  useClosestValueData,
+  useDomainGroups,
+  useAxesMetricsKey
+} from '../../Chart/hooks'
 import {
   getNewInterval,
   INTERVAL_ALIAS
@@ -31,8 +35,18 @@ const FullscreenChart = ({
   const [shareLink, setShareLink] = useState()
   const [chartHeight, setChartHeight] = useState()
   const [MetricTransformer, setMetricTransformer] = useState({})
-  const [data] = useTimeseries(metrics, settings, undefined, MetricTransformer)
+  const [rawData] = useTimeseries(
+    metrics,
+    settings,
+    undefined,
+    MetricTransformer
+  )
   const [events] = useTimeseries(activeEvents, settings)
+  const data = useClosestValueData(
+    rawData,
+    metrics,
+    options.isClosestDataActive
+  )
   const domainGroups = useDomainGroups(metrics)
   const axesMetricKeys = useAxesMetricsKey(metrics)
   const chartRef = useRef(null)

--- a/src/ducks/Studio/Chart/index.js
+++ b/src/ducks/Studio/Chart/index.js
@@ -89,8 +89,8 @@ const Canvas = ({
 
   function onMetricHover (metric, { currentTarget }) {
     const { parentNode } = currentTarget
-    // HACK: For some reason, fast pointer movement can trigger 'mouseenter' but not 'mouseleavel'
-    // It will leave the button in the stucked highlighted state [@vanguard | Jun 14, 2020]
+    // HACK: For some reason, fast pointer movement can trigger 'mouseenter' but not 'mouseleave'
+    // Hence, a metric might be stucked in the highlighted state [@vanguard | Jun 14, 2020]
     setTimeout(() => {
       if (parentNode.querySelector(':hover')) {
         setFocusedMetric(metric)

--- a/src/ducks/Studio/Chart/index.js
+++ b/src/ducks/Studio/Chart/index.js
@@ -54,6 +54,7 @@ const Canvas = ({
   const [isDomainGroupingActive, setIsDomainGroupingActive] = useState()
   const [FocusedMetric, setFocusedMetric] = useState()
   const [chartHeight, setChartHeight] = useState()
+  const [focusTimer, setFocusTimer] = useState()
   const MetricColor = useChartColors(metrics, FocusedMetric)
   const domainGroups = useDomainGroups(metrics)
   const axesMetricKeys = useAxesMetricsKey(metrics, isDomainGroupingActive)
@@ -91,14 +92,17 @@ const Canvas = ({
     const { parentNode } = currentTarget
     // HACK: For some reason, fast pointer movement can trigger 'mouseenter' but not 'mouseleave'
     // Hence, a metric might be stucked in the highlighted state [@vanguard | Jun 14, 2020]
-    setTimeout(() => {
-      if (parentNode.querySelector(':hover')) {
-        setFocusedMetric(metric)
-      }
-    }, 50)
+    setFocusTimer(
+      setTimeout(() => {
+        if (parentNode.querySelector(':hover')) {
+          setFocusedMetric(metric)
+        }
+      }, 60)
+    )
   }
 
   function onMetricHoverEnd () {
+    clearTimeout(focusTimer)
     setFocusedMetric()
   }
 

--- a/src/ducks/Studio/Chart/index.js
+++ b/src/ducks/Studio/Chart/index.js
@@ -53,6 +53,7 @@ const Canvas = ({
 }) => {
   const [isDomainGroupingActive, setIsDomainGroupingActive] = useState()
   const [FocusedMetric, setFocusedMetric] = useState()
+  const [chartHeight, setChartHeight] = useState()
   const MetricColor = useChartColors(metrics, FocusedMetric)
   const domainGroups = useDomainGroups(metrics)
   const axesMetricKeys = useAxesMetricsKey(metrics, isDomainGroupingActive)
@@ -66,6 +67,17 @@ const Canvas = ({
 
   useEffect(
     () => {
+      setChartHeight(
+        options.isMultiChartsActive
+          ? undefined
+          : chartRef.current.canvas.parentNode.clientHeight
+      )
+    },
+    [chartRef, options.isMultiChartsActive]
+  )
+
+  useEffect(
+    () => {
       if (chartSidepane === METRICS_EXPLANATION_PANE && !hasExplanaibles) {
         toggleChartSidepane()
       }
@@ -75,8 +87,15 @@ const Canvas = ({
 
   useEffect(onMetricHoverEnd, [metrics])
 
-  function onMetricHover (metric) {
-    setFocusedMetric(metric)
+  function onMetricHover (metric, { currentTarget }) {
+    const { parentNode } = currentTarget
+    // HACK: For some reason, fast pointer movement can trigger 'mouseenter' but not 'mouseleavel'
+    // It will leave the button in the stucked highlighted state [@vanguard | Jun 14, 2020]
+    setTimeout(() => {
+      if (parentNode.querySelector(':hover')) {
+        setFocusedMetric(metric)
+      }
+    }, 50)
   }
 
   function onMetricHoverEnd () {
@@ -149,6 +168,7 @@ const Canvas = ({
         {...props}
         brushData={allTimeData}
         chartRef={chartRef}
+        chartHeight={chartHeight}
         className={cx(styles.chart, isBlurred && styles.blur)}
         MetricColor={MetricColor}
         metrics={metrics}

--- a/src/ducks/Studio/Chart/index.module.scss
+++ b/src/ducks/Studio/Chart/index.module.scss
@@ -1,6 +1,9 @@
 .wrapper {
   position: relative;
   margin-top: 13px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 
   &_explained {
     padding-right: 340px !important;
@@ -71,6 +74,10 @@
 .explain {
   margin-left: 12px;
   white-space: nowrap;
+}
+
+.chart {
+  flex: 1;
 }
 
 .chart:hover .ico {

--- a/src/ducks/Studio/Main.js
+++ b/src/ducks/Studio/Main.js
@@ -7,6 +7,8 @@ import StudioTabsKeyStats from './Tabs/KeyStats'
 import StudioInfo from '../SANCharts/Header'
 import styles from './index.module.scss'
 
+const isChartPath = () => window.location.pathname === '/studio'
+
 const Main = ({
   topSlot,
   bottomSlot,
@@ -14,7 +16,13 @@ const Main = ({
   onProjectChange,
   ...props
 }) => {
-  const { settings, setSettings, setIsICOPriceDisabled, project } = props
+  const {
+    settings,
+    options,
+    project,
+    setSettings,
+    setIsICOPriceDisabled
+  } = props
 
   function onProjectSelect (project) {
     if (!project) return
@@ -39,7 +47,15 @@ const Main = ({
         />
       </div>
       <StudioTabs />
-      <div className={cx(styles.container, styles.content)}>
+      <div
+        className={cx(
+          styles.container,
+          styles.content,
+          !options.isMultiChartsActive &&
+            isChartPath() &&
+            styles.container_chart
+        )}
+      >
         <Switch>
           <Route path='/studio/stats'>
             <StudioTabsKeyStats {...props} {...settings} />

--- a/src/ducks/Studio/index.module.scss
+++ b/src/ducks/Studio/index.module.scss
@@ -13,6 +13,12 @@
 
 .container {
   padding: 44px 25px;
+
+  &_chart {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
 }
 
 .header {
@@ -35,6 +41,7 @@
 
 .data {
   display: flex;
+  flex: 1;
 }
 
 .advanced {

--- a/src/ducks/dataHub/metrics/index.js
+++ b/src/ducks/dataHub/metrics/index.js
@@ -8,6 +8,23 @@ import {
 } from '../../SANCharts/utils'
 import { millify } from '../../../utils/formatting'
 
+function normalizeAxisPercent (value) {
+  const percent = value * 100
+  const absPercent = Math.abs(percent)
+
+  if (absPercent >= 100) {
+    return Math.trunc(percent)
+  }
+
+  if (absPercent >= 10) {
+    return percent.toFixed(2)
+  }
+
+  return percent.toFixed(3)
+}
+
+const axisPercentFormatter = value => `${normalizeAxisPercent(value)}%`
+
 export const Metric = {
   price_usd: {
     node: 'line',
@@ -153,6 +170,7 @@ export const Metric = {
     fullTitle: 'Market Value To Realized Value Long-Short Difference',
     shortLabel: 'MVRV L/S Diff',
     formatter: v => (v ? `${(v * 100).toFixed(2)}%` : 'No data'),
+    axisFormatter: axisPercentFormatter,
     isBeta: true
   },
   transaction_volume: {
@@ -442,9 +460,11 @@ export const Metric = {
     category: 'Derivatives'
   },
   bitmex_perpetual_funding_rate: {
-    node: 'line',
+    node: 'filledLine',
     label: 'BitMEX Perpetual Contract Funding Rate',
-    category: 'Derivatives'
+    category: 'Derivatives',
+    formatter: v => (v ? `${(v * 100).toFixed(2)}%` : 'No data'),
+    axisFormatter: axisPercentFormatter
   },
   bitmex_perpetual_open_value: {
     node: 'line',


### PR DESCRIPTION
## Summary
- Generic axis formatters interface;
- `BitMEX Perpetual Contract Funding Rate` metric is now displayed as a filled line and a percentage formatter is applied.
- Fixing the stucked metric highlight issue;
- Single chart is now takes all the height.

## Screenshots
- Pic. 1
<img width="1500" alt="image" src="https://user-images.githubusercontent.com/25135650/84596032-f09c6c80-ae63-11ea-98fb-9a52e597f240.png">

- Pic. 2
![image](https://user-images.githubusercontent.com/25135650/84596003-cb0f6300-ae63-11ea-8b96-9db4738fa76b.png)
