### PR TITLE
fix(dashboards): add left axes for charts

### DIFF
--- a/src/components/DashboardMetricChart/DashboardMetricChart.js
+++ b/src/components/DashboardMetricChart/DashboardMetricChart.js
@@ -82,7 +82,8 @@ const DashboardMetricChart = ({
   rootMetric,
   metricsColor,
   setMeasurement,
-  measurement
+  measurement,
+  sliceMetricsCount = 1
 }) => {
   const MetricTransformer = useMirroredTransformer(metrics)
 
@@ -203,6 +204,7 @@ const DashboardMetricChart = ({
         domainGroups={domainGroups}
         mirrorDomainGroups={mirrorDomainGroups}
         isCartesianGridActive={true}
+        sliceMetricsCount={sliceMetricsCount}
       />
 
       <MobileOnly>

--- a/src/components/DashboardMetricChart/DashboardMetricChartWrapper.js
+++ b/src/components/DashboardMetricChart/DashboardMetricChartWrapper.js
@@ -33,13 +33,17 @@ const DashboardMetricChartWrapper = ({
   domainGroups,
   axesMetricKeysDefault,
   mirrorDomainGroups,
-  isCartesianGridActive = false
+  isCartesianGridActive = false,
+  sliceMetricsCount = 1
 }) => {
   const categories = useMetricCategories(metrics)
 
   const axesMetricKeys =
     axesMetricKeysDefault ||
-    useAxesMetricsKey(metrics, isDomainGroupingActive).slice(0, 1)
+    useAxesMetricsKey(metrics, isDomainGroupingActive).slice(
+      0,
+      sliceMetricsCount
+    )
 
   return (
     <Chart

--- a/src/ducks/Stablecoins/StablecoinsMarketCap/StablecoinsMarketCap.js
+++ b/src/ducks/Stablecoins/StablecoinsMarketCap/StablecoinsMarketCap.js
@@ -20,6 +20,7 @@ const StablecoinsMarketCap = () => {
       setRootMetric={setRootMetric}
       rootMetric={rootMetric}
       metricsColor={StablecoinColor}
+      sliceMetricsCount={2}
     />
   )
 }


### PR DESCRIPTION
**Summary**

Add left axes for 'TOTAL_MARKET' on dashboards chart

**Screeenshots**

![image](https://user-images.githubusercontent.com/14061779/96228439-47df5480-0f9e-11eb-97b4-b098ca1fe090.png)
