### PR TITLE
fix/holders-distribution-combined-balance-deletion

### DIFF
--- a/src/ducks/Studio/index.js
+++ b/src/ducks/Studio/index.js
@@ -100,6 +100,7 @@ export const Studio = ({
 
     if (
       widget.Widget !== HolderDistributionWidget &&
+      widget.Widget !== HolderDistributionCombinedBalanceWidget &&
       metrics.length === 0 &&
       widget.comparables.length === 0
     ) {


### PR DESCRIPTION
## Summary
Allowing the `HolderDistributionCombinedBalanceWidget` to be with no selected metrics.