### PR TITLE
add source metrics(without using slug)

### DIFF
--- a/src/ducks/GetTimeSeries/queries/GET_SOURCE_METRIC.js
+++ b/src/ducks/GetTimeSeries/queries/GET_SOURCE_METRIC.js
@@ -1,0 +1,19 @@
+import gql from 'graphql-tag'
+
+export const GET_SOURCE_METRIC = ({ key, queryKey }) => {
+  return gql`
+    query getMetric(
+      $from: DateTime!
+      $to: DateTime!
+      $interval: interval
+      $source: String
+    ) {
+      getMetric(metric: "${queryKey}") {
+        timeseriesData(selector: { source: $source}, from: $from, to: $to, interval: $interval) {
+          datetime
+          ${key}: value
+        }
+      }
+    }
+  `
+}

--- a/src/ducks/Studio/timeseries/fetcher.js
+++ b/src/ducks/Studio/timeseries/fetcher.js
@@ -7,6 +7,11 @@ import { GAS_USED_QUERY } from '../../GetTimeSeries/queries/gas_used'
 import { HISTORICAL_BALANCE_QUERY } from '../../HistoricalBalance/common/queries'
 import { TOP_HOLDERS_PERCENT_OF_TOTAL_SUPPLY } from '../../GetTimeSeries/queries/top_holders_percent_of_total_supply'
 import { ETH_SPENT_OVER_TIME_QUERY } from '../../GetTimeSeries/queries/eth_spent_over_time_query'
+import { GET_SOURCE_METRIC } from '../../GetTimeSeries/queries/GET_SOURCE_METRIC'
+import {
+  SOCIAL_ACTIVE_USERS_TELEGRAM,
+  SOCIAL_ACTIVE_USERS_TWITTER
+} from '../../dataHub/submetrics'
 import { client } from '../../../apollo'
 
 export const preTransform = ({
@@ -57,6 +62,14 @@ Object.assign(Fetcher, {
   minersBalance: {
     query: MINERS_BALANCE_QUERY,
     preTransform: extractTimeseries('minersBalance')
+  },
+  social_active_users_telegram: {
+    query: GET_SOURCE_METRIC(SOCIAL_ACTIVE_USERS_TELEGRAM),
+    preTransform
+  },
+  social_active_users_twitter: {
+    query: GET_SOURCE_METRIC(SOCIAL_ACTIVE_USERS_TWITTER),
+    preTransform
   }
 })
 

--- a/src/ducks/dataHub/metrics/index.js
+++ b/src/ducks/dataHub/metrics/index.js
@@ -482,6 +482,7 @@ export const Metric = {
     group: 'Social Active Users',
     shortLabel: 'Soc. Act. Us.',
     node: 'bar',
+    withoutRoot: true,
     showRoot: false,
     isBeta: true,
     checkIsVisible: ({ isBeta: isBetaApp }) => isBetaApp

--- a/src/ducks/dataHub/submetrics.js
+++ b/src/ducks/dataHub/submetrics.js
@@ -21,6 +21,31 @@ export const TopTransactionsTableMetric = {
   abbreviation: 'ttt'
 }
 
+export const SOCIAL_ACTIVE_USERS_TELEGRAM = {
+  ...Metric.social_active_users,
+  showRoot: true,
+  key: 'social_active_users_telegram',
+  label: 'Social Active Users (Telegram)',
+  shortLabel: 'Soc. Act. Us. Tg.',
+  channel: 'telegram',
+  reqMeta: {
+    source: 'telegram',
+    slug: undefined
+  }
+}
+
+export const SOCIAL_ACTIVE_USERS_TWITTER = {
+  ...Metric.social_active_users,
+  showRoot: true,
+  key: 'social_active_users_twitter',
+  label: 'Social Active Users (Twitter)',
+  shortLabel: 'Soc. Act. Us. Tw.',
+  channel: 'twitter',
+  reqMeta: {
+    source: 'twitter_crypto'
+  }
+}
+
 export const Submetrics = {
   [Metric.price_usd.key]: [
     {
@@ -65,28 +90,8 @@ export const Submetrics = {
     }
   })),
   [Metric.social_active_users.key]: [
-    {
-      ...Metric.social_active_users,
-      showRoot: true,
-      key: 'social_active_users_telegram',
-      label: 'Social Active Users (Telegram)',
-      shortLabel: 'Soc. Act. Us. Tg.',
-      channel: 'telegram',
-      reqMeta: {
-        source: 'telegram'
-      }
-    },
-    {
-      ...Metric.social_active_users,
-      showRoot: true,
-      key: 'social_active_users_twitter',
-      label: 'Social Active Users (Twitter)',
-      shortLabel: 'Soc. Act. Us. Tw.',
-      channel: 'twitter',
-      reqMeta: {
-        source: 'twitter_crypto'
-      }
-    }
+    SOCIAL_ACTIVE_USERS_TELEGRAM,
+    SOCIAL_ACTIVE_USERS_TWITTER
   ]
 }
 


### PR DESCRIPTION
**Summary**

Made 'social_active_users' metric as 'source' metric. Without using slug in query.

**Screenshots**

![image](https://user-images.githubusercontent.com/14061779/93059244-1b6faa00-f679-11ea-8f8e-bec84ce298df.png)
