### PR TITLE
enhance/studio

### DIFF
--- a/src/ducks/Studio/Sidebar/MetricSelector/Category.js
+++ b/src/ducks/Studio/Sidebar/MetricSelector/Category.js
@@ -5,7 +5,6 @@ import Icon from '@santiment-network/ui/Icon'
 import { WIDGET } from './types'
 import Group from './Group'
 import MetricButton from './MetricButton'
-import { CategoryWithNews } from '../../../dataHub/metrics/news'
 import styles from './index.module.scss'
 
 const DEFAULT_OPENED_CATEGORY = {
@@ -18,7 +17,14 @@ const HOLDER_DISTRIBUTION_NODE = {
   label: 'Holder Distribution'
 }
 
-const Category = ({ title, groups, hasTopHolders, project, ...rest }) => {
+const Category = ({
+  title,
+  groups,
+  hasTopHolders,
+  project,
+  NewMetricsCategory,
+  ...rest
+}) => {
   const [hidden, setHidden] = useState(!DEFAULT_OPENED_CATEGORY[title])
 
   function onToggleClick () {
@@ -28,7 +34,7 @@ const Category = ({ title, groups, hasTopHolders, project, ...rest }) => {
   return (
     <div className={cx(styles.category, hidden && styles.category_hidden)}>
       <h3
-        className={cx(styles.title, CategoryWithNews[title] && styles.news)}
+        className={cx(styles.title, NewMetricsCategory[title] && styles.news)}
         onClick={onToggleClick}
       >
         <Icon type='arrow-right-big' className={styles.toggle} />

--- a/src/ducks/Studio/Sidebar/MetricSelector/Group.js
+++ b/src/ducks/Studio/Sidebar/MetricSelector/Group.js
@@ -3,17 +3,18 @@ import cx from 'classnames'
 import Icon from '@santiment-network/ui/Icon'
 import MetricButton from './MetricButton'
 import { NO_GROUP } from '../utils'
-import { GroupWithNews } from '../../../dataHub/metrics/news'
 import styles from './index.module.scss'
 
 const Group = ({
   title,
   nodes,
   activeMetrics,
+  project,
+  NewMetric,
+  NewMetricsGroup,
   toggleMetric,
   isBeta,
   setMetricSettingMap,
-  project,
   ...rest
 }) => {
   const hasGroup = title !== NO_GROUP
@@ -27,7 +28,7 @@ const Group = ({
     <>
       {hasGroup && (
         <h4
-          className={cx(styles.group, GroupWithNews[title] && styles.news)}
+          className={cx(styles.group, NewMetricsGroup[title] && styles.news)}
           onClick={onToggleClick}
         >
           <Icon
@@ -72,6 +73,7 @@ const Group = ({
                 project={project}
                 isActive={activeMetrics.includes(item)}
                 isDisabled={!selectable}
+                isNew={NewMetric[item.key]}
               />
               {subitems &&
                 subitems.map(subitem => {
@@ -92,6 +94,7 @@ const Group = ({
                       project={project}
                       showBetaLabel={false}
                       isActive={isActive}
+                      isNew={NewMetric[subitem.key]}
                     />
                   )
                 })}

--- a/src/ducks/Studio/Sidebar/MetricSelector/MetricButton.js
+++ b/src/ducks/Studio/Sidebar/MetricSelector/MetricButton.js
@@ -4,7 +4,6 @@ import Button from '@santiment-network/ui/Button'
 import Icon from '@santiment-network/ui/Icon'
 import Settings from './Settings'
 import { MetricSettings } from '../../../dataHub/metrics/settings'
-import { NewMetric } from '../../../dataHub/metrics/news'
 import MetricExplanation from '../../../SANCharts/MetricExplanation'
 import styles from './MetricButton.module.scss'
 import settingsStyles from './Settings.module.scss'
@@ -13,9 +12,11 @@ const MetricButton = ({
   className,
   metric,
   label,
+  NewMetric,
   isActive,
   isError,
   isDisabled,
+  isNew,
   onClick,
   setMetricSettingMap,
   project,
@@ -46,9 +47,7 @@ const MetricButton = ({
         )}
         {label}
 
-        {metric && NewMetric[metric.key] && (
-          <div className={styles.new}>NEW</div>
-        )}
+        {metric && isNew && <div className={styles.new}>NEW</div>}
 
         {metric && metric.isBeta && showBetaLabel && (
           <div className={styles.beta}>BETA</div>

--- a/src/ducks/Studio/Sidebar/MetricSelector/MetricButton.js
+++ b/src/ducks/Studio/Sidebar/MetricSelector/MetricButton.js
@@ -12,7 +12,6 @@ const MetricButton = ({
   className,
   metric,
   label,
-  NewMetric,
   isActive,
   isError,
   isDisabled,

--- a/src/ducks/Studio/Tabs/Widgets.js
+++ b/src/ducks/Studio/Tabs/Widgets.js
@@ -60,7 +60,7 @@ const Chart = ({
     const from = new Date(dates[0])
     const to = new Date(dates[1])
 
-    if (PressedModifier.shiftKey) {
+    if (PressedModifier.cmdKey) {
       return changeDatesRange(from, to)
     }
 

--- a/src/ducks/Studio/Widget/TopTransactionsTable.js
+++ b/src/ducks/Studio/Widget/TopTransactionsTable.js
@@ -15,6 +15,12 @@ import widgetStyles from './Widget.module.scss'
 
 const { from, to } = getTimeIntervalFromToday(-30, DAY)
 const DEFAULT_DATES = [from, to]
+const DEFAULT_SORTED = [
+  {
+    id: 'value',
+    desc: true
+  }
+]
 
 export const TRANSACTIONS_QUERY = gql`
   query projectBySlug($slug: String!, $from: DateTime!, $to: DateTime!) {
@@ -107,6 +113,7 @@ const TopTransactionsTable = ({
     <TransactionTable
       className={widgetStyles.widget_secondary}
       defaultPageSize={50}
+      defaultSorted={DEFAULT_SORTED}
       header={
         <Header
           dates={dates}

--- a/src/ducks/Studio/hooks.js
+++ b/src/ducks/Studio/hooks.js
@@ -4,7 +4,9 @@ const DEFAULT_PRESSED_MOFIER = {
   altKey: false,
   shiftKey: false,
   metaKey: false,
-  ctrlKey: false
+  ctrlKey: false,
+  // NOTE: cmdKey is the "command" on macOS and the "ctrl" on Windows  [@vanguard | Jul  9, 2020]
+  cmdKey: false
 }
 
 export function useKeyDown (clb, key) {
@@ -25,6 +27,7 @@ export function useKeyboardShortcut (key, clb, target = window) {
   useEffect(
     () => {
       function onKeyDown (e) {
+        e.preventDefault()
         const { ctrlKey, metaKey } = e
 
         if ((metaKey || ctrlKey) && key === e.key) {
@@ -55,7 +58,8 @@ export function usePressedModifier () {
             altKey,
             shiftKey,
             metaKey,
-            ctrlKey
+            ctrlKey,
+            cmdKey: metaKey || ctrlKey
           }
       )
     }

--- a/src/ducks/Studio/index.js
+++ b/src/ducks/Studio/index.js
@@ -13,7 +13,7 @@ import HolderDistributionWidget from './Widget/HolderDistributionWidget'
 import SelectionOverview from './Overview/SelectionOverview'
 import * as Type from './Sidebar/MetricSelector/types'
 import { getNewInterval, INTERVAL_ALIAS } from '../SANCharts/IntervalSelector'
-import { NewMetric, seeMetric } from '../dataHub/metrics/news'
+import { NEW_METRIC_KEY_SET, seeMetric } from '../dataHub/metrics/news'
 import styles from './index.module.scss'
 
 export const Studio = ({
@@ -149,7 +149,7 @@ export const Studio = ({
     let appliedMetrics
     let appliedWidgets
 
-    if (NewMetric[key]) {
+    if (NEW_METRIC_KEY_SET.has(key)) {
       seeMetric(item)
     }
 
@@ -172,10 +172,7 @@ export const Studio = ({
       appliedMetrics = toggleSelectionMetric(item)
     }
 
-    if (
-      currentPhase === Phase.IDLE &&
-      (PressedModifier.metaKey || PressedModifier.ctrlKey)
-    ) {
+    if (currentPhase === Phase.IDLE && PressedModifier.cmdKey) {
       onWidgetClick(widgets[0], appliedMetrics, appliedWidgets)
     }
   }

--- a/src/ducks/Studio/withMetrics.js
+++ b/src/ducks/Studio/withMetrics.js
@@ -2,8 +2,8 @@ import gql from 'graphql-tag'
 import { graphql } from 'react-apollo'
 import { getCategoryGraph } from './Sidebar/utils'
 import { useMergedTimeboundSubmetrics } from '../dataHub/timebounds'
-import { getMarketSegment } from './timeseries/marketSegments'
 import { getAssetNewMetrics } from '../dataHub/metrics/news'
+import { getMarketSegment } from './timeseries/marketSegments'
 
 const PROJECT_METRICS_QUERIES_SEGMENTS_BY_SLUG_QUERY = gql`
   query projectBySlug($slug: String!) {

--- a/src/ducks/Studio/withMetrics.js
+++ b/src/ducks/Studio/withMetrics.js
@@ -3,6 +3,7 @@ import { graphql } from 'react-apollo'
 import { getCategoryGraph } from './Sidebar/utils'
 import { useMergedTimeboundSubmetrics } from '../dataHub/timebounds'
 import { getMarketSegment } from './timeseries/marketSegments'
+import { getAssetNewMetrics } from '../dataHub/metrics/news'
 
 const PROJECT_METRICS_QUERIES_SEGMENTS_BY_SLUG_QUERY = gql`
   query projectBySlug($slug: String!) {
@@ -60,7 +61,7 @@ export default graphql(PROJECT_METRICS_QUERIES_SEGMENTS_BY_SLUG_QUERY, {
         marketSegments = []
       } = {}
     },
-    ownProps: { noMarketSegments, hiddenMetrics = [] }
+    ownProps: { noMarketSegments, hiddenMetrics = [], slug }
   }) => {
     const Submetrics = useMergedTimeboundSubmetrics(availableMetrics)
 
@@ -75,7 +76,8 @@ export default graphql(PROJECT_METRICS_QUERIES_SEGMENTS_BY_SLUG_QUERY, {
     return {
       categories,
       Submetrics,
-      availableMetrics
+      availableMetrics,
+      ...getAssetNewMetrics(availableMetrics, { slug })
     }
   },
   skip: ({ slug }) => !slug,

--- a/src/ducks/dataHub/metrics/news.js
+++ b/src/ducks/dataHub/metrics/news.js
@@ -7,31 +7,68 @@ const NEW_METRICS = [
   Metric.bitmex_perpetual_basis_ratio,
   TopTransactionsTableMetric
 ]
+export const NEW_METRIC_KEY_SET = new Set(NEW_METRICS.map(({ key }) => key))
 
-const NewMetric = {}
-const CategoryWithNews = {}
-const GroupWithNews = {}
-
-const incrementProperty = (obj, prop) => (obj[prop] = (obj[prop] || 0) + 1)
-
-NEW_METRICS.forEach(({ key, category, group }) => {
-  if (localStorage.getItem(key)) return
-
-  NewMetric[key] = true
-  incrementProperty(CategoryWithNews, category)
-  if (group) {
-    incrementProperty(GroupWithNews, group)
+const NewSubmetricsByMetric = {}
+NEW_METRICS.forEach(metric => {
+  const { parentMetric } = metric
+  if (parentMetric) {
+    const { key, category, group } = parentMetric
+    metric.category = category
+    metric.group = group
+    const submetrics = NewSubmetricsByMetric[key]
+    if (submetrics) {
+      submetrics.push(metric)
+    } else {
+      NewSubmetricsByMetric[key] = [metric]
+    }
   }
 })
 
-export const seeMetric = ({ key, category, group }) => {
-  delete NewMetric[key]
-  CategoryWithNews[category] -= 1
-  if (group) {
-    GroupWithNews[group] -= 1
-  }
+function appendIfVisible (arr, metric, conditionProps) {
+  if (localStorage.getItem(metric.key)) return
 
-  localStorage.setItem(key, '+')
+  const { checkIsVisible } = metric
+  if (checkIsVisible ? checkIsVisible(conditionProps) : true) {
+    arr.push(metric)
+  }
 }
 
-export { NewMetric, CategoryWithNews, GroupWithNews }
+export function getAssetNewMetrics (metricKeys, conditionProps) {
+  const { length } = metricKeys
+  const newMetrics = []
+
+  for (let i = 0; i < length; i++) {
+    const key = metricKeys[i]
+    if (NEW_METRIC_KEY_SET.has(key)) {
+      const metric = Metric[key]
+      appendIfVisible(newMetrics, metric, conditionProps)
+    } else {
+      const submetrics = NewSubmetricsByMetric[key]
+      if (submetrics) {
+        submetrics.forEach(submetric =>
+          appendIfVisible(newMetrics, submetric, conditionProps)
+        )
+      }
+    }
+  }
+
+  const NewMetric = {}
+  const NewMetricsCategory = {}
+  const NewMetricsGroup = {}
+  newMetrics.forEach(({ key, category, group }) => {
+    NewMetric[key] = true
+    NewMetricsCategory[category] = true
+    if (group) {
+      NewMetricsGroup[group] = true
+    }
+  })
+
+  return {
+    NewMetric,
+    NewMetricsCategory,
+    NewMetricsGroup
+  }
+}
+
+export const seeMetric = ({ key }) => localStorage.setItem(key, '+')

--- a/src/ducks/dataHub/submetrics.js
+++ b/src/ducks/dataHub/submetrics.js
@@ -25,8 +25,7 @@ export const TopTransactionsTableMetric = {
   label: 'Top Transactions Table',
   widget: TopTransactionsTable,
   requiredMetric: Metric.transaction_volume,
-  category: Metric.transaction_volume.category,
-  group: Metric.transaction_volume.group
+  parentMetric: Metric.transaction_volume
 }
 
 export const Submetrics = {

--- a/src/pages/Detailed/transactionsInfo/DetailedTransactionsTable.js
+++ b/src/pages/Detailed/transactionsInfo/DetailedTransactionsTable.js
@@ -2,7 +2,6 @@ import React from 'react'
 import cx from 'classnames'
 import ReactTable from 'react-table'
 import PanelWithHeader from '@santiment-network/ui/Panel/PanelWithHeader'
-import { formatNumber } from '../../../utils/formatting'
 import { getDateFormats, getTimeFormats } from '../../../utils/dates'
 import SmoothDropdown from '../../../components/SmoothDropdown/SmoothDropdown'
 import { columns } from './columns'
@@ -25,6 +24,7 @@ export function normalizeTransactionData (
 
   return {
     trxHash,
+    trxValue,
     fromAddress: {
       ...fromAddress,
       assets: [slug, 'ethereum']
@@ -33,7 +33,6 @@ export function normalizeTransactionData (
       ...toAddress,
       assets: [slug, 'ethereum']
     },
-    trxValue: formatNumber(trxValue),
     datetime: `${YYYY}-${MM}-${DD} ${HH}:${mm}:${ss}`
   }
 }
@@ -48,13 +47,13 @@ export const TransactionTable = ({ header, data, className, ...props }) => (
     <SmoothDropdown verticalMotion>
       <ReactTable
         minRows={1}
-        {...props}
-        data={data}
-        columns={columns}
         className={styles.transactionsTable}
         defaultSorted={DEFAULT_SORTED}
         showPagination={false}
         resizable={false}
+        {...props}
+        data={data}
+        columns={columns}
       />
     </SmoothDropdown>
   </PanelWithHeader>

--- a/src/pages/Detailed/transactionsInfo/columns.js
+++ b/src/pages/Detailed/transactionsInfo/columns.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { formatNumber } from '../../../utils/formatting'
 import WalletLink from '../../../components/WalletLink/WalletLink'
 
 const TrxAddressCell = ({ value }) => <WalletLink {...value} />
@@ -17,11 +18,13 @@ export const columns = [
     sortMethod: (a, b) => (new Date(a) > new Date(b) ? 1 : -1)
   },
   {
+    id: 'value',
     Header: 'Value',
     accessor: 'trxValue',
     minWidth: 100,
     maxWidth: 150,
-    sortable: true
+    sortable: true,
+    Cell: ({ value }) => formatNumber(value)
   },
   {
     Header: 'From',


### PR DESCRIPTION
## Summary
- `Top Transaction Table` widget has a `Value` column sorted by the default in descending order;
- `Chart Widget` secondary selection is now done by holding the `cmd/ctrl` key (previously was `shift`);
- New metrics calculation now depends on the asset's available metrics.