### PR TITLE
enhance/collapsed-metric-categories

### DIFF
--- a/src/ducks/Studio/Chart/PaywallInfo.js
+++ b/src/ducks/Studio/Chart/PaywallInfo.js
@@ -86,7 +86,7 @@ const PaywallInfo = ({ subscription, metrics, isPro }) => {
     return <UpgradeBtn variant='fill' fluid className={styles.upgrade_trial} />
   }
 
-  if (isPro) return
+  if (isPro) return null
 
   return infos.length > 0 ? (
     <Tooltip

--- a/src/ducks/Studio/Sidebar/MetricSelector/Category.js
+++ b/src/ducks/Studio/Sidebar/MetricSelector/Category.js
@@ -7,6 +7,10 @@ import Group from './Group'
 import MetricButton from './MetricButton'
 import styles from './index.module.scss'
 
+const DEFAULT_OPENED_CATEGORY = {
+  Financial: true
+}
+
 const HOLDER_DISTRIBUTION_NODE = {
   key: 'holder_distribution',
   type: WIDGET,
@@ -14,7 +18,7 @@ const HOLDER_DISTRIBUTION_NODE = {
 }
 
 const Category = ({ title, groups, hasTopHolders, project, ...rest }) => {
-  const [hidden, setHidden] = useState(false)
+  const [hidden, setHidden] = useState(!DEFAULT_OPENED_CATEGORY[title])
 
   function onToggleClick () {
     setHidden(!hidden)

--- a/src/ducks/Studio/Widget/TopTransactionsTable.js
+++ b/src/ducks/Studio/Widget/TopTransactionsTable.js
@@ -20,7 +20,7 @@ export const TRANSACTIONS_QUERY = gql`
   query projectBySlug($slug: String!, $from: DateTime!, $to: DateTime!) {
     projectBySlug(slug: $slug) {
       id
-      tokenTopTransactions(from: $from, to: $to) {
+      tokenTopTransactions(from: $from, to: $to, limit: 50) {
         datetime
         trxValue
         trxHash
@@ -106,6 +106,7 @@ const TopTransactionsTable = ({
   return (
     <TransactionTable
       className={widgetStyles.widget_secondary}
+      defaultPageSize={50}
       header={
         <Header
           dates={dates}


### PR DESCRIPTION
## Summary
Studio's metric categories are collapsed by default except `Financial` category.
## Screenshots 
![image](https://user-images.githubusercontent.com/25135650/86884600-78d8ff00-c0fc-11ea-821b-53b72b64edc0.png)
