### PR TITLE
enhance/historical-balance-search-address-resubmit

### DIFF
--- a/src/ducks/HistoricalBalance/Address/index.js
+++ b/src/ducks/HistoricalBalance/Address/index.js
@@ -23,6 +23,16 @@ export const AddressSetting = ({
 
   useEffect(
     () => {
+      if (address !== value) {
+        setValue(address)
+      }
+    },
+
+    [address]
+  )
+
+  useEffect(
+    () => {
       if (value === settings.address || !infrastructure) return
 
       const timer = setTimeout(() => onAddressChange(value), 250)

--- a/src/ducks/HistoricalBalance/Address/index.js
+++ b/src/ducks/HistoricalBalance/Address/index.js
@@ -27,7 +27,6 @@ export const AddressSetting = ({
         setValue(address)
       }
     },
-
     [address]
   )
 

--- a/src/ducks/HistoricalBalance/index.js
+++ b/src/ducks/HistoricalBalance/index.js
@@ -104,7 +104,8 @@ const HistoricalBalance = ({
           settings,
           chartAssets,
           priceAssets,
-          isLog
+          isLog,
+          onAddressChange
         })
       )}
     </>

--- a/src/pages/HistoricalBalance/URLExtension.js
+++ b/src/pages/HistoricalBalance/URLExtension.js
@@ -1,13 +1,29 @@
 import { useEffect } from 'react'
-import { generateSearchQuery } from '../../ducks/HistoricalBalance/url'
+import {
+  parseUrl,
+  generateSearchQuery
+} from '../../ducks/HistoricalBalance/url'
 
 const URLExtension = ({
   history,
   settings,
   chartAssets,
   priceAssets,
-  isLog
+  isLog,
+  onAddressChange
 }) => {
+  const { search } = history.location
+
+  useEffect(
+    () => {
+      const { address } = parseUrl(search).settings
+      if (address !== settings.address) {
+        onAddressChange(address)
+      }
+    },
+    [search]
+  )
+
   useEffect(
     () => {
       history.replace(


### PR DESCRIPTION
## Changes
Handling address lookup via navbar's search when `Historical Balance` page is opened.

## Notion's card
https://www.notion.so/santiment/Historical-Balance-page-address-change-after-navbar-s-search-submitted-6736fa323d954e489bf6d0c4b5d60b8a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (Santiment Academy: Keyboard shortcuts or Account Settings)
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes in module from other person, I've asked how to use it or request a review
