### PR TITLE
enhance/screener-metrics

### DIFF
--- a/src/ducks/Watchlists/Widgets/Filter/FilterMetric.js
+++ b/src/ducks/Watchlists/Widgets/Filter/FilterMetric.js
@@ -39,9 +39,33 @@ const FilterMetric = ({
       if (percentTimeRanges.length === 0) {
         const timeRanges = getTimeRangesByMetric(baseMetric, availableMetrics)
         setPercentTimeRanges(timeRanges)
+
+        if (
+          Filter[settings.type].showTimeRange &&
+          !timeRanges.includes(settings.timeRange) &&
+          timeRanges[0]
+        ) {
+          setSettings(state => ({ ...state, timeRange: timeRanges[0].type }))
+        }
       }
     },
     [availableMetrics]
+  )
+
+  useEffect(
+    () => {
+      if (
+        Filter[settings.type].showTimeRange &&
+        !percentTimeRanges.includes(settings.timeRange) &&
+        percentTimeRanges[0]
+      ) {
+        setSettings(state => ({
+          ...state,
+          timeRange: percentTimeRanges[0].type
+        }))
+      }
+    },
+    [settings.type]
   )
 
   useEffect(
@@ -57,7 +81,8 @@ const FilterMetric = ({
         const aggregation =
           Filter[type].aggregation || baseMetric.aggregation || 'last'
         const metric = Filter[type].showTimeRange
-          ? `${baseMetric.key}_change_${timeRange}`
+          ? `${baseMetric.percentMetricKey ||
+              baseMetric.key}_change_${timeRange}`
           : baseMetric.key
         const operator = Filter[type].operator
         const formatter = Filter[type].serverValueFormatter
@@ -73,14 +98,26 @@ const FilterMetric = ({
 
         if (firstThreshold) {
           if (previousIsActive !== isActive) {
-            toggleMetricInFilter(newFilter)
+            toggleMetricInFilter(
+              newFilter,
+              baseMetric.key,
+              baseMetric.percentMetricKey
+            )
           } else {
-            updMetricInFilter(newFilter)
+            updMetricInFilter(
+              newFilter,
+              baseMetric.key,
+              baseMetric.percentMetricKey
+            )
           }
         }
 
         if (!firstThreshold && isActive && defaultSettings.isActive) {
-          toggleMetricInFilter(newFilter)
+          toggleMetricInFilter(
+            newFilter,
+            baseMetric.key,
+            baseMetric.percentMetricKey
+          )
         }
       }
     },

--- a/src/ducks/Watchlists/Widgets/Filter/detector.js
+++ b/src/ducks/Watchlists/Widgets/Filter/detector.js
@@ -2,7 +2,11 @@ import { Operator, Filter } from './types'
 import { DEFAULT_TIMERANGES } from './defaults'
 
 export function extractFilterByMetricType (filters = [], metric) {
-  return filters.filter(item => item.metric.includes(metric.key))
+  return filters.filter(
+    item =>
+      item.metric.includes(metric.key) ||
+      item.metric.includes(metric.percentMetricKey)
+  )
 }
 
 export function getFilterType (filter = []) {
@@ -88,10 +92,13 @@ function extractThreshold (filter = [], filterType) {
 
 export function getTimeRangesByMetric (baseMetric, availableMetrics = []) {
   const metrics = availableMetrics.filter(metric =>
-    metric.includes(`${baseMetric.key}_change_`)
+    metric.includes(`${baseMetric.percentMetricKey || baseMetric.key}_change_`)
   )
   const timeRanges = metrics.map(metric =>
-    metric.replace(`${baseMetric.key}_change_`, '')
+    metric.replace(
+      `${baseMetric.percentMetricKey || baseMetric.key}_change_`,
+      ''
+    )
   )
 
   return DEFAULT_TIMERANGES.filter(({ type }) => timeRanges.includes(type))

--- a/src/ducks/Watchlists/Widgets/Filter/index.js
+++ b/src/ducks/Watchlists/Widgets/Filter/index.js
@@ -72,11 +72,13 @@ const Filter = ({ watchlist = {}, projectsCount, isAuthor }) => {
     updateWatchlist(watchlist, { function: func })
   }
 
-  function updMetricInFilter (metric) {
-    const key = metric.metric.replace(`_change_${metric.dynamicFrom}`, '')
+  function updMetricInFilter (metric, key, alternativeKey = key) {
     const filters = isNoFilters
       ? []
-      : filter.filter(item => !item.metric.includes(key))
+      : filter.filter(
+        item =>
+          !item.metric.includes(key) && !item.metric.includes(alternativeKey)
+      )
     const newFilter = [...filters, metric]
     updateFilter(newFilter)
     updateWatchlist(watchlist, {
@@ -97,12 +99,16 @@ const Filter = ({ watchlist = {}, projectsCount, isAuthor }) => {
     })
   }
 
-  function toggleMetricInFilter (metric) {
-    const key = metric.metric.replace(`_change_${metric.dynamicFrom}`, '')
-    const isMetricInList = filter.some(item => item.metric.includes(key))
+  function toggleMetricInFilter (metric, key, alternativeKey = key) {
+    const isMetricInList = filter.some(
+      item => item.metric.includes(key) || item.metric.includes(alternativeKey)
+    )
     let newFilter = []
     if (isMetricInList) {
-      newFilter = filter.filter(item => !item.metric.includes(key))
+      newFilter = filter.filter(
+        item =>
+          !item.metric.includes(key) && !item.metric.includes(alternativeKey)
+      )
     } else {
       newFilter = [...filter, metric]
     }

--- a/src/ducks/Watchlists/Widgets/Filter/metrics.js
+++ b/src/ducks/Watchlists/Widgets/Filter/metrics.js
@@ -22,6 +22,7 @@ export const Metric = {
     category: 'Development',
     label: 'Development Activity',
     descriptionKey: 'dev_activity',
+    percentMetricKey: 'dev_activity',
     aggregation: 'avg',
     showTimeRange: true
   },
@@ -29,10 +30,15 @@ export const Metric = {
     category: 'On-chain',
     group: 'Network Activity',
     label: 'Daily Active Addresses',
+    percentMetricKey: 'active_addresses_24h',
     aggregation: 'avg',
     showTimeRange: true
   }
 }
+
+Object.keys(Metric).forEach(key => {
+  Metric[key].key = key
+})
 
 export const metrics = [
   Metric.price_usd,
@@ -42,6 +48,7 @@ export const metrics = [
   Metric.daily_active_addresses
 ]
 
-Object.keys(Metric).forEach(key => {
-  Metric[key].key = key
-})
+export const MetricAlias = {
+  active_addresses_24h: Metric.daily_active_addresses,
+  dev_activity: Metric.dev_activity
+}

--- a/src/ducks/Watchlists/Widgets/Filter/utils.js
+++ b/src/ducks/Watchlists/Widgets/Filter/utils.js
@@ -1,4 +1,4 @@
-import { Metric } from './metrics'
+import { Metric, MetricAlias } from './metrics'
 
 export function getActiveBaseMetrics (filter) {
   const activeMetrics = new Set(
@@ -9,7 +9,7 @@ export function getActiveBaseMetrics (filter) {
           ? metric
           : metric.substring(0, transformedMetricIndex)
 
-      return Metric[baseMetricKey]
+      return Metric[baseMetricKey] || MetricAlias[baseMetricKey]
     })
   )
 


### PR DESCRIPTION
**Summary**
Add alias If api have another base metric key for percentage metrics.

Example: 
base metric: `daily_active_addresses`
percentage metric: `active_addresses_24h_change_1d`