### PR TITLE
enhance/update-metrics-new-flag

### DIFF
--- a/src/ducks/dataHub/metrics/news.js
+++ b/src/ducks/dataHub/metrics/news.js
@@ -1,11 +1,7 @@
 import { Metric } from './index'
-import { Submetrics, TopTransactionsTableMetric } from '../submetrics'
+import { Submetrics } from '../submetrics'
 
 const NEW_METRICS = [
-  Metric.price_btc,
-  Metric.price_eth,
-  Metric.bitmex_perpetual_basis_ratio,
-  TopTransactionsTableMetric,
   Metric.transaction_volume_usd,
   Metric.social_active_users.key,
   Metric.price_daa_divergence,


### PR DESCRIPTION
## Summary
Removing `NEW` label for following metrics:
- Price BTC;
- Price ETH;
- Bitmex perpetual basis ratio;
- Top Transactions Table,