### PR TITLE
fix/chart-tooltip-hiding

### DIFF
--- a/src/ducks/Chart/tooltip.js
+++ b/src/ducks/Chart/tooltip.js
@@ -112,6 +112,8 @@ export function setupTooltip (chart, marker, useCustomTooltip, onPlotTooltip) {
   }
 }
 
+const metricValueAccessor = ({ value }) => value
+
 export function plotTooltip (chart, marker, point, options) {
   const {
     tooltip: { ctx },
@@ -125,10 +127,8 @@ export function plotTooltip (chart, marker, point, options) {
 
   clearCtx(chart, ctx)
 
-  const { x, value: datetime } = point
+  const { x, value: datetime, ...metrics } = point
   const { y, value } = metricPoint
-
-  const isInsideData = datetime <= Date.now()
 
   const xBubbleFormatter = isDayInterval(chart)
     ? getDateHoursMinutes
@@ -144,21 +144,23 @@ export function plotTooltip (chart, marker, point, options) {
       drawAlertPlus(chart, y)
     }
   } else {
+    const drawnMetrics = Object.values(metrics).filter(metricValueAccessor)
+
     drawHoverLineX(chart, x, hoverLineColor, 5)
     drawHoverLineY(chart, y, hoverLineColor, 0, 20)
 
     drawAlertPlus(chart, y)
 
-    if (isInsideData) {
+    if (drawnMetrics.length) {
       drawTooltip(ctx, point, TooltipSetting, marker, tooltipPaintConfig)
+      drawValueBubbleY(
+        chart,
+        yBubbleFormatter(value, tooltipKey),
+        y,
+        bubblesPaintConfig,
+        chart.isAlertsActive ? 5 : 0
+      )
     }
-    drawValueBubbleY(
-      chart,
-      yBubbleFormatter(value, tooltipKey),
-      y,
-      bubblesPaintConfig,
-      chart.isAlertsActive ? 5 : 0
-    )
     drawValueBubbleX(chart, xBubbleFormatter(datetime), x, bubblesPaintConfig)
   }
 }

--- a/src/ducks/SocialTool/index.js
+++ b/src/ducks/SocialTool/index.js
@@ -8,6 +8,7 @@ import SocialToolChart from './Chart'
 import { buildMetrics } from './utils'
 import { DEFAULT_SETTINGS, DEFAULT_OPTIONS, DEFAULT_METRICS } from './defaults'
 import { getNewInterval, INTERVAL_ALIAS } from '../SANCharts/IntervalSelector'
+import { useEdgeGaps } from '../Chart/hooks'
 import styles from './index.module.scss'
 
 function useSocialTimeseries (activeMetrics, settings, MetricSettingMap) {
@@ -47,11 +48,12 @@ const SocialTool = ({
   const [activeMetrics, setActiveMetrics] = useState(defaultActiveMetrics)
   const [MetricSettingMap, setMetricSettingMap] = useState()
   const [priceAsset, setPriceAsset] = useState()
-  const [data, loadings] = useSocialTimeseries(
+  const [rawData, loadings] = useSocialTimeseries(
     activeMetrics,
     settings,
     MetricSettingMap
   )
+  const data = useEdgeGaps(rawData)
   const allTimeData = useAllTimeData(activeMetrics, settings, MetricSettingMap)
   const [shareLink, setShareLink] = useState('')
   const chartRef = useRef(null)


### PR DESCRIPTION
## Summary
- Hiding tooltip if hovered point doesn't have any metrics data;
- Chart gap added to the social tool's main chart.