### PR TITLE
feat: add paywall into dashboard charts

### DIFF
--- a/src/components/DashboardMetricChart/DashboardMetricChart.js
+++ b/src/components/DashboardMetricChart/DashboardMetricChart.js
@@ -22,6 +22,7 @@ import {
 import { useMirroredTransformer } from '../../ducks/Studio/Widget/utils'
 import { useDomainGroups } from '../../ducks/Chart/hooks'
 import { extractMirrorMetricsDomainGroups } from '../../ducks/Chart/utils'
+import PaywallInfo from '../../ducks/Studio/Chart/PaywallInfo'
 import styles from './DashboardMetricChart.module.scss'
 
 const useBrush = ({ data, settings, setSettings, metrics, slug }) => {
@@ -137,6 +138,11 @@ const DashboardMetricChart = ({
               className={styles.sharedAxisToggle}
             />
           )}
+
+          <div className={styles.gaps}>
+            <PaywallInfo metrics={activeMetrics} />
+          </div>
+
           <DesktopOnly>
             <DashboardIntervals
               interval={intervalSelector}


### PR DESCRIPTION
**Summary**

Add paywall to header of dashboard's chart

**Screenshots**

![image](https://user-images.githubusercontent.com/14061779/95458509-ee15d380-097a-11eb-9fd9-2173de10ef6f.png)
