### PR TITLE
fix/card-checkout-night-mode

### DIFF
--- a/src/components/CheckoutForm/CheckoutForm.js
+++ b/src/components/CheckoutForm/CheckoutForm.js
@@ -2,56 +2,74 @@ import React from 'react'
 import cx from 'classnames'
 import Input from '@santiment-network/ui/Input'
 import { CardElement } from 'react-stripe-elements'
-import vars from '@santiment-network/ui/variables.scss'
+import COLOR from '@santiment-network/ui/variables.scss'
 import Confirmation from './Confirmation'
 import visaSrc from './visa.svg'
 import mastercardSrc from './mastercard.svg'
+import { useTheme } from '../../stores/ui/theme'
 import styles from './CheckoutForm.module.scss'
 
 const style = {
   base: {
     fontSize: '14px',
-    color: vars.mirage,
+    color: COLOR.rhino,
     fontFamily: 'Proxima Nova, sans-serif',
     '::placeholder': {
-      color: vars.casper
+      color: COLOR.casper
     }
   },
   invalid: {
-    color: vars.persimmon
+    color: COLOR.persimmon
   }
 }
 
-const CardInformation = () => (
-  <div className={styles.card}>
-    <div className={styles.top}>
-      Credit or debit card
-      <div className={styles.top__cards}>
-        <img width='40' alt='visa' src={visaSrc} className={styles.top__visa} />
-        <img
-          width='40'
-          alt='mastercard'
-          src={mastercardSrc}
-          className={styles.top__mastercard}
-        />
-      </div>
-    </div>
-    <label className={cx(styles.label, styles.label_card)}>
-      Full name
-      <Input
-        className={styles.input}
-        placeholder='John Doe'
-        required
-        name='name'
-      />
-    </label>
+const nightStyle = {
+  ...style,
+  base: {
+    ...style.base,
+    color: COLOR.mystic
+  }
+}
 
-    <label className={cx(styles.label, styles.label_card)}>
-      Card number
-      <CardElement style={style} />
-    </label>
-  </div>
-)
+const CardInformation = () => {
+  const { isNightMode } = useTheme()
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.top}>
+        Credit or debit card
+        <div className={styles.top__cards}>
+          <img
+            width='40'
+            alt='visa'
+            src={visaSrc}
+            className={styles.top__visa}
+          />
+          <img
+            width='40'
+            alt='mastercard'
+            src={mastercardSrc}
+            className={styles.top__mastercard}
+          />
+        </div>
+      </div>
+      <label className={cx(styles.label, styles.label_card)}>
+        Full name
+        <Input
+          className={styles.input}
+          placeholder='John Doe'
+          required
+          name='name'
+        />
+      </label>
+
+      <label className={cx(styles.label, styles.label_card)}>
+        Card number
+        <CardElement style={isNightMode ? nightStyle : style} />
+      </label>
+    </div>
+  )
+}
 
 const BillingAddress = () => (
   <div className={styles.address}>

--- a/src/components/CheckoutForm/Confirmation.module.scss
+++ b/src/components/CheckoutForm/Confirmation.module.scss
@@ -139,8 +139,9 @@
   position: relative;
   border-radius: $border-radius;
   color: var(--mirage);
+  fill: var(--mirage);
   padding: 12px 16px 8px 40px;
-  background: #ecfaf6;
+  background: var(--jungle-green-light);
   margin-bottom: 32px;
 
   &__icon {


### PR DESCRIPTION
## Changes
Applying correct checkout form input color styles when in night mode.

## Notion's card
https://www.notion.so/santiment/Checkout-form-card-input-black-font-in-night-mode-e8b9e68f04074e06afdbead881004fb9

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (Santiment Academy: Keyboard shortcuts or Account Settings)
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes in module from other person, I've asked how to use it or request a review

## Screenshots or GIFs
<img width="890" alt="image" src="https://user-images.githubusercontent.com/25135650/104164871-9ec3c100-5409-11eb-91d9-6a3901422101.png">

