### PR TITLE
feature/screener-market-segments

### DIFF
--- a/src/components/Calendar/CalendarBtn.module.scss
+++ b/src/components/Calendar/CalendarBtn.module.scss
@@ -1,6 +1,7 @@
 .icon {
   margin-left: auto;
   fill: var(--waterloo);
+  transition: transform 0.25s ease-in-out;
 }
 
 .btn {

--- a/src/components/ExplanationTooltip/ExplanationTooltip.module.scss
+++ b/src/components/ExplanationTooltip/ExplanationTooltip.module.scss
@@ -6,7 +6,7 @@
   color: $white;
   border-radius: $border-radius;
 
-  @include text('caption', 'l');
+  @include text('caption', 'm');
 }
 
 .arrow {

--- a/src/ducks/Watchlists/Cards/NewCard.js
+++ b/src/ducks/Watchlists/Cards/NewCard.js
@@ -4,7 +4,7 @@ import { NavLink as Link } from 'react-router-dom'
 import NewWatchlist from '../Actions/New'
 import { ProLabel } from '../../../components/ProLabel'
 import LoginDialogWrapper from '../../../components/LoginDialog/LoginDialogWrapper'
-import { useUserWatchlists, useUserScreeners } from '../gql/hooks'
+import { useUserWatchlists } from '../gql/hooks'
 import { useUserSubscriptionStatus } from '../../../stores/user/subscriptions'
 import NewScreener from '../Actions/New/NewScreener'
 import { Plus } from '../../../components/Illustrations/Plus'
@@ -30,46 +30,40 @@ const Trigger = ({ type, showProBanner, ...props }) => {
 }
 
 const NewCard = ({ type = 'watchlist' }) => {
-  const { isPro } = useUserSubscriptionStatus()
-  let lists = []
-
   if (type === 'watchlist') {
-    const [watchlists = []] = useUserWatchlists()
-    lists = watchlists
+    return <NewWatchlistCard />
   } else {
-    const [screeners = []] = useUserScreeners()
-    lists = screeners
+    return <NewScreenerCard />
   }
+}
 
-  const showProBanner = type === 'screener' && !isPro
+const NewWatchlistCard = () => {
+  const [watchlists = []] = useUserWatchlists()
+  let lists = watchlists
 
   return (
     <LoginDialogWrapper
-      title={`Create ${type}`}
-      trigger={props =>
-        showProBanner ? (
-          <Link to='/pricing'>
-            <Trigger showProBanner type={type} {...props} />
-          </Link>
-        ) : (
-          <Trigger type={type} {...props} />
-        )
-      }
+      title={`Create watchlist`}
+      trigger={props => <Trigger type='watchlist' {...props} />}
     >
-      {showProBanner ? (
-        <Link to='/pricing'>
-          <Trigger showProBanner type={type} />
-        </Link>
-      ) : type === 'screener' ? (
-        <NewScreener trigger={<Trigger type={type} />} />
-      ) : (
-        <NewWatchlist
-          watchlists={lists}
-          trigger={<Trigger type={type} />}
-          type={type}
-        />
-      )}
+      <NewWatchlist
+        watchlists={lists}
+        trigger={<Trigger type='watchlist' />}
+        type='watchlist'
+      />
     </LoginDialogWrapper>
+  )
+}
+
+const NewScreenerCard = () => {
+  const { isPro } = useUserSubscriptionStatus()
+
+  return !isPro ? (
+    <Link to='/pricing'>
+      <Trigger showProBanner type='screener' />
+    </Link>
+  ) : (
+    <NewScreener trigger={<Trigger type='screener' />} />
   )
 }
 

--- a/src/ducks/Watchlists/Widgets/Filter/Category/index.js
+++ b/src/ducks/Watchlists/Widgets/Filter/Category/index.js
@@ -32,7 +32,11 @@ const Category = ({ title, groups, counter, ...rest }) => {
               )}
               {groups[group].map(({ item: metric }) =>
                 metric.Widget ? (
-                  <metric.Widget {...rest} />
+                  <metric.Widget
+                    {...rest}
+                    key={metric.label}
+                    baseMetric={metric}
+                  />
                 ) : (
                   <FilterMetric
                     key={metric.label}

--- a/src/ducks/Watchlists/Widgets/Filter/Category/index.module.scss
+++ b/src/ducks/Watchlists/Widgets/Filter/Category/index.module.scss
@@ -17,6 +17,7 @@
   fill: var(--fiord);
   transform: rotate(-90deg);
   width: 12px;
+  transition: transform 0.25s ease-in-out;
 }
 
 .counter {

--- a/src/ducks/Watchlists/Widgets/Filter/Metric/MetricState/Explanation.js
+++ b/src/ducks/Watchlists/Widgets/Filter/Metric/MetricState/Explanation.js
@@ -3,7 +3,17 @@ import { Filter } from '../../dataHub/types'
 import { millify } from '../../../../../../utils/formatting'
 import styles from './index.module.scss'
 
-const Explanation = ({ firstThreshold, timeRange, type, metric }) => {
+const Explanation = ({
+  firstThreshold,
+  timeRange,
+  type,
+  metric,
+  customStateText
+}) => {
+  if (customStateText) {
+    return <span className={styles.explanation}>{customStateText}</span>
+  }
+
   if (!firstThreshold) {
     return null
   }

--- a/src/ducks/Watchlists/Widgets/Filter/Metric/MetricState/index.js
+++ b/src/ducks/Watchlists/Widgets/Filter/Metric/MetricState/index.js
@@ -12,7 +12,8 @@ const FilterMetricState = ({
   onCheckboxClicked,
   isViewMode,
   metric,
-  settings
+  settings,
+  customStateText = ''
 }) => {
   const metricForDescription = Metric[metric.descriptionKey || metric.key] || {}
 
@@ -37,6 +38,7 @@ const FilterMetricState = ({
             <Explanation
               {...settings}
               metric={metric}
+              customStateText={customStateText}
               className={styles.explanation}
             />
           )}

--- a/src/ducks/Watchlists/Widgets/Filter/Metric/index.js
+++ b/src/ducks/Watchlists/Widgets/Filter/Metric/index.js
@@ -76,12 +76,15 @@ const FilterMetric = ({
         const formatter = Filter[type].serverValueFormatter
 
         const newFilter = {
-          aggregation,
-          dynamicFrom,
-          dynamicTo: 'now',
-          metric,
-          operator,
-          threshold: formatter ? formatter(firstThreshold) : firstThreshold
+          args: {
+            aggregation,
+            dynamicFrom,
+            dynamicTo: 'now',
+            metric,
+            operator,
+            threshold: formatter ? formatter(firstThreshold) : firstThreshold
+          },
+          name: 'metric'
         }
 
         if (firstThreshold) {

--- a/src/ducks/Watchlists/Widgets/Filter/Metric/index.js
+++ b/src/ducks/Watchlists/Widgets/Filter/Metric/index.js
@@ -20,6 +20,10 @@ const FilterMetric = ({
   toggleMetricInFilter,
   isPro
 }) => {
+  if (!defaultSettings.isActive && baseMetric.isDeprecated) {
+    return null
+  }
+
   const [settings, setSettings] = useState(defaultSettings)
   const [percentTimeRanges, setPercentTimeRanges] = useState(
     getTimeRangesByMetric(baseMetric, availableMetrics)

--- a/src/ducks/Watchlists/Widgets/Filter/Widget/MarketSegments.js
+++ b/src/ducks/Watchlists/Widgets/Filter/Widget/MarketSegments.js
@@ -50,19 +50,22 @@ const MarketSegments = ({
         } = settings
         const { isActive: previousIsActive } = defaultSettings
 
-        const newFilter = { market_segments_combinator, market_segments }
+        const newFilter = {
+          args: { market_segments_combinator, market_segments },
+          name: 'market_segments'
+        }
 
-        //         if (hasActiveSegments) {
-        //           if (previousIsActive !== isActive) {
-        //             toggleMetricInFilter(newFilter, baseMetric.key)
-        //           } else {
-        //             updMetricInFilter(newFilter, baseMetric.key)
-        //           }
-        //         }
-        //
-        //         if (!hasActiveSegments && isActive && defaultSettings.isActive) {
-        //           toggleMetricInFilter(newFilter, baseMetric.key)
-        //         }
+        if (hasActiveSegments) {
+          if (previousIsActive !== isActive) {
+            toggleMetricInFilter(newFilter, baseMetric.key)
+          } else {
+            updMetricInFilter(newFilter, baseMetric.key)
+          }
+        }
+
+        if (!hasActiveSegments && isActive && defaultSettings.isActive) {
+          toggleMetricInFilter(newFilter, baseMetric.key)
+        }
       }
     },
     [settings]
@@ -212,13 +215,15 @@ const MarketSegments = ({
 
 export default ({ filters, baseMetric, ...props }) => {
   const filter = extractFilterByMetricType(filters, baseMetric)
+  const settings = filter.length === 0 ? {} : filter[0]
 
   return (
     <MarketSegments
       {...props}
       baseMetric={baseMetric}
       defaultSettings={{
-        ...DEFAULT_SETTINGS
+        ...DEFAULT_SETTINGS,
+        ...settings
       }}
     />
   )

--- a/src/ducks/Watchlists/Widgets/Filter/Widget/MarketSegments.js
+++ b/src/ducks/Watchlists/Widgets/Filter/Widget/MarketSegments.js
@@ -1,7 +1,172 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import cx from 'classnames'
+import ContextMenu from '@santiment-network/ui/ContextMenu'
+import Button from '@santiment-network/ui/Button'
+import Panel from '@santiment-network/ui/Panel'
+import Icon from '@santiment-network/ui/Icon'
+import Skeleton from '../../../../../components/Skeleton/Skeleton'
+import ExplanationTooltip from '../../../../../components/ExplanationTooltip/ExplanationTooltip'
+import MetricState from '../Metric/MetricState'
+import { useAvailableSegments } from '../../../gql/hooks'
+import { DEFAULT_SETTINGS } from '../defaults'
+import styles from './MarketSegments.module.scss'
 
-const MarketSegments = props => {
-  return <div>hello</div>
+const MarketSegments = ({ isViewMode, baseMetric, defaultSettings }) => {
+  const [segments = [], loading] = useAvailableSegments()
+  const [settings, setSettings] = useState(defaultSettings)
+
+  const hasActiveSegments = settings.segments.length > 0
+
+  function onCheckboxClicked () {
+    setSettings(state => ({ ...state, isActive: !settings.isActive }))
+  }
+
+  function onToggleMode () {
+    setSettings(state => ({
+      ...state,
+      combinator: settings.combinator === 'and' ? 'or' : 'and'
+    }))
+  }
+
+  function onToggleSegment (segment) {
+    const selectedSegmentsSet = new Set(settings.segments)
+
+    if (!selectedSegmentsSet.delete(segment)) {
+      selectedSegmentsSet.add(segment)
+    }
+
+    setSettings(state => ({ ...state, segments: [...selectedSegmentsSet] }))
+  }
+
+  return (
+    <>
+      <MetricState
+        isViewMode={isViewMode}
+        metric={baseMetric}
+        settings={settings}
+        isActive={settings.isActive}
+        onCheckboxClicked={onCheckboxClicked}
+        customStateText={
+          settings.isActive && hasActiveSegments
+            ? `shows ${
+              settings.combinator === 'and' ? 'all' : 'at least one'
+            } of`
+            : ''
+        }
+      />
+      {hasActiveSegments > 0 && (
+        <div className={styles.labels}>
+          {settings.segments.map((item, idx) => (
+            <span key={idx} className={styles.label}>
+              {item}
+            </span>
+          ))}
+        </div>
+      )}
+      {settings.isActive && !isViewMode && (
+        <div className={styles.settings}>
+          <ContextMenu
+            passOpenStateAs='isActive'
+            position='bottom'
+            align='start'
+            className={styles.dropdown}
+            trigger={
+              <Button border classes={styles} className={styles.trigger__btn}>
+                Choose market segments
+                <Icon type='arrow-down' className={styles.trigger__arrow} />
+              </Button>
+            }
+          >
+            <Panel className={styles.panel}>
+              {hasActiveSegments > 0 && (
+                <div className={styles.list}>
+                  {settings.segments.map((name, idx) => (
+                    <Button
+                      className={styles.item}
+                      fluid
+                      variant='ghost'
+                      key={idx}
+                      onClick={() => onToggleSegment(name)}
+                    >
+                      <div>
+                        <span className={styles.name}>{name}</span>
+                      </div>
+                      <div className={cx(styles.action, styles.delete)}>
+                        Remove
+                      </div>
+                    </Button>
+                  ))}
+                </div>
+              )}
+              <div className={styles.list}>
+                <Skeleton repeat={3} show={loading} className={styles.loader} />
+                {segments.map(({ name, count }, idx) => {
+                  const isSelected = settings.segments.includes(name)
+
+                  return (
+                    <Button
+                      className={cx(
+                        styles.item,
+                        isSelected && styles.item__selected
+                      )}
+                      fluid
+                      variant='ghost'
+                      key={idx}
+                      onClick={() => (isSelected ? {} : onToggleSegment(name))}
+                    >
+                      <div>
+                        <span className={styles.name}>{name}</span>
+                        <span className={styles.count}>({count})</span>
+                      </div>
+                      <div
+                        className={cx(
+                          styles.action,
+                          isSelected && styles.selected
+                        )}
+                      >
+                        Add
+                      </div>
+                    </Button>
+                  )
+                })}
+              </div>
+            </Panel>
+          </ContextMenu>
+          <ExplanationTooltip
+            text={
+              settings.combinator === 'and'
+                ? 'Show assets that matches all of selected segments'
+                : 'Show assets that matches at least one of selected segments'
+            }
+            className={styles.explanation}
+            align='end'
+            offsetY={10}
+          >
+            <Button
+              className={styles.toggleModeBtn}
+              fluid
+              variant='flat'
+              isActive
+              onClick={onToggleMode}
+            >
+              {settings.combinator === 'and' ? 'All' : 'Any'}
+            </Button>
+          </ExplanationTooltip>
+        </div>
+      )}
+    </>
+  )
 }
 
-export default MarketSegments
+export default ({ filters, baseMetric, ...props }) => {
+  return (
+    <MarketSegments
+      {...props}
+      baseMetric={baseMetric}
+      defaultSettings={{
+        ...DEFAULT_SETTINGS,
+        segments: []
+      }}
+    />
+  )
+}

--- a/src/ducks/Watchlists/Widgets/Filter/Widget/MarketSegments.js
+++ b/src/ducks/Watchlists/Widgets/Filter/Widget/MarketSegments.js
@@ -215,7 +215,7 @@ const MarketSegments = ({
 
 export default ({ filters, baseMetric, ...props }) => {
   const filter = extractFilterByMetricType(filters, baseMetric)
-  const settings = filter.length === 0 ? {} : filter[0]
+  const settings = filter.length === 0 ? {} : { ...filter[0], isActive: true }
 
   return (
     <MarketSegments

--- a/src/ducks/Watchlists/Widgets/Filter/Widget/MarketSegments.module.scss
+++ b/src/ducks/Watchlists/Widgets/Filter/Widget/MarketSegments.module.scss
@@ -1,0 +1,138 @@
+@import '~@santiment-network/ui/mixins';
+
+.panel {
+  max-height: 201px;
+  overflow-y: auto;
+  width: 252px;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 6px 8px;
+}
+
+.list {
+  padding: 10px 8px;
+}
+
+.list + .list {
+  border-top: 1px solid var(--porcelain);
+}
+
+.action {
+  margin-left: auto;
+}
+
+.count {
+  color: var(--waterloo);
+  margin-left: 4px;
+}
+
+.name {
+  color: var(--rhino);
+}
+
+.delete {
+  color: var(--waterloo);
+}
+
+.selected {
+  color: var(--casper);
+}
+
+.item__selected {
+  cursor: default;
+
+  &:hover {
+    background: none;
+  }
+
+  & .selected {
+    color: var(--casper);
+  }
+}
+
+.item:hover {
+  & .delete {
+    color: var(--persimmon);
+  }
+}
+
+.trigger__btn {
+  min-width: 252px;
+
+  &:hover {
+    border-color: var(--mystic);
+    color: var(--rhino);
+  }
+}
+
+.trigger__arrow {
+  margin-left: auto;
+  fill: var(--waterloo);
+  transition: transform 0.25s ease-in-out;
+}
+
+.active {
+  border-color: var(--jungle-green);
+
+  .trigger__arrow {
+    transform: rotate(180deg);
+    fill: var(--jungle-green);
+  }
+}
+
+.dropdown {
+  z-index: 1000;
+}
+
+.loader {
+  height: 32px;
+}
+
+.loader + .loader {
+  margin-top: 2px;
+}
+
+.labels {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 4px 0 6px;
+}
+
+.label {
+  padding: 2px 8px;
+  margin-right: 4px;
+  margin-bottom: 4px;
+  background-color: var(--porcelain);
+  border-radius: 4px;
+
+  @include text('caption');
+
+  &:last-child {
+    margin-right: 0;
+  }
+}
+
+.settings {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.toggleModeBtn {
+  padding-left: 6px;
+  padding-right: 6px;
+  width: 50px;
+  justify-content: center;
+  margin-left: 8px;
+}
+
+.explanation {
+  z-index: 1000;
+  max-width: 190px;
+  padding: 6px 12px;
+}

--- a/src/ducks/Watchlists/Widgets/Filter/dataHub/metrics.js
+++ b/src/ducks/Watchlists/Widgets/Filter/dataHub/metrics.js
@@ -52,7 +52,8 @@ export const Metric = {
     group: 'Network Value',
     label: 'MVRV',
     aggregation: 'avg',
-    showTimeRange: true
+    showTimeRange: true,
+    isDeprecated: true
   },
   mvrv_usd_30d: {
     category: 'On-chain',

--- a/src/ducks/Watchlists/Widgets/Filter/dataHub/metrics.js
+++ b/src/ducks/Watchlists/Widgets/Filter/dataHub/metrics.js
@@ -152,6 +152,7 @@ export const Metric = {
   },
   market_segments: {
     category: 'Financial',
+    label: 'Market Segments',
     Widget: props => <MarketSegments {...props} />
   }
 }
@@ -176,8 +177,8 @@ export const metrics = [
   Metric.exchange_balance,
   Metric.mvrv_usd_30d,
   Metric.mvrv_usd_180d,
-  Metric.mvrv_usd_365d
-  // Metric.market_segments
+  Metric.mvrv_usd_365d,
+  Metric.market_segments
 ]
 
 export const MetricAlias = {

--- a/src/ducks/Watchlists/Widgets/Filter/dataHub/metrics.js
+++ b/src/ducks/Watchlists/Widgets/Filter/dataHub/metrics.js
@@ -50,7 +50,7 @@ export const Metric = {
   transaction_volume_usd: {
     category: 'On-chain',
     group: 'Network Activity',
-    label: 'Transaction Volume in USD',
+    label: 'Transaction Volume USD',
     aggregation: 'sum',
     showTimeRange: true
   },

--- a/src/ducks/Watchlists/Widgets/Filter/dataHub/metrics.js
+++ b/src/ducks/Watchlists/Widgets/Filter/dataHub/metrics.js
@@ -47,6 +47,13 @@ export const Metric = {
     aggregation: 'sum',
     showTimeRange: true
   },
+  transaction_volume_usd: {
+    category: 'On-chain',
+    group: 'Network Activity',
+    label: 'Transaction Volume in USD',
+    aggregation: 'sum',
+    showTimeRange: true
+  },
   mvrv_usd: {
     category: 'On-chain',
     group: 'Network Value',
@@ -123,6 +130,11 @@ export const Metric = {
     group: 'Network Activity',
     label: 'Circulation'
   },
+  circulation_180d: {
+    category: 'On-chain',
+    group: 'Network Activity',
+    label: 'Circulation (180d)'
+  },
   network_growth: {
     category: 'On-chain',
     group: 'Network Activity',
@@ -170,12 +182,14 @@ export const metrics = [
   Metric.dev_activity_1d,
   Metric.daily_active_addresses,
   Metric.transaction_volume,
-  Metric.mvrv_usd,
+  Metric.transaction_volume_usd,
   Metric.circulation,
+  Metric.circulation_180d,
   Metric.network_growth,
   Metric.exchange_inflow,
   Metric.exchange_outflow,
   Metric.exchange_balance,
+  Metric.mvrv_usd,
   Metric.mvrv_usd_30d,
   Metric.mvrv_usd_180d,
   Metric.mvrv_usd_365d,

--- a/src/ducks/Watchlists/Widgets/Filter/detector.js
+++ b/src/ducks/Watchlists/Widgets/Filter/detector.js
@@ -3,17 +3,16 @@ import { DEFAULT_TIMERANGES } from './defaults'
 import { isContainMetric } from './utils'
 
 export function extractFilterByMetricType (filters = [], metric) {
-  return filters.filter(item => {
-    const filterMetric = item.name
-      ? item.name === 'metric'
-        ? item.args.metric
-        : item.name
-      : item.metric
-    return (
-      isContainMetric(filterMetric, metric.percentMetricKey) ||
-      isContainMetric(filterMetric, metric.key)
-    )
-  })
+  return filters
+    .filter(item => {
+      const filterMetric = item.name === 'metric' ? item.args.metric : item.name
+
+      return (
+        isContainMetric(filterMetric, metric.percentMetricKey) ||
+        isContainMetric(filterMetric, metric.key)
+      )
+    })
+    .map(({ args }) => ({ ...args }))
 }
 
 export function getFilterType (filter = []) {

--- a/src/ducks/Watchlists/Widgets/Filter/detector.js
+++ b/src/ducks/Watchlists/Widgets/Filter/detector.js
@@ -3,11 +3,17 @@ import { DEFAULT_TIMERANGES } from './defaults'
 import { isContainMetric } from './utils'
 
 export function extractFilterByMetricType (filters = [], metric) {
-  return filters.filter(
-    item =>
-      isContainMetric(item.metric, metric.percentMetricKey) ||
-      isContainMetric(item.metric, metric.key)
-  )
+  return filters.filter(item => {
+    const filterMetric = item.name
+      ? item.name === 'metric'
+        ? item.args.metric
+        : item.name
+      : item.metric
+    return (
+      isContainMetric(filterMetric, metric.percentMetricKey) ||
+      isContainMetric(filterMetric, metric.key)
+    )
+  })
 }
 
 export function getFilterType (filter = []) {

--- a/src/ducks/Watchlists/Widgets/Filter/index.js
+++ b/src/ducks/Watchlists/Widgets/Filter/index.js
@@ -12,7 +12,12 @@ import Category from './Category'
 import { DEFAULT_SCREENER_FUNCTION } from '../../utils'
 import { getCategoryGraph } from '../../../Studio/Sidebar/utils'
 import { countCategoryActiveMetrics } from '../../../SANCharts/ChartMetricSelector'
-import { getActiveBaseMetrics, getNewFunction, isContainMetric } from './utils'
+import {
+  getActiveBaseMetrics,
+  getNewFunction,
+  isContainMetric,
+  extractFilters
+} from './utils'
 import { useAvailableMetrics } from '../../gql/hooks'
 import { useUserSubscriptionStatus } from '../../../../stores/user/subscriptions'
 import styles from './index.module.scss'
@@ -36,15 +41,16 @@ const Filter = ({
   }
 
   const isViewMode = !isAuthor && (isLoggedIn || !isDefaultScreener)
-  const { filters = [] } = screenerFunction.args
-  const isNoFilters =
-    screenerFunction.name === 'top_all_projects' || filters.length === 0
+  const filters = extractFilters(screenerFunction.args)
+
   const filterRef = useRef(null)
   const filterContentRef = useRef(null)
   const [filter, updateFilter] = useState(filters)
   const [updateWatchlist, { loading }] = useUpdateWatchlist()
   const [availableMetrics] = useAvailableMetrics()
   const { isPro } = useUserSubscriptionStatus()
+
+  const isNoFilters = filters.length === 0
 
   useEffect(() => {
     const sidebar = filterRef.current
@@ -95,8 +101,8 @@ const Filter = ({
       ? []
       : filter.filter(
         item =>
-          !isContainMetric(item.metric, key) &&
-            !isContainMetric(item.metric, alternativeKey)
+          !isContainMetric(item.args.metric || item.name, key) &&
+            !isContainMetric(item.args.metric || item.name, alternativeKey)
       )
     const newFilter = [...filters, metric]
 
@@ -112,15 +118,15 @@ const Filter = ({
   function toggleMetricInFilter (metric, key, alternativeKey = key) {
     const isMetricInList = filter.some(
       item =>
-        isContainMetric(item.metric, key) ||
-        isContainMetric(item.metric, alternativeKey)
+        isContainMetric(item.args.metric || item.name, key) ||
+        isContainMetric(item.args.metric || item.name, alternativeKey)
     )
     let newFilter = []
     if (isMetricInList) {
       newFilter = filter.filter(
         item =>
-          !isContainMetric(item.metric, key) &&
-          !isContainMetric(item.metric, alternativeKey)
+          !isContainMetric(item.args.metric || item.name, key) &&
+          !isContainMetric(item.args.metric || item.name, alternativeKey)
       )
     } else {
       newFilter = [...filter, metric]

--- a/src/ducks/Watchlists/Widgets/Filter/index.js
+++ b/src/ducks/Watchlists/Widgets/Filter/index.js
@@ -37,7 +37,8 @@ const Filter = ({
 
   const isViewMode = !isAuthor && (isLoggedIn || !isDefaultScreener)
   const { filters = [] } = screenerFunction.args
-  const isNoFilters = screenerFunction.name === 'top_all_projects'
+  const isNoFilters =
+    screenerFunction.name === 'top_all_projects' || filters.length === 0
   const filterRef = useRef(null)
   const filterContentRef = useRef(null)
   const [filter, updateFilter] = useState(filters)

--- a/src/ducks/Watchlists/Widgets/Filter/index.js
+++ b/src/ducks/Watchlists/Widgets/Filter/index.js
@@ -50,7 +50,8 @@ const Filter = ({
   const [availableMetrics] = useAvailableMetrics()
   const { isPro } = useUserSubscriptionStatus()
 
-  const isNoFilters = filters.length === 0
+  const isNoFilters =
+    filters.length === 0 || screenerFunction.name === 'top_all_projects'
 
   useEffect(() => {
     const sidebar = filterRef.current

--- a/src/ducks/Watchlists/Widgets/Filter/utils.js
+++ b/src/ducks/Watchlists/Widgets/Filter/utils.js
@@ -1,4 +1,5 @@
 import { Metric, MetricAlias } from './dataHub/metrics'
+import { DEFAULT_SCREENER_FUNCTION } from '../../utils'
 
 export function getActiveBaseMetrics (filter) {
   const activeMetrics = new Set(
@@ -21,12 +22,14 @@ export function getActiveBaseMetrics (filter) {
 }
 
 export function getNewFunction (filter) {
-  return {
-    args: {
-      filters: filter
-    },
-    name: 'selector'
-  }
+  return filter.length > 0
+    ? {
+      args: {
+        filters: filter
+      },
+      name: 'selector'
+    }
+    : DEFAULT_SCREENER_FUNCTION
 }
 
 export const percentServerValueFormatter = value => value / 100

--- a/src/ducks/Watchlists/Widgets/Filter/utils.js
+++ b/src/ducks/Watchlists/Widgets/Filter/utils.js
@@ -1,5 +1,4 @@
 import { Metric, MetricAlias } from './dataHub/metrics'
-import { DEFAULT_SCREENER_FUNCTION } from '../../utils'
 
 export function getActiveBaseMetrics (filter) {
   const activeMetrics = new Set(
@@ -18,14 +17,12 @@ export function getActiveBaseMetrics (filter) {
 }
 
 export function getNewFunction (filter) {
-  return filter.length > 0
-    ? {
-      args: {
-        filters: filter
-      },
-      name: 'selector'
-    }
-    : DEFAULT_SCREENER_FUNCTION
+  return {
+    args: {
+      filters: filter
+    },
+    name: 'selector'
+  }
 }
 
 export const percentServerValueFormatter = value => value / 100

--- a/src/ducks/Watchlists/Widgets/Filter/utils.js
+++ b/src/ducks/Watchlists/Widgets/Filter/utils.js
@@ -2,7 +2,11 @@ import { Metric, MetricAlias } from './dataHub/metrics'
 
 export function getActiveBaseMetrics (filter) {
   const activeMetrics = new Set(
-    filter.map(({ metric }) => {
+    filter.map(({ args: { metric }, name }) => {
+      if (!metric) {
+        return Metric[name]
+      }
+
       const transformedMetricIndex = metric.indexOf('_change_')
       const baseMetricKey =
         transformedMetricIndex === -1
@@ -30,4 +34,21 @@ export const percentValueFormatter = value => value * 100
 
 export function isContainMetric (item, key) {
   return item.includes(`${key}_change_`) || item === key
+}
+
+// for screeners that created with old way
+function reconstructFilters (filters) {
+  return filters.map(filter => ({ args: filter, name: 'metric' }))
+}
+
+export function extractFilters ({ filters = [] }) {
+  if (filters.length === 0) {
+    return filters
+  }
+
+  if (!filters[0].name && !filters[0].args) {
+    return reconstructFilters(filters)
+  } else {
+    return filters
+  }
 }

--- a/src/ducks/Watchlists/Widgets/TopPanel/Actions.js
+++ b/src/ducks/Watchlists/Widgets/TopPanel/Actions.js
@@ -4,11 +4,9 @@ import ContextMenu from '@santiment-network/ui/ContextMenu'
 import Panel from '@santiment-network/ui/Panel/Panel'
 import UIButton from '@santiment-network/ui/Button'
 import UIIcon from '@santiment-network/ui/Icon'
-import Delete from '../../Actions/Delete'
 import Copy from '../../Actions/Copy'
 import DownloadCSV from '../../Actions/DownloadCSV'
 import { ProLabel } from '../../../../components/ProLabel'
-import { useUserScreeners } from '../../gql/hooks'
 import styles from './Actions.module.scss'
 
 export const Icon = ({ className, ...props }) => (
@@ -28,8 +26,6 @@ const Actions = ({ isAuthor, id, name, assets, isPro }) => {
   if (!id) {
     return null
   }
-
-  const [screeners = []] = useUserScreeners()
 
   return (
     <ContextMenu
@@ -64,19 +60,6 @@ const Actions = ({ isAuthor, id, name, assets, isPro }) => {
           Download .csv
           {!isPro && <ProLabel className={styles.proLabel} />}
         </DownloadCSV>
-        {isAuthor && screeners.length > 1 && (
-          <Delete
-            title='Do you want to delete this screener?'
-            id={id}
-            name={name}
-            trigger={
-              <Button variant='negative' className={styles.delete}>
-                <Icon type='remove' />
-                Delete
-              </Button>
-            }
-          />
-        )}
       </Panel>
     </ContextMenu>
   )

--- a/src/ducks/Watchlists/Widgets/TopPanel/Actions.module.scss
+++ b/src/ducks/Watchlists/Widgets/TopPanel/Actions.module.scss
@@ -74,16 +74,6 @@
   }
 }
 
-.delete {
-  fill: var(--persimmon);
-  color: var(--persimmon);
-
-  &:hover {
-    fill: var(--persimmon-hover);
-    color: var(--persimmon-hover);
-  }
-}
-
 .proLabel {
   margin-left: 8px;
 }

--- a/src/ducks/Watchlists/gql/hooks.js
+++ b/src/ducks/Watchlists/gql/hooks.js
@@ -5,12 +5,14 @@ import {
   CREATE_WATCHLIST_MUTATION,
   UPDATE_WATCHLIST_MUTATION,
   AVAILABLE_METRICS_QUERY,
+  AVAILABLE_SEGMENTS_QUERY,
   PROJECTS_BY_FUNCTION_QUERY
 } from './index'
 import { WATCHLIST_QUERY } from '../../../queries/WatchlistGQL'
 import { store } from '../../../index'
 import { checkIsLoggedIn } from '../../../pages/UserSelectors'
 import {
+  countAssetsSort,
   isStaticWatchlist,
   isDynamicWatchlist,
   DEFAULT_SCREENER,
@@ -163,6 +165,12 @@ export function useAvailableMetrics () {
   const { data, loading } = useQuery(AVAILABLE_METRICS_QUERY)
 
   return [data ? data.getAvailableMetrics : [], loading]
+}
+
+export function useAvailableSegments () {
+  const { data, loading } = useQuery(AVAILABLE_SEGMENTS_QUERY)
+
+  return [data ? data.allMarketSegments.sort(countAssetsSort) : [], loading]
 }
 
 export function getProjectsByFunction (func) {

--- a/src/ducks/Watchlists/gql/index.js
+++ b/src/ducks/Watchlists/gql/index.js
@@ -66,6 +66,15 @@ export const AVAILABLE_METRICS_QUERY = gql`
   }
 `
 
+export const AVAILABLE_SEGMENTS_QUERY = gql`
+  query allMarketSegments {
+    allMarketSegments {
+      count
+      name
+    }
+  }
+`
+
 export const CREATE_WATCHLIST_MUTATION = gql`
   mutation createWatchlist(
     $isPublic: Boolean

--- a/src/ducks/Watchlists/utils.js
+++ b/src/ducks/Watchlists/utils.js
@@ -134,3 +134,7 @@ export const BASIC_CATEGORIES = [
     assetType: 'erc20'
   }
 ]
+
+export function countAssetsSort ({ count: countA }, { count: countB }) {
+  return countA > countB ? -1 : 1
+}


### PR DESCRIPTION
**Summary**
- add custom `Market Segments` filter
- rebuild filters combination via new api
- add `transaction_volume_usd`, `circulation_180d`
- hide `mvrv_usd` 
- remove duplicate `delete screener` button

**Screenshots**
![image](https://user-images.githubusercontent.com/24521041/90114672-b82de780-dd5b-11ea-96c3-2f9ab49d1018.png)
---
![image](https://user-images.githubusercontent.com/24521041/90114618-a51b1780-dd5b-11ea-9979-642d5c0c1df4.png)
