### PR TITLE
feat: add percent key for age_consumend in screener

### DIFF
--- a/src/ducks/Watchlists/Widgets/Filter/dataHub/metrics.js
+++ b/src/ducks/Watchlists/Widgets/Filter/dataHub/metrics.js
@@ -447,7 +447,9 @@ export const Metric = {
   age_consumed: {
     category: 'On-chain',
     group: 'Network Activity',
-    label: 'Age Consumed'
+    label: 'Age Consumed',
+    isOnlyPercentFilters: true,
+    percentMetricKey: 'age_destroyed'
   }
 }
 


### PR DESCRIPTION
**Summary**

Fixed `age_consumed` metric 