### PR TITLE
change version update label

### DIFF
--- a/src/components/Navbar/NavbarProfileDropdown.js
+++ b/src/components/Navbar/NavbarProfileDropdown.js
@@ -22,6 +22,7 @@ import {
 import styles from './NavbarProfileDropdown.module.scss'
 import { VersionLabel } from '../Version/Version'
 import dropdownStyles from './NavbarDropdown.module.scss'
+import { APP_STATES } from '../../ducks/Updates/reducers'
 
 const personalLinks = [
   { as: Link, to: '/sonar/my-signals', children: 'My alerts' },
@@ -107,7 +108,7 @@ const SubscriptionsList = () => {
 export const NavbarProfileDropdown = ({
   activeLink,
   toggleNightMode,
-  isUpdateAvailable
+  appVersionState
 }) => {
   const { user } = useUser()
   const { isPro } = useUserSubscriptionStatus()
@@ -130,28 +131,35 @@ export const NavbarProfileDropdown = ({
           )}
         </div>
       )}
+
       <DropdownDevider />
 
-      <div className={dropdownStyles.list}>
-        {isUpdateAvailable ? (
-          <Button
-            variant='ghost'
-            fluid
-            accent='positive'
-            className={cx(dropdownStyles.item, dropdownStyles.updateBtn)}
-            onClick={() => window.location.reload(true)}
-          >
-            Update available. Restart now
-          </Button>
-        ) : (
-          <div className={styles.version}>
-            You have the latest version!
-            <VersionLabel className={styles.versionLabel} />
+      {appVersionState && (
+        <>
+          <div className={dropdownStyles.list}>
+            {appVersionState === APP_STATES.LATEST && (
+              <div className={styles.version}>
+                You have the latest version!
+                <VersionLabel className={styles.versionLabel} />
+              </div>
+            )}
+            {appVersionState === APP_STATES.NEW_AVAILABLE && (
+              <Button
+                variant='ghost'
+                fluid
+                accent='positive'
+                className={cx(dropdownStyles.item, dropdownStyles.updateBtn)}
+                onClick={() => window.location.reload(true)}
+              >
+                Update available. Restart now
+              </Button>
+            )}
           </div>
-        )}
-      </div>
 
-      <DropdownDevider />
+          <DropdownDevider />
+        </>
+      )}
+
       {user && (
         <>
           <div className={dropdownStyles.list}>
@@ -221,7 +229,7 @@ export const NavbarProfileDropdown = ({
 
 const mapStateToProps = ({ rootUi, app }) => ({
   status: rootUi.isOnline ? 'online' : 'offline',
-  isUpdateAvailable: app.isUpdateAvailable
+  appVersionState: app.appVersionState
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/ducks/Updates/actions.js
+++ b/src/ducks/Updates/actions.js
@@ -1,6 +1,10 @@
 // timeseries
 export const NEW_APP_AVAILABLE = '[version] NEW_APP_AVAILABLE'
+export const IS_LATEST_APP = '[version] IS_LATEST_APP'
 
 export const newAppAvailable = () => ({
   type: NEW_APP_AVAILABLE
+})
+export const markAsLatestApp = () => ({
+  type: IS_LATEST_APP
 })

--- a/src/ducks/Updates/reducers.js
+++ b/src/ducks/Updates/reducers.js
@@ -2,12 +2,22 @@ import * as actions from './actions'
 
 export const initialState = {}
 
+export const APP_STATES = {
+  LATEST: 'latest',
+  NEW_AVAILABLE: 'new_available'
+}
+
 export default (state = initialState, action) => {
   switch (action.type) {
     case actions.NEW_APP_AVAILABLE:
       return {
         ...state,
-        isUpdateAvailable: true
+        appVersionState: APP_STATES.NEW_AVAILABLE
+      }
+    case actions.IS_LATEST_APP:
+      return {
+        ...state,
+        appVersionState: APP_STATES.LATEST
       }
     default:
       return state

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ import authLink from './apollo/auth-link'
 import retryLink from './apollo/retry-link'
 import ChartPage from './pages/Chart'
 import { register, unregister } from './serviceWorker'
-import { newAppAvailable } from './ducks/Updates/actions'
+import { markAsLatestApp, newAppAvailable } from './ducks/Updates/actions'
 import { ThemeProvider } from './stores/ui/theme'
 import './index.scss'
 
@@ -126,13 +126,14 @@ const main = () => {
     store.dispatch(changeNetworkStatus(online))
   })
 
-  const onServiceWorkerUpdate = () => {
-    store.dispatch(newAppAvailable())
-  }
-
   if (isNotSafari) {
     register({
-      onUpdate: onServiceWorkerUpdate
+      onUpdate: () => {
+        store.dispatch(newAppAvailable())
+      },
+      onSuccess: () => {
+        store.dispatch(markAsLatestApp())
+      }
     })
   } else {
     unregister()


### PR DESCRIPTION
**Summary**

Check current/new version via updates from service worker. Doesn't need to show a default static label with version before event.