### PR TITLE
refactor/stablecoins-holder-distribution-labels

### DIFF
--- a/src/ducks/Studio/Chart/ActiveMetrics.js
+++ b/src/ducks/Studio/Chart/ActiveMetrics.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
 import Icon from '@santiment-network/ui/Icon'
 import Button from '@santiment-network/ui/Button'
@@ -37,13 +37,7 @@ const MetricButton = ({
   ...rest
 }) => {
   const { key, dataKey = key, node, comparedTicker } = metric
-
-  const label = useMemo(
-    () => {
-      return getMetricLabel(metric)
-    },
-    [metric]
-  )
+  const label = getMetricLabel(metric)
 
   return (
     <Button

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/index.js
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/index.js
@@ -67,7 +67,11 @@ const ToggleButton = ({
 )
 
 const CheckboxButton = ({ metric, label, isChecked, onClick, ...props }) => (
-  <Button className={styles.check} onClick={() => onClick(metric)} {...props}>
+  <Button
+    className={isChecked && styles.active}
+    onClick={() => onClick(metric)}
+    {...props}
+  >
     <Checkbox className={styles.checkbox} isActive={isChecked} />
     {label}
   </Button>

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/index.js
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/index.js
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import UIButton from '@santiment-network/ui/Button'
 import { Checkbox } from '@santiment-network/ui/Checkboxes'
 import Tabs, { Tab, TabMetrics } from './Tabs'
+import { removeLabelPostfix } from './utils'
 import MetricIcon from '../../../../SANCharts/MetricIcon'
 import styles from './index.module.scss'
 
@@ -35,6 +36,7 @@ const Button = ({ className, isChecked, ...props }) => (
 const ToggleButton = ({
   className,
   metric,
+  label,
   color,
   isActive,
   onClick,
@@ -48,7 +50,7 @@ const ToggleButton = ({
   >
     <MetricIcon node='line' color={color} className={styles.icon} />
     <span className={styles.label}>
-      {metric.label}
+      {label}
       {onUnmerge && (
         <span
           className={styles.unmerge}
@@ -64,10 +66,10 @@ const ToggleButton = ({
   </Button>
 )
 
-const CheckboxButton = ({ metric, isChecked, onClick, ...props }) => (
+const CheckboxButton = ({ metric, label, isChecked, onClick, ...props }) => (
   <Button className={styles.check} onClick={() => onClick(metric)} {...props}>
     <Checkbox className={styles.checkbox} isActive={isChecked} />
-    {metric.label}
+    {label}
   </Button>
 )
 
@@ -135,11 +137,12 @@ const HolderDistribution = ({
       <div className={styles.metrics}>
         {isIdlePhase &&
           mergedMetrics.map(metric => {
-            const { key } = metric
+            const { key, label } = metric
             return (
               <MetricButton
                 key={key}
                 metric={metric}
+                label={label}
                 color={MetricColor[key]}
                 isActive={metrics.includes(metric)}
                 onClick={toggleMetric}
@@ -149,11 +152,12 @@ const HolderDistribution = ({
           })}
 
         {distributionMetrics.map(metric => {
-          const { key } = metric
+          const { key, label } = metric
           return (
             <MetricButton
               key={key}
               metric={metric}
+              label={removeLabelPostfix(label)}
               color={MetricColor[key]}
               isActive={metrics.includes(metric)}
               isChecked={checkedMetrics && checkedMetrics.has(metric)}

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/index.module.scss
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/index.module.scss
@@ -29,6 +29,8 @@
   color: var(--casper);
   fill: var(--casper);
   stroke: var(--casper);
+  min-height: auto;
+  padding: 7px 12px;
 
   &.active {
     border: 1px solid var(--porcelain);

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/index.module.scss
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/index.module.scss
@@ -10,11 +10,17 @@
   }
 }
 
+.toggle {
+  color: var(--casper);
+  fill: var(--casper);
+  stroke: var(--casper);
+}
+
 .btn {
   margin-bottom: 8px;
-  border: 1px solid transparent;
   height: auto;
-  min-height: 32px;
+  min-height: auto;
+  padding: 7px 12px;
 
   &:last-child {
     margin: 0;
@@ -22,26 +28,17 @@
 
   &:hover {
     fill: var(--casper);
+    color: var(--casper);
+    background: var(--athens);
   }
-}
-
-.toggle {
-  color: var(--casper);
-  fill: var(--casper);
-  stroke: var(--casper);
-  min-height: auto;
-  padding: 7px 12px;
 
   &.active {
-    border: 1px solid var(--porcelain);
     color: var(--rhino);
-    box-shadow: 0 2px 8px rgba(59, 84, 106, 0.03),
-      0 1px 2px rgba(59, 84, 106, 0.03);
   }
 }
 
 .check:hover {
-  background: var(--athens);
+  color: var(--rhino);
 }
 
 .label {

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/index.module.scss
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/index.module.scss
@@ -21,6 +21,7 @@
   height: auto;
   min-height: auto;
   padding: 7px 12px;
+  color: var(--casper);
 
   &:last-child {
     margin: 0;
@@ -28,17 +29,13 @@
 
   &:hover {
     fill: var(--casper);
-    color: var(--casper);
+    color: var(--rhino);
     background: var(--athens);
   }
 
   &.active {
     color: var(--rhino);
   }
-}
-
-.check:hover {
-  color: var(--rhino);
 }
 
 .label {

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/metrics.js
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/metrics.js
@@ -1,3 +1,4 @@
+import { LABEL_PERCENT_POSTFIX } from './utils'
 import { TooltipSetting, FORMATTER } from '../../../../dataHub/tooltipSettings'
 
 const HOLDER_DISTRIBUTION_TEMPLATE = {
@@ -47,23 +48,19 @@ const PERCENT_HOLDER_DISTRIBUTION_KEY =
   'percent_of_holders_distribution_combined_balance'
 const KEYS = Object.keys(HOLDER_DISTRIBUTION_TEMPLATE)
 
-const activeMetricBtnFormatters = {
-  [PERCENT_HOLDER_DISTRIBUTION_KEY]: label => `${label} %`
-}
-
-function buildMetrics (templateKey, type) {
+function buildMetrics (templateKey, type, labelPostfix = '') {
   const Metric = {}
   KEYS.forEach(range => {
     const key = templateKey + range
-    const { label, queryKey } = HOLDER_DISTRIBUTION_TEMPLATE[range]
+    const { label: tmpLabel, queryKey } = HOLDER_DISTRIBUTION_TEMPLATE[range]
+    const label = tmpLabel + labelPostfix
 
     Metric[key] = {
       key,
       type,
       label,
       node: 'line',
-      queryKey: queryKey && templateKey + queryKey,
-      activeMetricBtnFormatter: activeMetricBtnFormatters[templateKey]
+      queryKey: queryKey && templateKey + queryKey
     }
 
     TooltipSetting[key] = {
@@ -81,7 +78,8 @@ export const HolderDistributionAbsoluteMetric = buildMetrics(
 
 export const HolderDistributionPercentMetric = buildMetrics(
   PERCENT_HOLDER_DISTRIBUTION_KEY,
-  'percent'
+  'percent',
+  LABEL_PERCENT_POSTFIX
 )
 
 export const HolderDistributionMetric = {

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/utils.js
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/utils.js
@@ -1,0 +1,3 @@
+export const LABEL_PERCENT_POSTFIX = ' %'
+
+export const removeLabelPostfix = str => str.replace(LABEL_PERCENT_POSTFIX, '')

--- a/src/ducks/Studio/Widget/HolderDistributionWidget/utils.js
+++ b/src/ducks/Studio/Widget/HolderDistributionWidget/utils.js
@@ -15,7 +15,8 @@ export const checkIfWasNotMerged = (newKey, mergedMetrics) =>
   mergedMetrics.every(({ key }) => key !== newKey)
 
 export function buildMergedMetric (baseMetrics) {
-  const isPercentMerge = baseMetrics[0].type === 'percent'
+  const labelPostfix = baseMetrics[0].type === 'percent' ? ' coins %' : ' coins'
+
   const metric = {
     fetch,
     baseMetrics,
@@ -24,9 +25,7 @@ export function buildMergedMetric (baseMetrics) {
       .map(keyGetter)
       .sort()
       .join(MERGED_DIVIDER),
-    label:
-      baseMetrics.map(labelGetter).join(', ') +
-      (isPercentMerge ? ' coins %' : ' coins')
+    label: baseMetrics.map(labelGetter).join(', ') + labelPostfix
   }
 
   updateTooltipSetting(metric)

--- a/src/ducks/Studio/Widget/HolderDistributionWidget/utils.js
+++ b/src/ducks/Studio/Widget/HolderDistributionWidget/utils.js
@@ -1,5 +1,6 @@
 import { GET_METRIC } from '../../timeseries/metrics'
 import { preTransform } from '../../timeseries/fetcher'
+import { removeLabelPostfix } from '../../Chart/Sidepanel/HolderDistribution/utils'
 import { updateTooltipSetting } from '../../../dataHub/tooltipSettings'
 import { client } from '../../../../apollo'
 
@@ -7,12 +8,14 @@ export const MERGED_DIVIDER = '__MM__'
 
 const immutate = v => Object.assign({}, v)
 const keyGetter = ({ key }) => key
-const labelGetter = ({ label }) => label.replace(' coins', '')
+const labelGetter = ({ label }) =>
+  removeLabelPostfix(label.replace(' coins', ''))
 
 export const checkIfWasNotMerged = (newKey, mergedMetrics) =>
   mergedMetrics.every(({ key }) => key !== newKey)
 
 export function buildMergedMetric (baseMetrics) {
+  const isPercentMerge = baseMetrics[0].type === 'percent'
   const metric = {
     fetch,
     baseMetrics,
@@ -21,7 +24,9 @@ export function buildMergedMetric (baseMetrics) {
       .map(keyGetter)
       .sort()
       .join(MERGED_DIVIDER),
-    label: baseMetrics.map(labelGetter).join(', ') + ' coins'
+    label:
+      baseMetrics.map(labelGetter).join(', ') +
+      (isPercentMerge ? ' coins %' : ' coins')
   }
 
   updateTooltipSetting(metric)

--- a/src/ducks/dataHub/metrics/labels.js
+++ b/src/ducks/dataHub/metrics/labels.js
@@ -4,11 +4,4 @@ const Labels = {
   [Metric.dormant_circulation.key]: 'Dormant Circulation (365d)'
 }
 
-export const getMetricLabel = ({
-  key,
-  label,
-  activeMetricBtnFormatter: formatter
-}) => {
-  const value = Labels[key] || label
-  return formatter ? formatter(value) : value
-}
+export const getMetricLabel = ({ key, label }) => Labels[key] || label


### PR DESCRIPTION
## Summary
- Appending percent metrics with the `%` symbol, when showed in tooltip;
- `Holder Distribution Sidepanel` updated button styles.

## Screenshots
<img width="366" alt="image" src="https://user-images.githubusercontent.com/25135650/91843010-b15d0b00-ec5d-11ea-8771-9561e5e1bfb8.png">
