### PR TITLE
enhance/mvrv-formatting

### DIFF
--- a/src/ducks/dataHub/metrics/formatters.js
+++ b/src/ducks/dataHub/metrics/formatters.js
@@ -18,6 +18,8 @@ export const absoluteToPercentsFormatter = val => {
   return percentageFormatter(percents.toFixed(2))
 }
 
+export const mvrvFormatter = val => absoluteToPercentsFormatter(val - 1)
+
 export const tooltipValueFormatter = ({
   value,
   formatter,

--- a/src/ducks/dataHub/metrics/index.js
+++ b/src/ducks/dataHub/metrics/index.js
@@ -4,7 +4,8 @@ import {
   ethFormatter,
   percentageFormatter,
   absoluteToPercentsFormatter,
-  tooltipValueFormatter
+  tooltipValueFormatter,
+  mvrvFormatter
 } from './formatters'
 import { updateTooltipSettings } from '../tooltipSettings'
 import { Node } from '../../Chart/nodes'
@@ -161,7 +162,8 @@ export const Metric = {
     fullTitle: 'Market Value To Realized Value',
     shortLabel: 'MVRV',
     abbreviation: 'mvrv',
-    video: 'https://www.youtube.com/watch?v=foMhhHbCgBE'
+    video: 'https://www.youtube.com/watch?v=foMhhHbCgBE',
+    formatter: mvrvFormatter
   },
   mvrv_long_short_diff_usd: {
     category: 'On-chain',


### PR DESCRIPTION
## Summary
Formatting MVRV as a percentage difference.
Example: 
- `1.25` MVRV value is displayed as the `25%`;
- `0.83` MVRV value is displayed as the `-17%`;

## Screenshots
<img width="414" alt="image" src="https://user-images.githubusercontent.com/25135650/95978480-e9da3200-0e22-11eb-96ca-db24258f675b.png">
