### PR TITLE
feature/metric-exchange-setting-tabs

### DIFF
--- a/src/ducks/Studio/Chart/MetricSettings/Dropdown.js
+++ b/src/ducks/Studio/Chart/MetricSettings/Dropdown.js
@@ -3,8 +3,21 @@ import ContextMenu from '@santiment-network/ui/ContextMenu'
 import styles from './index.module.scss'
 
 export const useDropdown = () => {
-  const activeRef = useRef()
+  const activeRef = useRef(null)
   const [isOpened, setIsOpened] = useState(false)
+  const stateRef = useRef(isOpened)
+  stateRef.current = isOpened
+  const Dropdown = useRef(props => (
+    <ContextMenu
+      {...props}
+      open={stateRef.current}
+      className={styles.tooltip}
+      position='bottom'
+      on='click'
+      onOpen={open}
+      onClose={close}
+    />
+  )).current
 
   useEffect(
     () => {
@@ -30,16 +43,6 @@ export const useDropdown = () => {
   return {
     activeRef,
     close,
-    Dropdown: props => (
-      <ContextMenu
-        {...props}
-        open={isOpened}
-        className={styles.tooltip}
-        position='bottom'
-        on='click'
-        onOpen={open}
-        onClose={close}
-      />
-    )
+    Dropdown
   }
 }

--- a/src/ducks/Studio/Chart/MetricSettings/ExchangeSetting/Tabs.js
+++ b/src/ducks/Studio/Chart/MetricSettings/ExchangeSetting/Tabs.js
@@ -3,8 +3,8 @@ import UITabs from '@santiment-network/ui/Tabs'
 import styles from './Tabs.module.scss'
 
 export const Tab = {
-  CEX: 'Cex',
-  DEX: 'Dex'
+  CEX: 'CEX',
+  DEX: 'DEX'
 }
 const TABS = Object.values(Tab)
 

--- a/src/ducks/Studio/Chart/MetricSettings/ExchangeSetting/Tabs.js
+++ b/src/ducks/Studio/Chart/MetricSettings/ExchangeSetting/Tabs.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import UITabs from '@santiment-network/ui/Tabs'
+import styles from './Tabs.module.scss'
+
+export const Tab = {
+  CEX: 'Cex',
+  DEX: 'Dex'
+}
+const TABS = Object.values(Tab)
+
+const Tabs = ({ activeTab, setActiveTab }) => (
+  <UITabs
+    options={TABS}
+    className={styles.tabs}
+    classes={styles}
+    defaultSelectedIndex={activeTab}
+    onSelect={tab => setActiveTab(tab)}
+  />
+)
+
+export default Tabs

--- a/src/ducks/Studio/Chart/MetricSettings/ExchangeSetting/Tabs.module.scss
+++ b/src/ducks/Studio/Chart/MetricSettings/ExchangeSetting/Tabs.module.scss
@@ -1,0 +1,17 @@
+.tabs {
+  margin: 0 0 8px;
+  display: flex;
+}
+
+.tab {
+  padding: 0 8px 7px;
+  margin: 0;
+  color: var(--casper);
+  font-weight: 600;
+  flex: 1;
+  justify-content: center;
+}
+
+.selectedTab {
+  color: var(--rhino);
+}

--- a/src/ducks/Studio/Chart/MetricSettings/ExchangeSetting/hooks.js
+++ b/src/ducks/Studio/Chart/MetricSettings/ExchangeSetting/hooks.js
@@ -2,17 +2,17 @@ import { useQuery } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 
 const METRIC_EXCHANGES_QUERY = gql`
-  query($slug: String!) {
-    allExchanges(slug: $slug)
+  query($slug: String!, $isDex: Boolean) {
+    allExchanges(slug: $slug, isDex: $isDex)
   }
 `
 
 export const DEFAULT_EXCHANGE = 'All'
 const DEFAULT_EXCHANGES = [DEFAULT_EXCHANGE]
 
-export function useMetricExchanges (slug) {
+export function useMetricExchanges (slug, isDex) {
   const { data, loading } = useQuery(METRIC_EXCHANGES_QUERY, {
-    variables: { slug }
+    variables: { slug, isDex }
   })
 
   return {

--- a/src/ducks/Studio/Chart/MetricSettings/ExchangeSetting/hooks.js
+++ b/src/ducks/Studio/Chart/MetricSettings/ExchangeSetting/hooks.js
@@ -7,7 +7,7 @@ const METRIC_EXCHANGES_QUERY = gql`
   }
 `
 
-export const DEFAULT_EXCHANGE = 'All'
+export const DEFAULT_EXCHANGE = 'All (CEX+DEX)'
 const DEFAULT_EXCHANGES = [DEFAULT_EXCHANGE]
 
 export function useMetricExchanges (slug, isDex) {

--- a/src/ducks/Studio/Chart/MetricSettings/ExchangeSetting/index.js
+++ b/src/ducks/Studio/Chart/MetricSettings/ExchangeSetting/index.js
@@ -1,15 +1,19 @@
-import React, { useMemo } from 'react'
+import React, { useState, useMemo } from 'react'
 import Button from '@santiment-network/ui/Button'
 import Loader from '@santiment-network/ui/Loader/Loader'
 import { useMetricExchanges, DEFAULT_EXCHANGE } from './hooks'
+import Tabs, { Tab } from './Tabs'
 import { useDropdown } from '../Dropdown'
 import Setting from '../Setting'
 import { mergeMetricSettingMap } from '../../../utils'
 import styles from '../index.module.scss'
 
+const { CEX, DEX } = Tab
+
 const ExchangeSetting = ({ metric, widget, rerenderWidgets, slug }) => {
   const { activeRef, close, Dropdown } = useDropdown()
-  const { exchanges, loading } = useMetricExchanges(slug)
+  const [activeTab, setActiveTab] = useState(CEX)
+  const { exchanges, loading } = useMetricExchanges(slug, activeTab === DEX)
   const owner = useMemo(
     () => {
       const settings = widget.MetricSettingMap.get(metric)
@@ -39,18 +43,21 @@ const ExchangeSetting = ({ metric, widget, rerenderWidgets, slug }) => {
 
   return (
     <Dropdown trigger={<Setting>Exchange {owner}</Setting>}>
-      {exchanges &&
-        exchanges.map(exchange => (
-          <Button
-            key={exchange}
-            variant='ghost'
-            isActive={owner === exchange}
-            onClick={() => onChange(exchange)}
-            forwardedRef={owner === exchange ? activeRef : undefined}
-          >
-            {exchange}
-          </Button>
-        ))}
+      <Tabs activeTab={activeTab} setActiveTab={setActiveTab} />
+      <div className={styles.exchanges}>
+        {exchanges &&
+          exchanges.map(exchange => (
+            <Button
+              key={exchange}
+              variant='ghost'
+              isActive={owner === exchange}
+              onClick={() => onChange(exchange)}
+              forwardedRef={owner === exchange ? activeRef : undefined}
+            >
+              {exchange}
+            </Button>
+          ))}
+      </div>
       {loading && <Loader className={styles.loader} />}
     </Dropdown>
   )

--- a/src/ducks/Studio/Chart/MetricSettings/index.module.scss
+++ b/src/ducks/Studio/Chart/MetricSettings/index.module.scss
@@ -82,3 +82,10 @@
   font-size: 4px;
   margin: 5px auto 2px;
 }
+
+.exchanges {
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+  min-width: 165px;
+}


### PR DESCRIPTION
## Summary
`Exchange Inflow/Outlflow` metrics' `Echange` setting now has two exchange categories: `Cex`, `Dex`.

## Screenshots
<img width="211" alt="image" src="https://user-images.githubusercontent.com/25135650/93202633-ad4fe380-f75b-11ea-9784-b05721b0d80d.png">
