### PR TITLE
fix/social-grid/small-display-alert-box-position

### DIFF
--- a/src/ducks/Chart/Signals/Add.js
+++ b/src/ducks/Chart/Signals/Add.js
@@ -1,9 +1,29 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import Alerts from '../../Studio/Alerts'
 import styles from './index.module.scss'
 
-export default ({ hoverPoint, ...rest }) => (
-  <div className={styles.add} style={{ '--top': hoverPoint.y + 'px' }}>
-    <Alerts {...rest} {...hoverPoint} className={styles.alerts} />
-  </div>
-)
+export default ({ hoverPoint, ...rest }) => {
+  const containerRef = useRef(null)
+
+  useEffect(
+    () => {
+      const container = containerRef.current
+
+      if (container && container.getBoundingClientRect().x < -15) {
+        container.classList.add(styles.alerts_right)
+      }
+    },
+    [containerRef]
+  )
+
+  return (
+    <div className={styles.add} style={{ '--top': hoverPoint.y + 'px' }}>
+      <Alerts
+        {...rest}
+        {...hoverPoint}
+        className={styles.alerts}
+        containerRef={containerRef}
+      />
+    </div>
+  )
+}

--- a/src/ducks/Chart/Signals/index.module.scss
+++ b/src/ducks/Chart/Signals/index.module.scss
@@ -29,12 +29,18 @@
 }
 
 .alerts {
-  display: none;
   width: 370px;
   position: absolute;
   right: 17px;
   transform: translateY(-50%);
   max-width: initial !important;
+  opacity: 0;
+  pointer-events: none;
+
+  &_right {
+    right: initial;
+    left: 17px;
+  }
 }
 
 .add {
@@ -63,8 +69,9 @@
     background-color: $fiord;
 
     .alerts {
-      display: block;
+      opacity: 1;
       top: 50%;
+      pointer-events: initial;
 
       &::before {
         content: '';
@@ -73,6 +80,11 @@
         top: 30%;
         width: 13px;
         left: 100%;
+      }
+
+      &_right::before {
+        left: initial;
+        right: 100%;
       }
     }
   }

--- a/src/ducks/Studio/Alerts/index.js
+++ b/src/ducks/Studio/Alerts/index.js
@@ -20,11 +20,17 @@ const Alert = ({ alert, render, createAlert }) => {
   )
 }
 
-export default ({ className, metricValues, onDialogClose, ...rest }) => {
+export default ({
+  className,
+  metricValues,
+  containerRef,
+  onDialogClose,
+  ...rest
+}) => {
   const suggestions = useSuggestions(metricValues)
 
   return (
-    <div className={cx(styles.wrapper, className)}>
+    <div ref={containerRef} className={cx(styles.wrapper, className)}>
       <div className={styles.header}>
         Create alert if:
         <SignalMasterModalForm


### PR DESCRIPTION
## Summary
Displaying alert's suggestions on the right when they can't fit inside the viewport.
## Screenshots
<img width="714" alt="image" src="https://user-images.githubusercontent.com/25135650/97871727-ee10b580-1d25-11eb-8e7c-0b10d12358e1.png">
