### PR TITLE
fix/soc-vol-column

### DIFF
--- a/src/components/Tables/Trends/TrendsTable.js
+++ b/src/components/Tables/Trends/TrendsTable.js
@@ -24,6 +24,7 @@ const TrendsTable = ({
   className,
   isDesktop,
   isCompactView,
+  showSocialVol,
   contentClassName
 }) => {
   const tableData = useMemo(
@@ -46,7 +47,11 @@ const TrendsTable = ({
   const columns = useMemo(
     () => {
       const baseColumns = isDesktop
-        ? getTrendsDesktopCols({ trendConnections, TrendToInsights })
+        ? getTrendsDesktopCols({
+          trendConnections,
+          TrendToInsights,
+          showSocialVol
+        })
         : getTrendsMobileCols({ trendConnections })
 
       return isCompactView

--- a/src/components/Tables/Trends/columns.js
+++ b/src/components/Tables/Trends/columns.js
@@ -69,66 +69,83 @@ const CHART_COLUMN = {
   Cell: ({ value }) => <SocialVolumeGraph word={value} />
 }
 
-export const getCommonColumns = ({ trendConnections }) => [
-  {
-    Header: 'Trending words',
-    accessor: 'word',
-    Cell: ({ value: word }) => (
-      <Link
-        className={cx(
-          styles.word,
-          trendConnections.includes(word.toUpperCase()) && styles.connected
-        )}
-        to={`${EXPLORE_PAGE_URL}${word}`}
-        onClick={evt => {
-          if (evt.ctrlKey || evt.metaKey) {
-            const { pathname } = window.location
-            const topic = pathname.replace(EXPLORE_PAGE_URL, '')
+export const getCommonColumns = ({
+  trendConnections,
+  showSocialVol = true
+}) => {
+  const columns = [
+    {
+      Header: 'Trending words',
+      accessor: 'word',
+      Cell: ({ value: word }) => (
+        <Link
+          className={cx(
+            styles.word,
+            trendConnections.includes(word.toUpperCase()) && styles.connected
+          )}
+          to={`${EXPLORE_PAGE_URL}${word}`}
+          onClick={evt => {
+            if (evt.ctrlKey || evt.metaKey) {
+              const { pathname } = window.location
+              const topic = pathname.replace(EXPLORE_PAGE_URL, '')
 
-            if (pathname.includes(EXPLORE_PAGE_URL)) {
-              evt.preventDefault()
-              evt.stopPropagation()
-              if (word !== topic) {
-                const addedTopics = new Set(getTopicsFromUrl())
-                addedTopics.add(word)
-                const newTopics = updTopicsInUrl([...addedTopics])
-                const url = topic ? `?${newTopics}` : `${word}`
+              if (pathname.includes(EXPLORE_PAGE_URL)) {
+                evt.preventDefault()
+                evt.stopPropagation()
+                if (word !== topic) {
+                  const addedTopics = new Set(getTopicsFromUrl())
+                  addedTopics.add(word)
+                  const newTopics = updTopicsInUrl([...addedTopics])
+                  const url = topic ? `?${newTopics}` : `${word}`
 
-                store.dispatch(push(pathname + url))
+                  store.dispatch(push(pathname + url))
+                }
               }
             }
-          }
-        }}
-      >
-        {word}
-      </Link>
-    )
-  },
-  {
-    Header: 'Soc. vol., 24h',
-    accessor: 'volume',
-    Cell: ({ value: volumeChange }) => {
-      const volumeIsLoading = !volumeChange
-      const [oldVolume = 0, newVolume = 0] = volumeChange || []
-
-      return volumeIsLoading ? (
-        <Skeleton centered className={styles.skeleton} show={true} repeat={1} />
-      ) : (
-        <>
-          <div className={styles.volume}>{newVolume}</div>{' '}
-          <ValueChange
-            change={
-              oldVolume !== 0 ? (100 * (newVolume - oldVolume)) / oldVolume : 0
-            }
-            className={styles.valueChange}
-            suffix={'%'}
-            render={formatNumber}
-          />
-        </>
+          }}
+        >
+          {word}
+        </Link>
       )
     }
+  ]
+
+  if (showSocialVol) {
+    columns.push({
+      Header: 'Soc. vol., 24h',
+      accessor: 'volume',
+      Cell: ({ value: volumeChange }) => {
+        const volumeIsLoading = !volumeChange
+        const [oldVolume = 0, newVolume = 0] = volumeChange || []
+
+        return volumeIsLoading ? (
+          <Skeleton
+            centered
+            className={styles.skeleton}
+            show={true}
+            repeat={1}
+          />
+        ) : (
+          <>
+            <div className={styles.volume}>{newVolume}</div>{' '}
+            <ValueChange
+              change={
+                oldVolume !== 0
+                  ? (100 * (newVolume - oldVolume)) / oldVolume
+                  : 0
+              }
+              className={styles.valueChange}
+              suffix={'%'}
+              render={formatNumber}
+            />
+          </>
+        )
+      }
+    })
   }
-]
+
+  return columns
+}
 
 export const getTrendsCompatctViewCols = ({ trendConnections }) => {
   return [
@@ -142,14 +159,18 @@ export const getTrendsMobileCols = ({ trendConnections }) => [
   CHART_COLUMN
 ]
 
-export const getTrendsDesktopCols = ({ trendConnections, TrendToInsights }) => {
+export const getTrendsDesktopCols = ({
+  trendConnections,
+  TrendToInsights,
+  showSocialVol
+}) => {
   const hasInsights =
     TrendToInsights &&
     Object.values(TrendToInsights).some(item => item && item.length > 0)
 
   const columns = [
     getIndexColumn(),
-    ...getCommonColumns({ trendConnections }),
+    ...getCommonColumns({ trendConnections, showSocialVol }),
     CHART_COLUMN,
     {
       Header: 'Connected words',

--- a/src/components/Trends/TrendsTable/Tables/TrendsTablesDesktop.js
+++ b/src/components/Trends/TrendsTable/Tables/TrendsTablesDesktop.js
@@ -7,7 +7,8 @@ const TrendsTablesDesktop = ({
   trends,
   isLoggedIn,
   isLoading,
-  trendConnections
+  trendConnections,
+  showSocialVol
 }) => {
   const { length } = trends
   return isLoading ? (
@@ -20,6 +21,7 @@ const TrendsTablesDesktop = ({
         trendWords={length > 0 ? trends[length - 1].topWords : undefined}
         isLoggedIn={isLoggedIn || true}
         trendConnections={trendConnections}
+        showSocialVol={showSocialVol}
       />
     </div>
   )

--- a/src/pages/Index/Section/Trends/index.js
+++ b/src/pages/Index/Section/Trends/index.js
@@ -37,6 +37,7 @@ const TabTypeContent = {
       <Santrends
         className={styles.santrends}
         slice={trends => trends.slice(-2)}
+        showSocialVol={false}
       />
     ),
     description: (


### PR DESCRIPTION
## Changes

Hide soc vol column on home page trends table


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (Santiment Academy: Keyboard shortcuts or Account Settings)
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [ ] If I make changes in module from other person, I've asked how to use it or request a review

## Screenshots or GIFs
![image](https://user-images.githubusercontent.com/14061779/104304903-0c8ced00-54dd-11eb-9123-1b90e8d5fd2c.png)


P.S. Don't forget about naming conventions for PRs, functions and modules.
