### PR TITLE
Feature/handle private layouts

### DIFF
--- a/src/ducks/Studio/Template/Button.js
+++ b/src/ducks/Studio/Template/Button.js
@@ -28,6 +28,7 @@ const Trigger = ({ hasTemplates, selectedTemplate, openDialog, loading }) => {
           on='click'
           offsetY={13}
           closeTimeout={500}
+          className={styles.tooltip}
           trigger={
             <div className={styles.tooltipTrigger}>
               <div className={styles.detailsIcon}>

--- a/src/ducks/Studio/Template/TemplateDetailsDialog/TemplateDetailsDialog.js
+++ b/src/ducks/Studio/Template/TemplateDetailsDialog/TemplateDetailsDialog.js
@@ -56,7 +56,7 @@ const TemplateDetailsDialog = ({
       title={isDialog && template.title}
       classes={styles}
       trigger={<TemplateInfoTrigger />}
-      className={cx(styles.template)}
+      className={styles.template}
     >
       <div className={styles.container}>
         <div className={styles.actions}>

--- a/src/ducks/Studio/Template/gql/hooks.js
+++ b/src/ducks/Studio/Template/gql/hooks.js
@@ -18,6 +18,7 @@ import {
 } from '../utils'
 import { store, client } from '../../../../index'
 import { getSavedMulticharts } from '../../../../utils/localStorage'
+import { showNotification } from '../../../../actions/rootActions'
 
 const DEFAULT_TEMPLATES = []
 
@@ -83,6 +84,10 @@ export function useSelectedTemplate (templates, selectTemplate) {
   const [loading, setLoading] = useState()
 
   const loadTemplate = () => {
+    if (loading) {
+      return
+    }
+
     const targetTemplate = urlId ? { id: urlId } : getLastTemplate()
     if (!targetTemplate) return
 
@@ -105,13 +110,22 @@ export function useSelectedTemplate (templates, selectTemplate) {
           selectTemplate(template)
         }
       })
-      .catch(console.warn)
-      .finally(() => {
+      .catch(() => {
+        store.dispatch(
+          showNotification({
+            variant: 'error',
+            title:
+              'Chart Layout with id ' +
+              targetTemplate.id +
+              " is private or does't exist"
+          })
+        )
+      })
+      .finally(data => {
         setLoading(false)
       })
   }
 
-  useEffect(loadTemplate, [])
   useEffect(loadTemplate, [urlId])
   useEffect(
     () => {

--- a/src/ducks/Studio/Template/index.module.scss
+++ b/src/ducks/Studio/Template/index.module.scss
@@ -109,6 +109,10 @@
   padding: 2px 24px 24px 24px;
 }
 
+.tooltip {
+  z-index: 10;
+}
+
 .delete {
   padding: 6px 12px !important;
 }


### PR DESCRIPTION
**Summary**

Add notification for private or not existing chart layouts.
We can't show 404 error page, because it is async loading for Studio on bg. User views default chart and then an info about layout.

**Screenshots**

![image](https://user-images.githubusercontent.com/14061779/85115659-b4328d00-b224-11ea-994b-e9b32ccf97a8.png)
