### PR TITLE
fix/payment-invalid-coupon

### DIFF
--- a/src/components/CheckoutForm/Confirmation.js
+++ b/src/components/CheckoutForm/Confirmation.js
@@ -62,6 +62,17 @@ const TotalPrice = connect(mapStateToProps)(
   }
 )
 
+const DiscountIcon = ({ isValid }) => {
+  if (isValid === undefined) return null
+
+  return (
+    <Icon
+      type={isValid ? 'success-round' : 'error'}
+      className={cx(styles.discount__icon, isValid && styles.valid)}
+    />
+  )
+}
+
 const DiscountInput = ({ setCoupon, isValid }) => {
   const setCouponDebounced = useDebounce(value => setCoupon(value), 500)
 
@@ -73,9 +84,10 @@ const DiscountInput = ({ setCoupon, isValid }) => {
           className={styles.input}
           placeholder='2H8vZG5P'
           name='coupon'
+          data-is-valid={isValid}
           onChange={({ currentTarget: { value } }) => setCouponDebounced(value)}
         />
-        {isValid && <Icon type='success-round' className={styles.valid} />}
+        <DiscountIcon isValid={isValid} />
       </div>
     </label>
   )
@@ -123,7 +135,10 @@ const Confirmation = ({
             const { isValid, percentOff } = error ? {} : getCoupon || {}
             return (
               <>
-                <DiscountInput isValid={isValid} setCoupon={setCoupon} />
+                <DiscountInput
+                  isValid={!error && isValid}
+                  setCoupon={setCoupon}
+                />
                 <div className={styles.hold}>
                   <Icon className={styles.hold__icon} type='info-round' />
                   Holding 1000 SAN tokens will result in a 20% discount.
@@ -138,7 +153,7 @@ const Confirmation = ({
                 </div>
                 <TotalPrice
                   error={error}
-                  percentOff={percentOff}
+                  percentOff={isValid && percentOff}
                   price={formatOnlyPrice(price)}
                   planWithBilling={planWithBilling}
                 />

--- a/src/components/CheckoutForm/Confirmation.module.scss
+++ b/src/components/CheckoutForm/Confirmation.module.scss
@@ -23,6 +23,14 @@
   position: relative;
   margin-bottom: 16px;
   margin-top: 3px;
+
+  &__icon {
+    position: absolute;
+    top: 50%;
+    right: 16px;
+    transform: translateY(-50%);
+    fill: var(--persimmon);
+  }
 }
 
 .label {
@@ -53,7 +61,8 @@
     margin-top: 16px;
     align-items: flex-end;
 
-    @include text('body-2', 'm'); }
+    @include text('body-2', 'm');
+  }
 
   &__price {
     @include text('h4', 'l');
@@ -61,10 +70,6 @@
 }
 
 .valid {
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  transform: translateY(-50%);
   fill: var(--jungle-green);
 }
 

--- a/src/components/Plans/PlanPaymentDialog.js
+++ b/src/components/Plans/PlanPaymentDialog.js
@@ -164,9 +164,9 @@ const PaymentDialog = ({
                   })
 
                   const form = e.currentTarget
-                  const {
-                    coupon: { value: coupon }
-                  } = form
+                  const formCoupon = form.coupon
+                  const coupon =
+                    formCoupon.dataset.isValid === 'true' && formCoupon.value
 
                   stripe
                     .createToken(getTokenDataByForm(form))


### PR DESCRIPTION
## Changes
- Displaying coupon invalid status;
- Attaching coupon to the payment only if it's valid;

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (Santiment Academy: Keyboard shortcuts or Account Settings)
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes in module from other person, I've asked how to use it or request a review

## Screenshots or GIFs
<img width="892" alt="image" src="https://user-images.githubusercontent.com/25135650/103275538-771a3500-49d5-11eb-8d24-d6ca948c5eae.png">
