### PR TITLE
enhance/historical-balance-latest-transactions-table

### DIFF
--- a/src/ducks/HistoricalBalance/Address/Actions.js
+++ b/src/ducks/HistoricalBalance/Address/Actions.js
@@ -32,7 +32,7 @@ const Actions = ({ address, infrastructure, assets }) => {
 
       <Button className={styles.btn} onClick={onCommentClick}>
         <Icon type='comment' className={styles.btn__icon} />
-        Leave comment
+        Comment
       </Button>
     </div>
   )

--- a/src/ducks/HistoricalBalance/Chart/SettingsMenu.js
+++ b/src/ducks/HistoricalBalance/Chart/SettingsMenu.js
@@ -1,11 +1,5 @@
 import React from 'react'
-import { generateSearchQuery } from '../url'
-import {
-  Menu,
-  Setting,
-  ShareButton
-} from '../../SANCharts/ChartSettingsContextMenu'
-import { useShortShareLink } from '../../../components/Share/hooks'
+import { Menu, Setting } from '../../SANCharts/ChartSettingsContextMenu'
 import styles from './index.module.scss'
 
 const SettingsMenu = ({
@@ -15,36 +9,23 @@ const SettingsMenu = ({
   isLog,
   togglePriceAsset,
   setIsLog
-}) => {
-  const { shortShareLink, getShortShareLink } = useShortShareLink()
-
-  function onShareClick () {
-    getShortShareLink(
-      '/labs/balance?' +
-        generateSearchQuery(settings, chartAssets, priceAssets, isLog)
-    )
-  }
-
-  return (
-    <Menu>
-      <ShareButton shareLink={shortShareLink} onMouseDown={onShareClick} />
-      <hr className={styles.divider} />
+}) => (
+  <Menu className={styles.menu}>
+    <Setting
+      title='Log scale'
+      isActive={isLog}
+      onClick={() => setIsLog(!isLog)}
+    />
+    {chartAssets.length > 0 && <hr className={styles.divider} />}
+    {chartAssets.map(({ slug }) => (
       <Setting
-        title='Log scale'
-        isActive={isLog}
-        onClick={() => setIsLog(!isLog)}
+        key={slug}
+        title={`Price of ${slug}`}
+        isActive={priceAssets.includes(slug)}
+        onClick={() => togglePriceAsset(slug)}
       />
-      {chartAssets.length > 0 && <hr className={styles.divider} />}
-      {chartAssets.map(({ slug }) => (
-        <Setting
-          key={slug}
-          title={`Price of ${slug}`}
-          isActive={priceAssets.includes(slug)}
-          onClick={() => togglePriceAsset(slug)}
-        />
-      ))}
-    </Menu>
-  )
-}
+    ))}
+  </Menu>
+)
 
 export default SettingsMenu

--- a/src/ducks/HistoricalBalance/Chart/index.js
+++ b/src/ducks/HistoricalBalance/Chart/index.js
@@ -6,6 +6,7 @@ import Assets from './Assets'
 import DatePicker from './DatePicker'
 import SettingsMenu from './SettingsMenu'
 import { useWalletMetrics } from '../hooks'
+import { ShareButton } from '../../Studio/Header/Settings'
 import styles from './index.module.scss'
 
 const Configurations = ({
@@ -44,6 +45,7 @@ const Configurations = ({
             isPhone={isPhone}
             changeTimePeriod={changeTimePeriod}
           />
+          <ShareButton />
           <SettingsMenu
             isLog={isLog}
             settings={settings}

--- a/src/ducks/HistoricalBalance/Chart/index.module.scss
+++ b/src/ducks/HistoricalBalance/Chart/index.module.scss
@@ -15,7 +15,7 @@
 }
 
 .calendar {
-  margin: 0 8px;
+  margin-left: 8px;
   min-width: 167px;
 }
 
@@ -34,4 +34,8 @@
   top: 50%;
   transform: translate(0, -50%);
   font-size: 6px;
+}
+
+.menu {
+  margin-left: 8px;
 }

--- a/src/ducks/HistoricalBalance/Comments/index.module.scss
+++ b/src/ducks/HistoricalBalance/Comments/index.module.scss
@@ -9,4 +9,8 @@
     font-size: 18px !important;
     line-height: 26px !important;
   }
+
+  textarea {
+    font-family: 'Proxima Nova', sans-serif;
+  }
 }

--- a/src/ducks/HistoricalBalance/LatestTransactions/columns.js
+++ b/src/ducks/HistoricalBalance/LatestTransactions/columns.js
@@ -23,7 +23,7 @@ function getDatetime (datetime) {
 
 const checkIsSending = (address, fromAddress) => address === fromAddress.address
 
-const Values = ({ slug, toAddress, fromAddress, trxValue }, { address }) => {
+const Values = ({ address, slug, toAddress, fromAddress, trxValue }) => {
   const { logoUrl, ticker = `"${slug}"` } = useTransactionProject(slug)
   const isSending = checkIsSending(address, fromAddress)
   const anotherAddress = isSending ? toAddress.address : fromAddress.address

--- a/src/ducks/HistoricalBalance/LatestTransactions/columns.js
+++ b/src/ducks/HistoricalBalance/LatestTransactions/columns.js
@@ -1,0 +1,83 @@
+import React from 'react'
+import { useTransactionProject } from '../hooks'
+import { prepareColumns } from '../../_Table'
+import { getDateFormats, getTimeFormats } from '../../../utils/dates'
+import styles from './index.module.scss'
+
+const trxValueFormatter = new Intl.NumberFormat('en')
+
+function formatValue (value, ticker, isSending) {
+  const formattedValue = trxValueFormatter.format(
+    +(value < 1 ? value.toFixed(6) : value.toFixed(2))
+  )
+  return `${isSending ? '-' : '+'} ${formattedValue} ${ticker}`
+}
+
+function getDatetime (datetime) {
+  const date = new Date(datetime)
+  const { YYYY, MMM, DD } = getDateFormats(date)
+  const { HH, mm, ss } = getTimeFormats(date)
+
+  return `${YYYY}, ${MMM} ${DD}, ${HH}:${mm}:${ss}`
+}
+
+const checkIsSending = (address, fromAddress) => address === fromAddress.address
+
+const Values = ({ slug, toAddress, fromAddress, trxValue }, { address }) => {
+  const { logoUrl, ticker = `"${slug}"` } = useTransactionProject(slug)
+  const isSending = checkIsSending(address, fromAddress)
+  const anotherAddress = isSending ? toAddress.address : fromAddress.address
+
+  return (
+    <>
+      <div className={styles.asset}>
+        <img alt='' src={logoUrl} className={styles.logo} />{' '}
+        {formatValue(trxValue, ticker, isSending)}
+      </div>
+      <div className={styles.actor}>
+        {isSending ? 'to' : 'from'}
+        <a
+          className={styles.address}
+          href={`/labs/balance?address=${anotherAddress}`}
+          rel='noopener noreferrer'
+          target='_blank'
+        >
+          {anotherAddress}
+        </a>
+      </div>
+    </>
+  )
+}
+
+export const COLUMNS = prepareColumns([
+  {
+    title: 'Time',
+    render: ({ datetime }) => getDatetime(datetime)
+  },
+  {
+    title: 'Kind of TX',
+    render: ({ fromAddress }, { address }) =>
+      checkIsSending(address, fromAddress) ? 'Send' : 'Receive'
+  },
+  {
+    title: 'Values',
+    className: styles.values,
+    render: (transaction, { address }) => (
+      <Values {...transaction} address={address} />
+    )
+  },
+  {
+    title: 'Tx hash',
+    className: styles.hash,
+    render: ({ trxHash }, { address }) => (
+      <a
+        href={`https://etherscan.io/tx/${address}`}
+        rel='noopener noreferrer'
+        target='_blank'
+        className={styles.link}
+      >
+        {trxHash}
+      </a>
+    )
+  }
+])

--- a/src/ducks/HistoricalBalance/LatestTransactions/index.js
+++ b/src/ducks/HistoricalBalance/LatestTransactions/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef, useMemo, useState } from 'react'
 import { COLUMNS } from './columns'
 import Section from '../Section'
 import { useRecentTransactions } from '../hooks'
@@ -6,7 +6,26 @@ import PagedTable from '../../_Table/Paged'
 import styles from './index.module.scss'
 
 const LatestTransactions = ({ settings }) => {
-  const { recentTransactions, isLoading } = useRecentTransactions(settings)
+  const pagesItems = useRef([]).current
+  const [page, setPage] = useState(0)
+  const { recentTransactions, isLoading } = useRecentTransactions(
+    settings,
+    page + 1
+  )
+  const nextRecentTransactions = useRecentTransactions(
+    settings,
+    page + 2,
+    isLoading
+  ).recentTransactions
+
+  const items = useMemo(
+    () => {
+      pagesItems[page] = recentTransactions
+      pagesItems[page + 1] = nextRecentTransactions
+      return pagesItems.flat()
+    },
+    [recentTransactions, nextRecentTransactions]
+  )
 
   return (
     <Section title='Latest transactions'>
@@ -14,10 +33,11 @@ const LatestTransactions = ({ settings }) => {
         className={styles.table}
         columns={COLUMNS}
         itemKeyProperty='trxHash'
-        items={recentTransactions}
+        items={items}
         isLoading={isLoading}
         minRows={10}
         itemProps={settings}
+        onPageChange={setPage}
       />
     </Section>
   )

--- a/src/ducks/HistoricalBalance/LatestTransactions/index.js
+++ b/src/ducks/HistoricalBalance/LatestTransactions/index.js
@@ -1,93 +1,24 @@
 import React from 'react'
+import { COLUMNS } from './columns'
 import Section from '../Section'
-import { useRecentTransactions, useTransactionProject } from '../hooks'
-import { getDateFormats, getTimeFormats } from '../../../utils/dates'
-import { FluidSkeleton as Skeleton } from '../../../components/Skeleton'
+import { useRecentTransactions } from '../hooks'
+import PagedTable from '../../_Table/Paged'
 import styles from './index.module.scss'
 
-function formatValue (value, ticker, isSending) {
-  const formattedValue = +(value < 1 ? value.toFixed(6) : value.toFixed(2))
-  return `${isSending ? '-' : '+'} ${formattedValue} ${ticker}`
-}
-
-function getDatetime (datetime) {
-  const date = new Date(datetime)
-  const { YYYY, MMM, DD } = getDateFormats(date)
-  const { HH, mm, ss } = getTimeFormats(date)
-
-  return `${YYYY}, ${MMM} ${DD}, ${HH}:${mm}:${ss}`
-}
-
-const Row = ({
-  address,
-  datetime,
-  trxHash,
-  slug,
-  trxValue,
-  toAddress,
-  fromAddress
-}) => {
-  const { logoUrl, ticker = `"${slug}"` } = useTransactionProject(slug)
-  const isSending = address === fromAddress.address
-  const anotherAddress = isSending ? toAddress.address : fromAddress.address
-
-  return (
-    <tr>
-      <td>{getDatetime(datetime)}</td>
-      <td>{isSending ? 'Send' : 'Receive'}</td>
-      <td className={styles.values}>
-        <div className={styles.asset}>
-          <img alt='' src={logoUrl} className={styles.logo} />{' '}
-          {formatValue(trxValue, ticker, isSending)}
-        </div>
-        <div className={styles.actor}>
-          {isSending ? 'to' : 'from'}
-          <a
-            className={styles.address}
-            href={`/labs/balance?address=${anotherAddress}`}
-            rel='noopener noreferrer'
-            target='_blank'
-          >
-            {anotherAddress}
-          </a>
-        </div>
-      </td>
-      <td className={styles.hash}>
-        <a
-          href={`https://etherscan.io/tx/${address}`}
-          rel='noopener noreferrer'
-          target='_blank'
-          className={styles.link}
-        >
-          {trxHash}
-        </a>
-      </td>
-    </tr>
-  )
-}
-
 const LatestTransactions = ({ settings }) => {
-  const { address } = settings
   const { recentTransactions, isLoading } = useRecentTransactions(settings)
 
   return (
     <Section title='Latest transactions'>
-      <div className={styles.container}>
-        <table className={styles.table}>
-          <tbody>
-            <tr className={styles.header}>
-              <th>Time</th>
-              <th>Kind of TX</th>
-              <th>Values</th>
-              <th>Tx hash</th>
-            </tr>
-            {recentTransactions.map(trx => (
-              <Row key={trx.trxHash + trx.slug} {...trx} address={address} />
-            ))}
-          </tbody>
-        </table>
-        <Skeleton show={isLoading} className={styles.skeleton} />
-      </div>
+      <PagedTable
+        className={styles.table}
+        columns={COLUMNS}
+        itemKeyProperty='trxHash'
+        items={recentTransactions}
+        isLoading={isLoading}
+        minRows={10}
+        itemProps={settings}
+      />
     </Section>
   )
 }

--- a/src/ducks/HistoricalBalance/LatestTransactions/index.js
+++ b/src/ducks/HistoricalBalance/LatestTransactions/index.js
@@ -5,6 +5,8 @@ import { useRecentTransactions } from '../hooks'
 import PagedTable from '../../_Table/Paged'
 import styles from './index.module.scss'
 
+const getItemKey = ({ trxHash, slug }) => trxHash + slug
+
 const LatestTransactions = ({ settings }) => {
   const pagesItems = useRef([]).current
   const [page, setPage] = useState(0)
@@ -32,12 +34,12 @@ const LatestTransactions = ({ settings }) => {
       <PagedTable
         className={styles.table}
         columns={COLUMNS}
-        itemKeyProperty='trxHash'
         items={items}
         isLoading={isLoading}
         minRows={10}
         itemProps={settings}
         onPageChange={setPage}
+        getItemKey={getItemKey}
       />
     </Section>
   )

--- a/src/ducks/HistoricalBalance/LatestTransactions/index.module.scss
+++ b/src/ducks/HistoricalBalance/LatestTransactions/index.module.scss
@@ -6,42 +6,28 @@
 }
 
 .table {
-  width: 100%;
   border: 1px solid var(--porcelain);
   border-radius: 4px;
-  border-spacing: 0;
-  overflow: hidden;
-  text-align: left;
-}
 
-.header {
-  @include text('caption');
+  :global {
+    td {
+      border-top: 1px solid var(--porcelain);
+    }
 
-  background: var(--athens);
-  color: var(--casper);
-
-  :global(th) {
-    padding: 8px 16px;
-    white-space: nowrap;
+    tbody tr {
+      height: 62px;
+    }
   }
-}
-
-.table :global(td) {
-  padding: 8px 16px;
-  border-top: 1px solid var(--porcelain);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .hash {
   max-width: 0;
-  width: 35%;
+  width: 30%;
 }
 
 .values {
   max-width: 0;
-  width: 35%;
+  width: 45%;
 }
 
 .link {
@@ -76,10 +62,4 @@
   padding: 1px 8px;
   border-radius: 4px;
   margin-left: 4px;
-}
-
-.skeleton {
-  position: absolute;
-  width: 100%;
-  top: 0;
 }

--- a/src/ducks/HistoricalBalance/hooks.js
+++ b/src/ducks/HistoricalBalance/hooks.js
@@ -15,9 +15,9 @@ import { getAddressInfrastructure } from '../../utils/address'
 
 const DEFAULT_STATE = []
 
-const useWalletQuery = (query, variables) =>
+const useWalletQuery = (query, variables, skip) =>
   useQuery(query, {
-    skip: !variables.infrastructure,
+    skip: !variables.infrastructure || skip,
     variables
   })
 
@@ -50,8 +50,12 @@ export function useWalletAssets (wallet) {
   }
 }
 
-export function useRecentTransactions (wallet) {
-  const { data, loading } = useWalletQuery(RECENT_TRANSACTIONS_QUERY, wallet)
+export function useRecentTransactions (wallet, page, skip) {
+  const { data, loading } = useWalletQuery(
+    RECENT_TRANSACTIONS_QUERY,
+    Object.assign({ page }, wallet),
+    skip
+  )
   return {
     recentTransactions: data ? data.recentTransactions : DEFAULT_STATE,
     isLoading: loading

--- a/src/ducks/HistoricalBalance/index.js
+++ b/src/ducks/HistoricalBalance/index.js
@@ -92,10 +92,10 @@ const HistoricalBalance = ({
 
       <div className={cx(styles.bottom, isPhone && styles.bottom_phone)}>
         <div className={styles.left}>
-          <Comments settings={settings} />
+          <LatestTransactions settings={settings} />
         </div>
         <div className={styles.right}>
-          <LatestTransactions settings={settings} />
+          <Comments settings={settings} />
         </div>
       </div>
 

--- a/src/ducks/HistoricalBalance/index.module.scss
+++ b/src/ducks/HistoricalBalance/index.module.scss
@@ -18,17 +18,14 @@
   color: var(--waterloo);
 }
 
-.left,
-.right {
-  width: 50%;
-}
-
 .left {
   padding-right: 24px;
+  width: 65%;
 }
 
 .right {
   padding-left: 24px;
+  width: 35%;
 }
 
 .bottom {

--- a/src/ducks/HistoricalBalance/queries.js
+++ b/src/ducks/HistoricalBalance/queries.js
@@ -27,8 +27,13 @@ export const ADDRESS_QUERY = gql`
 `
 
 export const RECENT_TRANSACTIONS_QUERY = gql`
-  query recentTransactions($address: String!, $pageSize: Int = 20) {
-    recentTransactions(address: $address, pageSize: $pageSize, type: ERC20) {
+  query recentTransactions($address: String!, $page: Int, $pageSize: Int = 20) {
+    recentTransactions(
+      address: $address
+      page: $page
+      pageSize: $pageSize
+      type: ERC20
+    ) {
       datetime
       fromAddress {
         address

--- a/src/ducks/HistoricalBalance/queries.js
+++ b/src/ducks/HistoricalBalance/queries.js
@@ -27,8 +27,8 @@ export const ADDRESS_QUERY = gql`
 `
 
 export const RECENT_TRANSACTIONS_QUERY = gql`
-  query recentTransactions($address: String!) {
-    recentTransactions(address: $address, type: ERC20) {
+  query recentTransactions($address: String!, $pageSize: Int = 20) {
+    recentTransactions(address: $address, pageSize: $pageSize, type: ERC20) {
       datetime
       fromAddress {
         address

--- a/src/ducks/WatchlistTable/index.js
+++ b/src/ducks/WatchlistTable/index.js
@@ -1,5 +1,4 @@
 import React, { useMemo, useState } from 'react'
-import cx from 'classnames'
 import SaveAs from './SaveAs'
 import DownloadCSV from './DownloadCSV'
 import PagedTable from '../_Table/Paged'
@@ -49,7 +48,8 @@ const WatchlistTable = ({
       <PagedTable
         {...props}
         itemProps={useSelectedItemsSet(items)}
-        className={cx(styles.table)}
+        className={styles.table}
+        stickyPageControls
       />
     </div>
   )

--- a/src/ducks/WatchlistTable/index.js
+++ b/src/ducks/WatchlistTable/index.js
@@ -47,9 +47,10 @@ const WatchlistTable = ({
 
       <PagedTable
         {...props}
+        stickyPageControls
+        padding
         itemProps={useSelectedItemsSet(items)}
         className={styles.table}
-        stickyPageControls
       />
     </div>
   )

--- a/src/ducks/_Table/Paged.js
+++ b/src/ducks/_Table/Paged.js
@@ -18,9 +18,10 @@ const PAGE_SIZES = [10, 20, 50, 100].map(index => ({
 }))
 
 const PagedTable = ({
+  stickyPageControls,
+  padding,
   defaultPage,
   defaultPageSize,
-  stickyPageControls,
   items,
   onPageChange,
   ...props
@@ -48,7 +49,8 @@ const PagedTable = ({
       <div
         className={cx(
           styles.controls,
-          stickyPageControls && styles.stickyPageControls
+          stickyPageControls && styles.stickyPageControls,
+          padding && styles.padding
         )}
       >
         <Dropdown

--- a/src/ducks/_Table/Paged.js
+++ b/src/ducks/_Table/Paged.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import cx from 'classnames'
 import Icon from '@santiment-network/ui/Icon'
 import Input from '@santiment-network/ui/Input'
 import Button from '@santiment-network/ui/Button'
@@ -11,22 +12,27 @@ const DROPDOWN_CLASSES = {
   options: styles.options
 }
 
-const DEFAULT_PAGE_SIZE = 20
 const PAGE_SIZES = [10, 20, 50, 100].map(index => ({
   index,
   content: `${index} rows`
 }))
 
-const PagedTable = ({ defaultPage, items, ...props }) => {
+const PagedTable = ({
+  defaultPage,
+  defaultPageSize,
+  stickyPageControls,
+  items,
+  ...props
+}) => {
   const [page, setPage] = useState(defaultPage)
-  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE)
+  const [pageSize, setPageSize] = useState(defaultPageSize)
 
   const offset = page * pageSize
   const pageItems = items.slice(offset, offset + pageSize)
 
   const maxPage = Math.ceil(items.length / pageSize)
-  const isPrevPageDisabled = page === 0
-  const isNextPageDisabled = page === maxPage - 1
+  const isPrevPageDisabled = page < 1
+  const isNextPageDisabled = page >= maxPage - 1
 
   function onPageInput (e) {
     const newPage = e.target.value - 1
@@ -39,7 +45,12 @@ const PagedTable = ({ defaultPage, items, ...props }) => {
   return (
     <>
       <Table {...props} items={pageItems} offset={offset} />
-      <div className={styles.controls}>
+      <div
+        className={cx(
+          styles.controls,
+          stickyPageControls && styles.stickyPageControls
+        )}
+      >
         <Dropdown
           options={PAGE_SIZES}
           selected={pageSize}
@@ -79,7 +90,9 @@ const PagedTable = ({ defaultPage, items, ...props }) => {
 }
 
 PagedTable.defaultProps = {
-  defaultPage: 0
+  defaultPage: 0,
+  defaultPageSize: 20,
+  items: []
 }
 
 export default PagedTable

--- a/src/ducks/_Table/Paged.js
+++ b/src/ducks/_Table/Paged.js
@@ -22,6 +22,7 @@ const PagedTable = ({
   defaultPageSize,
   stickyPageControls,
   items,
+  onPageChange,
   ...props
 }) => {
   const [page, setPage] = useState(defaultPage)
@@ -34,11 +35,10 @@ const PagedTable = ({
   const isPrevPageDisabled = page < 1
   const isNextPageDisabled = page >= maxPage - 1
 
-  function onPageInput (e) {
-    const newPage = e.target.value - 1
-
+  function changePage (newPage) {
     if (newPage > -1 && newPage < maxPage) {
       setPage(newPage)
+      if (onPageChange) onPageChange(newPage)
     }
   }
 
@@ -63,14 +63,14 @@ const PagedTable = ({
           type='number'
           style={{ '--width': `${(page + 1).toString().length}ch` }}
           value={page + 1}
-          onChange={onPageInput}
+          onChange={({ target }) => changePage(target.value - 1)}
         />
-        of {maxPage}
+        of {maxPage || 1}
         <Button
           className={styles.prev}
           border
           disabled={isPrevPageDisabled}
-          onClick={() => setPage(page - 1)}
+          onClick={() => changePage(page - 1)}
         >
           Prev
           <Icon className={styles.prev__icon} type='arrow-left' />
@@ -79,7 +79,7 @@ const PagedTable = ({
           className={styles.next}
           border
           disabled={isNextPageDisabled}
-          onClick={() => setPage(page + 1)}
+          onClick={() => changePage(page + 1)}
         >
           <Icon className={styles.next__icon} type='arrow-right' />
           Next

--- a/src/ducks/_Table/Paged.module.scss
+++ b/src/ducks/_Table/Paged.module.scss
@@ -1,11 +1,15 @@
 .controls {
   display: flex;
   align-items: center;
-  padding: 16px 32px;
+  padding: 16px 0;
   background-color: var(--white);
   color: var(--waterloo);
   bottom: 0;
   z-index: 1;
+}
+
+.padding {
+  padding: 16px 32px;
 }
 
 .stickyPageControls {
@@ -32,6 +36,7 @@
 .prev,
 .next {
   fill: var(--waterloo);
+  user-select: none;
 }
 
 .prev {

--- a/src/ducks/_Table/Paged.module.scss
+++ b/src/ducks/_Table/Paged.module.scss
@@ -4,9 +4,12 @@
   padding: 16px 32px;
   background-color: var(--white);
   color: var(--waterloo);
-  position: sticky;
   bottom: 0;
   z-index: 1;
+}
+
+.stickyPageControls {
+  position: sticky;
 }
 
 .dropdown {

--- a/src/ducks/_Table/index.js
+++ b/src/ducks/_Table/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import cx from 'classnames'
 import { FluidSkeleton as Skeleton } from '../../components/Skeleton'
+import NoDataImage from '../../components/Illustrations/NoData'
 import styles from './index.module.scss'
 
 export function prepareColumns (columns) {
@@ -11,6 +12,17 @@ export function prepareColumns (columns) {
   return columns
 }
 
+function minRowsPadding (minRows, { length }) {
+  if (length >= minRows) return null
+
+  const rowsToAdd = minRows - length
+  const rows = new Array(rowsToAdd)
+  for (let i = 0; i < rowsToAdd; i++) {
+    rows[i] = <tr key={i} />
+  }
+  return rows
+}
+
 const Table = ({
   className,
   offset,
@@ -18,6 +30,7 @@ const Table = ({
   items,
   itemKeyProperty,
   itemProps,
+  minRows,
   isLoading
 }) => (
   <table className={cx(styles.wrapper, className)}>
@@ -41,9 +54,13 @@ const Table = ({
           </tr>
         )
       })}
+      {minRowsPadding(minRows, items)}
     </tbody>
     <caption>
       <Skeleton show={isLoading} className={styles.skeleton} />
+      {!isLoading && items.length === 0 && (
+        <NoDataImage className={styles.nodata} />
+      )}
     </caption>
   </table>
 )
@@ -51,7 +68,8 @@ const Table = ({
 Table.defaultProps = {
   items: [],
   itemProps: {},
-  itemKeyProperty: 'id'
+  itemKeyProperty: 'id',
+  minRows: 0
 }
 
 export default Table

--- a/src/ducks/_Table/index.js
+++ b/src/ducks/_Table/index.js
@@ -27,11 +27,12 @@ const Table = ({
   className,
   offset,
   columns,
+  minRows,
   items,
   itemKeyProperty,
   itemProps,
-  minRows,
-  isLoading
+  isLoading,
+  getItemKey
 }) => (
   <table className={cx(styles.wrapper, className)}>
     <thead>
@@ -45,7 +46,7 @@ const Table = ({
       {items.map((item, i) => {
         const itemIndex = offset + i
         return (
-          <tr key={item[itemKeyProperty]}>
+          <tr key={getItemKey ? getItemKey(item) : item[itemKeyProperty]}>
             {columns.map(({ id, render, className }) => (
               <td key={id} className={className}>
                 {render(item, itemProps, itemIndex)}

--- a/src/ducks/_Table/index.module.scss
+++ b/src/ducks/_Table/index.module.scss
@@ -28,3 +28,10 @@
   width: 100%;
   top: 0;
 }
+
+.nodata {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}

--- a/src/pages/WatchlistAddresses/index.js
+++ b/src/pages/WatchlistAddresses/index.js
@@ -27,7 +27,7 @@ const WatchlistAddress = ({ match }) => {
     <Page
       className={styles.wrapper}
       headerClassName={styles.header}
-      isWidthPadding={false}
+      isWithPadding={false}
       title={watchlist.name}
       actions={<Actions watchlist={watchlist} isAuthor={isAuthor} />}
     >


### PR DESCRIPTION
## Changes
- `Latest Transactions` moved to the left and increased in size;
- Displaying last 20 transactions by default in `Latest Transactions`;
- Lazily pagination for `Latest Transactions` table;
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/Historical-Balance-Latest-Transactions-pagination-e0c4ae6e7d0b4e999d00ca87761b79cd

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (Santiment Academy: Keyboard shortcuts or Account Settings)
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes in module from other person, I've asked how to use it or request a review

## Screenshots or GIFs
<img width="1759" alt="image" src="https://user-images.githubusercontent.com/25135650/102932573-95ea6a00-44b1-11eb-9490-c6c8b1841fba.png">
