### PR TITLE
enhance/holder-distribution-tabs

### DIFF
--- a/src/ducks/Stablecoins/HolderDistribution/StablecoinHolderDistribution.js
+++ b/src/ducks/Stablecoins/HolderDistribution/StablecoinHolderDistribution.js
@@ -60,9 +60,7 @@ const StablecoinHolderDistribution = ({ isDesktop, className }) => {
   const [checkedMetrics, setSelectedMetrics] = useState(DEFAULT_CHECKED_METRICS)
   const [metrics, setMetrics] = useState([
     HolderDistributionMetric.holders_distribution_100_to_1k,
-    HolderDistributionMetric.holders_distribution_1k_to_10k,
-    HolderDistributionMetric.percent_of_holders_distribution_combined_balance_100_to_1k,
-    HolderDistributionMetric.percent_of_holders_distribution_combined_balance_1k_to_10k
+    HolderDistributionMetric.holders_distribution_1k_to_10k
   ])
   const [mergedMetrics, setMergedMetrics] = useState([])
   const { currentPhase, setPhase } = usePhase()

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/Tabs.js
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/Tabs.js
@@ -13,7 +13,9 @@ export const Tab = {
 }
 export const TABS = [Tab.PERCENTS, Tab.ABSOLUTE]
 export const TabMetrics = {
-  [Tab.PERCENTS]: HOLDER_DISTRIBUTION_PERCENT_METRICS,
+  // TODO: Change to the PERCENTS metrics when the API will be available [@vanguard | Sep  2, 2020]
+  /* [Tab.PERCENTS]: HOLDER_DISTRIBUTION_PERCENT_METRICS, */
+  [Tab.PERCENTS]: HOLDER_DISTRIBUTION_ABSOLUTE_METRICS,
   [Tab.ABSOLUTE]: HOLDER_DISTRIBUTION_ABSOLUTE_METRICS
 }
 export const TabCombinedBalanceMetrics = {

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/index.js
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/index.js
@@ -3,7 +3,6 @@ import cx from 'classnames'
 import UIButton from '@santiment-network/ui/Button'
 import { Checkbox } from '@santiment-network/ui/Checkboxes'
 import Tabs, { Tab, TabMetrics } from './Tabs'
-import { removeLabelPostfix } from './utils'
 import MetricIcon from '../../../../SANCharts/MetricIcon'
 import styles from './index.module.scss'
 
@@ -36,7 +35,6 @@ const Button = ({ className, isChecked, ...props }) => (
 const ToggleButton = ({
   className,
   metric,
-  label,
   color,
   isActive,
   onClick,
@@ -50,7 +48,7 @@ const ToggleButton = ({
   >
     <MetricIcon node='line' color={color} className={styles.icon} />
     <span className={styles.label}>
-      {label}
+      {metric.label}
       {onUnmerge && (
         <span
           className={styles.unmerge}
@@ -66,14 +64,14 @@ const ToggleButton = ({
   </Button>
 )
 
-const CheckboxButton = ({ metric, label, isChecked, onClick, ...props }) => (
+const CheckboxButton = ({ metric, isChecked, onClick, ...props }) => (
   <Button
     className={isChecked && styles.active}
     onClick={() => onClick(metric)}
     {...props}
   >
     <Checkbox className={styles.checkbox} isActive={isChecked} />
-    {label}
+    {metric.label}
   </Button>
 )
 
@@ -106,6 +104,7 @@ const HolderDistribution = ({
   TabMetrics,
   toggleMetric,
   currentPhase,
+  isWithTabs,
   onMergeClick,
   onMergeConfirmClick,
   onUnmergeClick
@@ -128,21 +127,22 @@ const HolderDistribution = ({
         )}
       </div>
 
-      <Tabs
-        activeTab={activeTab}
-        isIdlePhase={isIdlePhase}
-        setActiveTab={setActiveTab}
-      />
+      {isWithTabs && (
+        <Tabs
+          activeTab={activeTab}
+          isIdlePhase={isIdlePhase}
+          setActiveTab={setActiveTab}
+        />
+      )}
 
       <div className={styles.metrics}>
         {isIdlePhase &&
           mergedMetrics.map(metric => {
-            const { key, label } = metric
+            const { key } = metric
             return (
               <MetricButton
                 key={key}
                 metric={metric}
-                label={label}
                 color={MetricColor[key]}
                 isActive={metrics.includes(metric)}
                 onClick={toggleMetric}
@@ -152,12 +152,11 @@ const HolderDistribution = ({
           })}
 
         {TabMetrics[activeTab].map(metric => {
-          const { key, label } = metric
+          const { key } = metric
           return (
             <MetricButton
               key={key}
               metric={metric}
-              label={removeLabelPostfix(label)}
               color={MetricColor[key]}
               isActive={metrics.includes(metric)}
               isChecked={checkedMetrics && checkedMetrics.has(metric)}

--- a/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/utils.js
+++ b/src/ducks/Studio/Chart/Sidepanel/HolderDistribution/utils.js
@@ -4,10 +4,13 @@ export const LABEL_PERCENT_POSTFIX = ' %'
 
 export const removeLabelPostfix = str => str.replace(LABEL_PERCENT_POSTFIX, '')
 
-export const percentFormatter = value => FORMATTER(value) + '%'
+export const percentFormatter = value => {
+  const result = FORMATTER(value)
+  return Number.isFinite(+result) ? result + '%' : result
+}
 
 function normalizeAxisPercent (value) {
-  if (!Number.isFinite(value)) return
+  if (!Number.isFinite(+value)) return
 
   if (value >= 10) {
     return value.toFixed(2)

--- a/src/ducks/Studio/Widget/HolderDistributionWidget/CombinedBalance.js
+++ b/src/ducks/Studio/Widget/HolderDistributionWidget/CombinedBalance.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import HolderDistributionWidget from './index'
-import ChartWidget from '../ChartWidget'
+import HolderDistributionWidget, { holderDistributionBuilder } from './index'
 import { HOLDER_DISTRIBUTION_PERCENT_METRICS } from '../../Chart/Sidepanel/HolderDistribution/metrics'
 import { TabCombinedBalanceMetrics } from '../../Chart/Sidepanel/HolderDistribution/Tabs'
 
 const HolderDistributionCombinedBalanceWidget = ({ ...props }) => (
   <HolderDistributionWidget
+    isWithTabs
     TabMetrics={TabCombinedBalanceMetrics}
     sidepanelHeader={`${
       props.settings.ticker
@@ -14,14 +14,9 @@ const HolderDistributionCombinedBalanceWidget = ({ ...props }) => (
   />
 )
 
-HolderDistributionCombinedBalanceWidget.new = props =>
-  ChartWidget.new(
-    {
-      metrics: HOLDER_DISTRIBUTION_PERCENT_METRICS,
-      mergedMetrics: [],
-      ...props
-    },
-    HolderDistributionCombinedBalanceWidget
-  )
+HolderDistributionCombinedBalanceWidget.new = holderDistributionBuilder(
+  HolderDistributionCombinedBalanceWidget,
+  HOLDER_DISTRIBUTION_PERCENT_METRICS
+)
 
 export default HolderDistributionCombinedBalanceWidget

--- a/src/ducks/Studio/Widget/HolderDistributionWidget/index.js
+++ b/src/ducks/Studio/Widget/HolderDistributionWidget/index.js
@@ -9,7 +9,7 @@ import ChartActiveMetrics from '../../Chart/ActiveMetrics'
 import { TOP_HOLDERS_PANE } from '../../Chart/Sidepanel/panes'
 import {
   HolderDistributionMetric,
-  HOLDER_DISTRIBUTION_PERCENT_METRICS
+  HOLDER_DISTRIBUTION_ABSOLUTE_METRICS
 } from '../../Chart/Sidepanel/HolderDistribution/metrics'
 import { useChartColors } from '../../../Chart/colors'
 import { usePressedModifier } from '../../../../hooks/keyboard'
@@ -30,6 +30,7 @@ const HolderDistributionWidget = ({
   widget,
   sidepanelHeader,
   TabMetrics,
+  isWithTabs,
   ...props
 }) => {
   const [isOpened, setIsOpened] = useState(true)
@@ -104,6 +105,7 @@ const HolderDistributionWidget = ({
           checkedMetrics={checkedMetrics}
           MetricColor={MetricColor}
           TabMetrics={TabMetrics}
+          isWithTabs={isWithTabs}
           toggleMetric={toggleWidgetMetric}
           toggleChartSidepane={toggleSidepane}
           onMergeClick={onMergeClick}
@@ -117,16 +119,19 @@ const HolderDistributionWidget = ({
   )
 }
 
-const newHolderDistributionWidget = props =>
+export const holderDistributionBuilder = (widget, metrics) => props =>
   ChartWidget.new(
     {
-      metrics: HOLDER_DISTRIBUTION_PERCENT_METRICS,
       mergedMetrics: [],
+      metrics,
       ...props
     },
-    HolderDistributionWidget
+    widget
   )
 
-HolderDistributionWidget.new = newHolderDistributionWidget
+HolderDistributionWidget.new = holderDistributionBuilder(
+  HolderDistributionWidget,
+  HOLDER_DISTRIBUTION_ABSOLUTE_METRICS
+)
 
 export default HolderDistributionWidget

--- a/src/ducks/dataHub/tooltipSettings.js
+++ b/src/ducks/dataHub/tooltipSettings.js
@@ -23,6 +23,10 @@ export function FORMATTER (value) {
     return 'No data'
   }
 
+  if (value === 0) {
+    return 0
+  }
+
   if (value > LARGE_NUMBER_THRESHOLD) {
     return millify(value, 2)
   }

--- a/src/ducks/dataHub/tooltipSettings.js
+++ b/src/ducks/dataHub/tooltipSettings.js
@@ -23,6 +23,7 @@ export function FORMATTER (value) {
     return 'No data'
   }
 
+  // NOTE: Handling float type 0's (e.g. "0.0000") [@vanguard | Sep  2, 2020]
   if (value === 0) {
     return 0
   }


### PR DESCRIPTION
## Summary
Hiding `Percents` tab for `Holders Distribution` widget since the API is not available 