### PR TITLE
fix/studio-holders-distribution

### DIFF
--- a/src/ducks/Chart/colors.js
+++ b/src/ducks/Chart/colors.js
@@ -101,8 +101,8 @@ export function highlightMetricColor (MetricColor, focusedMetricKey) {
 }
 
 const INITIAL_STATE = {}
-export function useChartColors (metrics) {
-  const [ChartColor, setChartColors] = useState(INITIAL_STATE)
+export function useChartColors (metrics, initialState = INITIAL_STATE) {
+  const [ChartColor, setChartColors] = useState(initialState)
 
   useEffect(
     () => {

--- a/src/ducks/Studio/Overview/Overview.js
+++ b/src/ducks/Studio/Overview/Overview.js
@@ -45,7 +45,8 @@ const Overview = ({
             {currentPhase === Phase.MAPVIEW_SELECTION && (
               <div
                 className={cx(styles.item, styles.item_new, styles.idle)}
-                onClick={onNewChartClick}
+                onClick={() => onNewChartClick()}
+                // NOTE: Not passing `onNewChartClick` as a reference since arguments will be mapped incorrectly [@vanguard | Aug  5, 2020]
               >
                 <Plus className={styles.iconNew} />
                 Add new chart

--- a/src/ducks/Studio/Sidebar/Category.js
+++ b/src/ducks/Studio/Sidebar/Category.js
@@ -13,7 +13,7 @@ const DEFAULT_OPENED_CATEGORY = {
   'Santiment Alerts': true
 }
 
-const HOLDER_DISTRIBUTION_NODE = {
+export const HOLDER_DISTRIBUTION_NODE = {
   key: 'holder_distribution',
   type: WIDGET,
   label: 'Holder Distribution'

--- a/src/ducks/Studio/Sidebar/Search.js
+++ b/src/ducks/Studio/Sidebar/Search.js
@@ -1,5 +1,8 @@
 import React from 'react'
 import { SearchWithSuggestions } from '@santiment-network/ui/Search'
+import { HOLDER_DISTRIBUTION_NODE } from './Category'
+
+const HOLDER_DISTRIBUTION_ITEM = { item: HOLDER_DISTRIBUTION_NODE }
 
 const predicate = searchTerm => {
   const upperCaseSearchTerm = searchTerm.toUpperCase()
@@ -18,7 +21,7 @@ export const getMetricSuggestions = categories => {
   const suggestions = []
   for (const categoryKey in categories) {
     const category = categories[categoryKey]
-    const items = []
+    const items = categoryKey === 'On-chain' ? [HOLDER_DISTRIBUTION_ITEM] : []
     for (const group in category) {
       items.push(...category[group])
     }

--- a/src/ducks/Studio/Widget/HolderDistributionWidget.js
+++ b/src/ducks/Studio/Widget/HolderDistributionWidget.js
@@ -15,7 +15,7 @@ const Title = ({ settings }) => (
 
 const HolderDistributionWidget = ({ widget, ...props }) => {
   const [isOpened, setIsOpened] = useState(true)
-  const MetricColor = useChartColors(widget.metrics)
+  const MetricColor = useChartColors(widget.metrics, widget.MetricColor)
   const PressedModifier = usePressedModifier()
 
   function toggleWidgetMetric (metric) {

--- a/src/ducks/Studio/index.js
+++ b/src/ducks/Studio/index.js
@@ -185,7 +185,13 @@ export const Studio = ({
     }
 
     if (currentPhase === Phase.IDLE && PressedModifier.cmdKey) {
-      onWidgetClick(widgets[0], appliedMetrics, appliedWidgets)
+      if (PressedModifier.shiftKey) {
+        if (appliedMetrics) {
+          onNewChartClick(appliedMetrics, true)
+        }
+      } else {
+        onWidgetClick(widgets[0], appliedMetrics, appliedWidgets)
+      }
     }
   }
 
@@ -218,11 +224,15 @@ export const Studio = ({
     resetSelecion()
   }
 
-  function onNewChartClick () {
+  function onNewChartClick (
+    appliedMetrics = selectedMetrics,
+    scrollIntoViewOnMount
+  ) {
     setWidgets([
       ...widgets,
       ChartWidget.new({
-        metrics: selectedMetrics,
+        scrollIntoViewOnMount,
+        metrics: appliedMetrics,
         MetricSettingMap: selectedMetricSettingsMap,
         connectedWidgets: mergeConnectedWidgetsWithSelected([], selectedWidgets)
       })


### PR DESCRIPTION
## Summary
- Correctly mapping shared colors;
- `Holder Distribution` now visible in search;