### PR TITLE
enhance/holder-distribution-tooltip-formatter

### DIFF
--- a/src/ducks/Chart/axes.js
+++ b/src/ducks/Chart/axes.js
@@ -10,7 +10,7 @@ import {
   getDateHoursMinutes
 } from './utils'
 import { dayTicksPaintConfig, dayAxesColor } from './paintConfigs'
-import { Metric } from '../dataHub/metrics'
+import { TooltipSetting } from '../dataHub/tooltipSettings'
 import { mirroredMetrics } from '../dataHub/metrics/mirrored'
 import { millify } from '../../utils/formatting'
 
@@ -47,7 +47,8 @@ function yFormatter (value) {
 const selectYFormatter = metricKey =>
   mirroredMetrics.includes(metricKey)
     ? value => yFormatter(Math.abs(value))
-    : (Metric[metricKey] && Metric[metricKey].axisFormatter) || yFormatter
+    : (TooltipSetting[metricKey] && TooltipSetting[metricKey].axisFormatter) ||
+      yFormatter
 
 export function plotAxes (chart, scale) {
   const {

--- a/src/ducks/Chart/utils.js
+++ b/src/ducks/Chart/utils.js
@@ -1,4 +1,5 @@
 import { Metric } from '../dataHub/metrics'
+import { TooltipSetting } from '../dataHub/tooltipSettings'
 import { MirroredMetric } from '../dataHub/metrics/mirrored'
 import {
   getDateFormats,
@@ -40,7 +41,7 @@ export function getDateHoursMinutes (date) {
 }
 
 export function yBubbleFormatter (value, metricKey) {
-  const metric = Metric[metricKey]
+  const metric = TooltipSetting[metricKey]
   if (metric && metric.axisFormatter) {
     return metric.axisFormatter(value)
   }

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/metrics.js
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/metrics.js
@@ -1,4 +1,8 @@
-import { percentFormatter, LABEL_PERCENT_POSTFIX } from './utils'
+import {
+  percentFormatter,
+  axisPercentFormatter,
+  LABEL_PERCENT_POSTFIX
+} from './utils'
 import { updateTooltipSetting } from '../../../../dataHub/tooltipSettings'
 
 const HOLDER_DISTRIBUTION_TEMPLATE = {
@@ -48,7 +52,13 @@ const PERCENT_HOLDER_DISTRIBUTION_KEY =
   'percent_of_holders_distribution_combined_balance'
 const KEYS = Object.keys(HOLDER_DISTRIBUTION_TEMPLATE)
 
-function buildMetrics (templateKey, type, labelPostfix = '', formatter) {
+function buildMetrics (
+  templateKey,
+  type,
+  labelPostfix = '',
+  formatter,
+  axisFormatter
+) {
   const Metric = {}
   KEYS.forEach(range => {
     const key = templateKey + range
@@ -60,6 +70,7 @@ function buildMetrics (templateKey, type, labelPostfix = '', formatter) {
       type,
       label,
       formatter,
+      axisFormatter,
       node: 'line',
       queryKey: queryKey && templateKey + queryKey
     }
@@ -79,7 +90,8 @@ export const HolderDistributionPercentMetric = buildMetrics(
   PERCENT_HOLDER_DISTRIBUTION_KEY,
   'percent',
   LABEL_PERCENT_POSTFIX,
-  percentFormatter
+  percentFormatter,
+  axisPercentFormatter
 )
 
 export const HolderDistributionMetric = {

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/metrics.js
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/metrics.js
@@ -1,5 +1,5 @@
-import { LABEL_PERCENT_POSTFIX } from './utils'
-import { TooltipSetting, FORMATTER } from '../../../../dataHub/tooltipSettings'
+import { percentFormatter, LABEL_PERCENT_POSTFIX } from './utils'
+import { updateTooltipSetting } from '../../../../dataHub/tooltipSettings'
 
 const HOLDER_DISTRIBUTION_TEMPLATE = {
   _0_to_0001: {
@@ -48,25 +48,24 @@ const PERCENT_HOLDER_DISTRIBUTION_KEY =
   'percent_of_holders_distribution_combined_balance'
 const KEYS = Object.keys(HOLDER_DISTRIBUTION_TEMPLATE)
 
-function buildMetrics (templateKey, type, labelPostfix = '') {
+function buildMetrics (templateKey, type, labelPostfix = '', formatter) {
   const Metric = {}
   KEYS.forEach(range => {
     const key = templateKey + range
     const { label: tmpLabel, queryKey } = HOLDER_DISTRIBUTION_TEMPLATE[range]
     const label = tmpLabel + labelPostfix
 
-    Metric[key] = {
+    const metric = {
       key,
       type,
       label,
+      formatter,
       node: 'line',
       queryKey: queryKey && templateKey + queryKey
     }
 
-    TooltipSetting[key] = {
-      label,
-      formatter: FORMATTER
-    }
+    updateTooltipSetting(metric)
+    Metric[key] = metric
   })
 
   return Metric
@@ -79,7 +78,8 @@ export const HolderDistributionAbsoluteMetric = buildMetrics(
 export const HolderDistributionPercentMetric = buildMetrics(
   PERCENT_HOLDER_DISTRIBUTION_KEY,
   'percent',
-  LABEL_PERCENT_POSTFIX
+  LABEL_PERCENT_POSTFIX,
+  percentFormatter
 )
 
 export const HolderDistributionMetric = {

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/utils.js
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/utils.js
@@ -1,3 +1,7 @@
+import { FORMATTER } from '../../../../dataHub/tooltipSettings'
+
 export const LABEL_PERCENT_POSTFIX = ' %'
 
 export const removeLabelPostfix = str => str.replace(LABEL_PERCENT_POSTFIX, '')
+
+export const percentFormatter = value => `${FORMATTER(value)}%`

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/utils.js
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/utils.js
@@ -4,4 +4,14 @@ export const LABEL_PERCENT_POSTFIX = ' %'
 
 export const removeLabelPostfix = str => str.replace(LABEL_PERCENT_POSTFIX, '')
 
-export const percentFormatter = value => `${FORMATTER(value)}%`
+export const percentFormatter = value => FORMATTER(value) + '%'
+
+function normalizeAxisPercent (value) {
+  if (value >= 10) {
+    return value.toFixed(2)
+  }
+
+  return value.toFixed(3)
+}
+
+export const axisPercentFormatter = value => normalizeAxisPercent(value) + '%'

--- a/src/ducks/Studio/Widget/HolderDistributionWidget/utils.js
+++ b/src/ducks/Studio/Widget/HolderDistributionWidget/utils.js
@@ -1,6 +1,9 @@
 import { GET_METRIC } from '../../timeseries/metrics'
 import { preTransform } from '../../timeseries/fetcher'
-import { removeLabelPostfix } from '../../Chart/Sidepanel/HolderDistribution/utils'
+import {
+  removeLabelPostfix,
+  percentFormatter
+} from '../../Chart/Sidepanel/HolderDistribution/utils'
 import { updateTooltipSetting } from '../../../dataHub/tooltipSettings'
 import { client } from '../../../../apollo'
 
@@ -15,11 +18,14 @@ export const checkIfWasNotMerged = (newKey, mergedMetrics) =>
   mergedMetrics.every(({ key }) => key !== newKey)
 
 export function buildMergedMetric (baseMetrics) {
-  const labelPostfix = baseMetrics[0].type === 'percent' ? ' coins %' : ' coins'
+  const isPercentMerge = baseMetrics[0].type === 'percent'
+  const labelPostfix = isPercentMerge ? ' coins %' : ' coins'
+  const formatter = isPercentMerge ? percentFormatter : undefined
 
   const metric = {
     fetch,
     baseMetrics,
+    formatter,
     node: 'line',
     key: baseMetrics
       .map(keyGetter)

--- a/src/ducks/Studio/Widget/HolderDistributionWidget/utils.js
+++ b/src/ducks/Studio/Widget/HolderDistributionWidget/utils.js
@@ -2,12 +2,17 @@ import { GET_METRIC } from '../../timeseries/metrics'
 import { preTransform } from '../../timeseries/fetcher'
 import {
   removeLabelPostfix,
-  percentFormatter
+  percentFormatter,
+  axisPercentFormatter
 } from '../../Chart/Sidepanel/HolderDistribution/utils'
 import { updateTooltipSetting } from '../../../dataHub/tooltipSettings'
 import { client } from '../../../../apollo'
 
 export const MERGED_DIVIDER = '__MM__'
+const MergedTypePropsTuple = [
+  [' coins'], // 0 === false
+  [' coins %', percentFormatter, axisPercentFormatter] // 1 === true
+]
 
 const immutate = v => Object.assign({}, v)
 const keyGetter = ({ key }) => key
@@ -19,13 +24,15 @@ export const checkIfWasNotMerged = (newKey, mergedMetrics) =>
 
 export function buildMergedMetric (baseMetrics) {
   const isPercentMerge = baseMetrics[0].type === 'percent'
-  const labelPostfix = isPercentMerge ? ' coins %' : ' coins'
-  const formatter = isPercentMerge ? percentFormatter : undefined
+  const [labelPostfix, formatter, axisFormatter] = MergedTypePropsTuple[
+    +isPercentMerge
+  ]
 
   const metric = {
     fetch,
     baseMetrics,
     formatter,
+    axisFormatter,
     node: 'line',
     key: baseMetrics
       .map(keyGetter)

--- a/src/ducks/dataHub/tooltipSettings.js
+++ b/src/ducks/dataHub/tooltipSettings.js
@@ -35,12 +35,13 @@ export function FORMATTER (value) {
 }
 
 export function updateTooltipSetting (metric) {
-  const { key, dataKey = key, formatter = FORMATTER, label } = metric
+  const { key, dataKey, formatter = FORMATTER, label, axisFormatter } = metric
 
   metric.formatter = formatter
-  TooltipSetting[dataKey] = {
+  TooltipSetting[dataKey || key] = {
     label,
-    formatter
+    formatter,
+    axisFormatter
   }
 }
 


### PR DESCRIPTION
## Summary
- Appending percent metric's values in the tooltip with a `%`;
- Appending percent at the end of the axis values.

## Screenshots
<img width="248" alt="image" src="https://user-images.githubusercontent.com/25135650/91852192-271aa400-ec69-11ea-96f1-4069ad822f9c.png">
