### PR TITLE
enhance/studio-metrics-lock

### DIFF
--- a/src/components/ToggleSetting/index.js
+++ b/src/components/ToggleSetting/index.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import cx from 'classnames'
+import Toggle from '@santiment-network/ui/Toggle'
+import Button from '@santiment-network/ui/Button'
+import styles from './index.module.scss'
+
+const ToggleSetting = ({ title, isActive, className, ...props }) => (
+  <Button
+    {...props}
+    fluid
+    variant='ghost'
+    className={cx(styles.btn, className)}
+  >
+    {title}
+    <Toggle isActive={isActive} className={styles.toggle} />
+  </Button>
+)
+
+export default ToggleSetting

--- a/src/components/ToggleSetting/index.module.scss
+++ b/src/components/ToggleSetting/index.module.scss
@@ -1,0 +1,7 @@
+.btn {
+  justify-content: space-between;
+}
+
+.toggle {
+  margin-left: 16px;
+}

--- a/src/ducks/Studio/Chart/ActiveMetrics.js
+++ b/src/ducks/Studio/Chart/ActiveMetrics.js
@@ -84,7 +84,7 @@ const MetricButton = ({
       )}
       aria-invalid={error}
     >
-      {metric.base && <LockInfo metric={metric} />}
+      {metric.project && <LockInfo metric={metric} />}
 
       {isWithIcon ? (
         isLoading ? (

--- a/src/ducks/Studio/Chart/ActiveMetrics.js
+++ b/src/ducks/Studio/Chart/ActiveMetrics.js
@@ -33,20 +33,27 @@ const Customization = ({ metric, onClick }) => (
   </ExplanationTooltip>
 )
 
-const LockIcon = () => (
-  <div className={styles.lock}>
-    <svg width='8' height='8' xmlns='http://www.w3.org/2000/svg'>
-      <path
-        fillRule='evenodd'
-        clipRule='evenodd'
-        d='M3 3h2v-.5c0-.4-.12-.63-.23-.75-.09-.1-.3-.25-.77-.25-.48 0-.68.15-.77.25-.11.12-.23.35-.23.75V3zM1.5 3h-.13C.9 3 .5 3.33.5 3.73v3.54c0 .4.4.73.88.73h5.25c.48 0 .87-.33.87-.73V3.73c0-.4-.4-.73-.88-.73H6.5v-.5C6.5 1.12 5.67 0 4 0S1.5 1.12 1.5 2.5V3z'
-      />
-    </svg>
-  </div>
+const LockInfo = ({ metric }) => (
+  <ExplanationTooltip
+    offsetY={6}
+    align='start'
+    text={`Metric is locked to ${metric.project.ticker}`}
+  >
+    <div className={styles.lock}>
+      <svg width='8' height='8' xmlns='http://www.w3.org/2000/svg'>
+        <path
+          fillRule='evenodd'
+          clipRule='evenodd'
+          d='M3 3h2v-.5c0-.4-.12-.63-.23-.75-.09-.1-.3-.25-.77-.25-.48 0-.68.15-.77.25-.11.12-.23.35-.23.75V3zM1.5 3h-.13C.9 3 .5 3.33.5 3.73v3.54c0 .4.4.73.88.73h5.25c.48 0 .87-.33.87-.73V3.73c0-.4-.4-.73-.88-.73H6.5v-.5C6.5 1.12 5.67 0 4 0S1.5 1.12 1.5 2.5V3z'
+        />
+      </svg>
+    </div>
+  </ExplanationTooltip>
 )
 
 const MetricButton = ({
   className,
+  metrics,
   metric,
   colors,
   error,
@@ -77,7 +84,8 @@ const MetricButton = ({
       )}
       aria-invalid={error}
     >
-      {metric.base && <LockIcon />}
+      {metric.base && <LockInfo metric={metric} />}
+
       {isWithIcon ? (
         isLoading ? (
           <div className={styles.loader} />
@@ -108,6 +116,7 @@ const MetricButton = ({
         <Actions isActive={metricSettings === metric}>
           <Customization metric={metric} onClick={onSettingsClick} />
           <MetricLock
+            metrics={metrics}
             metric={metric}
             project={settings}
             onClick={onLockClick}
@@ -162,6 +171,7 @@ export default ({
     <MetricButton
       key={metric.key}
       className={className}
+      metrics={activeMetrics}
       metric={metric}
       colors={MetricColor}
       error={ErrorMsg[metric.key]}

--- a/src/ducks/Studio/Chart/ActiveMetrics.module.scss
+++ b/src/ducks/Studio/Chart/ActiveMetrics.module.scss
@@ -13,6 +13,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
+
+  &_disabled {
+    fill: var(--mystic);
+  }
 }
 
 .btn {

--- a/src/ducks/Studio/Chart/ActiveMetrics.module.scss
+++ b/src/ducks/Studio/Chart/ActiveMetrics.module.scss
@@ -15,7 +15,7 @@
   justify-content: center;
 
   &_disabled {
-    fill: var(--mystic);
+    fill: var(--mystic) !important;
   }
 }
 

--- a/src/ducks/Studio/Chart/MetricLock.js
+++ b/src/ducks/Studio/Chart/MetricLock.js
@@ -1,4 +1,6 @@
-import React from 'react'
+import React, { useMemo } from 'react'
+import cx from 'classnames'
+import { convertBaseProjectMetric } from '../metrics'
 import ExplanationTooltip from '../../../components/ExplanationTooltip/ExplanationTooltip'
 import styles from './ActiveMetrics.module.scss'
 
@@ -25,14 +27,21 @@ const UnlockIcon = props => (
   </svg>
 )
 
-const MetricLock = ({ metric, project, onClick }) => {
+const MetricLock = ({ metrics, metric, project, onClick }) => {
   const isLocked = metric.base
   const explanation = isLocked ? LOCKED_TEXT : UNLOCKED_TEXT + project.ticker
   const Icon = isLocked ? UnlockIcon : LockIcon
+  const isDisabled = useMemo(
+    () => metrics.includes(convertBaseProjectMetric(metric, project)),
+    [metrics, metric, project]
+  )
 
   return (
     <ExplanationTooltip text={explanation}>
-      <div className={styles.settings__btn} onClick={onClick}>
+      <div
+        className={cx(styles.settings__btn, isDisabled && styles.lock_disabled)}
+        onClick={isDisabled ? undefined : onClick}
+      >
         <Icon />
       </div>
     </ExplanationTooltip>

--- a/src/ducks/Studio/Chart/MetricSettings/IndicatorsSetting.js
+++ b/src/ducks/Studio/Chart/MetricSettings/IndicatorsSetting.js
@@ -66,7 +66,7 @@ export function buildIndicatorMetric (metric, indicator) {
   const { key, label } = metric
   const indicatorMetric = deriveMetric(metric, {
     indicator,
-    metricKey: key,
+    base: metric,
     node: Node.LINE,
     key: `${indicator.key}_${key}`,
     label: `${label} ${indicator.label}`,

--- a/src/ducks/Studio/Chart/MetricSettings/IndicatorsSetting.js
+++ b/src/ducks/Studio/Chart/MetricSettings/IndicatorsSetting.js
@@ -2,10 +2,10 @@ import React, { useMemo } from 'react'
 import Setting from './Setting'
 import { useDropdown } from './Dropdown'
 import { getMetricSetting } from '../../utils'
-import { Setting as Option } from '../../../SANCharts/ChartSettingsContextMenu'
 import { deriveMetric } from '../../../dataHub/metrics'
 import { updateTooltipSetting } from '../../../dataHub/tooltipSettings'
 import { Node } from '../../../Chart/nodes'
+import Option from '../../../../components/ToggleSetting'
 
 const RAW_INDICATORS = {
   MA: {

--- a/src/ducks/Studio/Widget/ChartWidget.js
+++ b/src/ducks/Studio/Widget/ChartWidget.js
@@ -10,9 +10,8 @@ import StudioChart from '../Chart'
 import { dispatchWidgetMessage } from '../widgetMessage'
 import { DEFAULT_OPTIONS } from '../defaults'
 import { getMetricSetting, calculateMovingAverageFromInterval } from '../utils'
-import { newProjectMetric, getMetricByKey } from '../metrics'
+import { convertBaseProjectMetric } from '../metrics'
 import { useTimeseries } from '../timeseries/hooks'
-import { buildIndicatorMetric } from '../Chart/MetricSettings/IndicatorsSetting'
 import { useEdgeGaps, useClosestValueData } from '../../Chart/hooks'
 import { useSyncDateEffect } from '../../Chart/sync'
 import { TooltipSetting } from '../../dataHub/tooltipSettings'
@@ -143,20 +142,7 @@ export const Chart = ({
   }
 
   function toggleMetricLock (metric) {
-    let newMetric
-
-    if (metric.base) {
-      newMetric = metric.indicator
-        ? buildIndicatorMetric(metric.base, metric.indicator)
-        : metric.base
-    } else if (metric.indicator) {
-      newMetric = buildIndicatorMetric(
-        newProjectMetric(settings, getMetricByKey(metric.metricKey)),
-        metric.indicator
-      )
-    } else {
-      newMetric = newProjectMetric(settings, metric)
-    }
+    const newMetric = convertBaseProjectMetric(metric, settings)
 
     if (metrics.includes(newMetric)) return
 

--- a/src/ducks/Studio/Widget/ChartWidget.js
+++ b/src/ducks/Studio/Widget/ChartWidget.js
@@ -165,6 +165,11 @@ export const Chart = ({
       toggleIndicatorMetric(newMetric)
     }
 
+    const newMap = new Map(widget.MetricSettingMap)
+    newMap.set(newMetric, getMetricSetting(newMap, metric))
+    newMap.delete(metric)
+    widget.MetricSettingMap = newMap
+
     for (let i = 0; i < metrics.length; i++) {
       if (metrics[i] !== metric) continue
 

--- a/src/ducks/Studio/metrics.js
+++ b/src/ducks/Studio/metrics.js
@@ -1,3 +1,4 @@
+import { buildIndicatorMetric } from './Chart/MetricSettings/IndicatorsSetting'
 import { HolderDistributionMetric } from './Chart/Sidepanel/HolderDistribution/metrics'
 import { tryMapToTimeboundMetric } from '../dataHub/timebounds'
 import { updateTooltipSetting } from '../dataHub/tooltipSettings'
@@ -76,4 +77,21 @@ export function getProjectMetricByKey (key, connector = METRIC_CONNECTOR) {
     metric,
     isProjectMetricConnector ? key : buildKey(slug, ticker, metricKey)
   )
+}
+
+export function convertBaseProjectMetric (metric, project) {
+  if (metric.base) {
+    return metric.indicator
+      ? buildIndicatorMetric(metric.base, metric.indicator)
+      : metric.base
+  }
+
+  if (metric.indicator) {
+    return buildIndicatorMetric(
+      newProjectMetric(project, getMetricByKey(metric.metricKey)),
+      metric.indicator
+    )
+  }
+
+  return newProjectMetric(project, metric)
 }

--- a/src/ducks/Studio/metrics.js
+++ b/src/ducks/Studio/metrics.js
@@ -1,4 +1,4 @@
-import { buildIndicatorMetric } from './Chart/MetricSettings/IndicatorsSetting'
+import { cacheIndicator } from './Chart/MetricSettings/IndicatorsSetting'
 import { HolderDistributionMetric } from './Chart/Sidepanel/HolderDistribution/metrics'
 import { tryMapToTimeboundMetric } from '../dataHub/timebounds'
 import { updateTooltipSetting } from '../dataHub/tooltipSettings'
@@ -80,15 +80,14 @@ export function getProjectMetricByKey (key, connector = METRIC_CONNECTOR) {
 }
 
 export function convertBaseProjectMetric (metric, project) {
-  if (metric.base) {
-    return metric.indicator
-      ? buildIndicatorMetric(metric.base, metric.indicator)
-      : metric.base
+  if (metric.project) {
+    const { base } = metric
+    return metric.indicator ? cacheIndicator(base.base, metric.indicator) : base
   }
 
   if (metric.indicator) {
-    return buildIndicatorMetric(
-      newProjectMetric(project, getMetricByKey(metric.metricKey)),
+    return cacheIndicator(
+      newProjectMetric(project, metric.base),
       metric.indicator
     )
   }

--- a/src/ducks/Studio/timeseries/errors.js
+++ b/src/ducks/Studio/timeseries/errors.js
@@ -5,7 +5,7 @@ const SUBSCRIPTION_INTERVAL = {
 }
 
 const PROJECT_FETCH = {
-  anchor: 'for project with slug: ',
+  anchor: 'for project with slug',
   msg: "Can't fetch data for this project"
 }
 


### PR DESCRIPTION
## Summary
- Locked metric explanation tooltip;
- Enabled/disabled `Lock` action state;
- Sharing metric settings after `lock`/`unlock` action;
## Screenshots
- Explanation tooltip
<img width="208" alt="image" src="https://user-images.githubusercontent.com/25135650/99383128-7ffbef00-28de-11eb-857f-e95ee822d1d4.png">
- Metric lock button is disabled, since there already is the result of the lock action
<img width="373" alt="image" src="https://user-images.githubusercontent.com/25135650/99383153-87bb9380-28de-11eb-8f4c-050e14abb856.png">
