### PR TITLE
feature/watchlists-page-queued-render

### DIFF
--- a/src/ducks/Watchlists/Cards/Card.js
+++ b/src/ducks/Watchlists/Cards/Card.js
@@ -32,21 +32,23 @@ const LOADING = {
 const DEFAULT = {
   marketcap: NULL_MARKETCAP
 }
-const useMarketcap = variables => {
+const useMarketcap = (variables, skip, onLoad) => {
   const { data } = useQuery(WATCHLIST_MARKETCAP_HISTORY_QUERY, {
-    variables
+    variables,
+    skip
   })
 
   return useMemo(
     () => {
       if (!data) return LOADING
+      if (onLoad) onLoad()
 
       const { historicalStats } = data.watchlist
+      const { length } = historicalStats
 
-      if (historicalStats.length === 0) return DEFAULT
+      if (length === 0) return DEFAULT
 
-      const lastMarketcap =
-        historicalStats[historicalStats.length - 1].marketcap
+      const lastMarketcap = historicalStats[length - 1].marketcap
       const firstMarketcap = historicalStats[0].marketcap
 
       return {
@@ -63,12 +65,18 @@ const WatchlistCard = ({
   className,
   watchlist,
   path,
+  skipMarketcap,
   isSimplified,
   isWithNewCheck,
-  isWithVisibility
+  isWithVisibility,
+  onMarketcapLoad
 }) => {
   const { id, name, insertedAt, isPublic, href } = watchlist
-  const { data, marketcap, change } = useMarketcap(watchlist)
+  const { data, marketcap, change } = useMarketcap(
+    watchlist,
+    skipMarketcap,
+    onMarketcapLoad
+  )
   const noMarketcap = marketcap === NULL_MARKETCAP
   const to = href || path + getSEOLinkFromIdAndTitle(id, name)
 
@@ -122,9 +130,13 @@ WatchlistCard.defaultProps = {
   isWithVisibility: true
 }
 
-export const WatchlistCards = ({ watchlists, ...props }) =>
+export const WatchlistCards = ({ watchlists, Card, ...props }) =>
   watchlists.map(watchlist => (
-    <WatchlistCard {...props} key={watchlist.id} watchlist={watchlist} />
+    <Card {...props} key={watchlist.id} watchlist={watchlist} />
   ))
+
+WatchlistCards.defaultProps = {
+  Card: WatchlistCard
+}
 
 export default WatchlistCard

--- a/src/ducks/Watchlists/Cards/Featured.js
+++ b/src/ducks/Watchlists/Cards/Featured.js
@@ -2,11 +2,12 @@ import React from 'react'
 import { WatchlistCards } from './Card'
 import { useFeaturedWatchlists } from '../gql/queries'
 
-const FeaturedWatchlists = ({ className }) => {
+const FeaturedWatchlists = ({ className, ...props }) => {
   const [watchlists] = useFeaturedWatchlists()
 
   return (
     <WatchlistCards
+      {...props}
       className={className}
       watchlists={watchlists}
       path='/watchlist/projects/'

--- a/src/ducks/Watchlists/Cards/marketcapRenderQueue.js
+++ b/src/ducks/Watchlists/Cards/marketcapRenderQueue.js
@@ -1,0 +1,56 @@
+import React, { useState, useContext, useEffect } from 'react'
+
+function RenderQueue () {
+  const queue = []
+  const loadingSet = new Set()
+
+  function renderNext () {
+    const [ref, setIsRendered] = queue.shift()
+
+    loadingSet.add(ref)
+    setIsRendered(true)
+  }
+
+  function onItemLoad (ref) {
+    loadingSet.delete(ref)
+
+    if (queue.length) renderNext()
+  }
+
+  function Ref () {
+    const ref = () => onItemLoad(ref)
+    return ref
+  }
+
+  function register (ref, setIsRendered) {
+    if (loadingSet.size < 4) {
+      loadingSet.add(ref)
+      setIsRendered(true)
+    } else {
+      queue.push([ref, setIsRendered])
+    }
+  }
+
+  return () => {
+    const [isRendered, setIsRendered] = useState(false)
+    const ref = useState(Ref)[0]
+
+    useEffect(() => register(ref, setIsRendered), [])
+
+    return { isRendered, onLoad: ref }
+  }
+}
+
+const RenderQueueContext = React.createContext()
+export const useRenderQueueItem = () => useContext(RenderQueueContext)()
+
+export const RenderQueueProvider = ({ children }) => (
+  <RenderQueueContext.Provider value={useState(RenderQueue)[0]}>
+    {children}
+  </RenderQueueContext.Provider>
+)
+export const withRenderQueueProvider = Component => props => (
+  <RenderQueueProvider>
+    <Component {...props} />
+  </RenderQueueProvider>
+)

--- a/src/pages/Watchlists/index.js
+++ b/src/pages/Watchlists/index.js
@@ -5,7 +5,9 @@ import { useUser } from '../../stores/user'
 import { DesktopOnly, MobileOnly } from '../../components/Responsive'
 import StoriesList from '../../components/Stories/StoriesList'
 import RecentlyWatched from '../../components/RecentlyWatched/RecentlyWatched'
-import { WatchlistCards } from '../../ducks/Watchlists/Cards/Card'
+import WatchlistCard, {
+  WatchlistCards
+} from '../../ducks/Watchlists/Cards/Card'
 import FeaturedWatchlistCards from '../../ducks/Watchlists/Cards/Featured'
 import { WatchlistEmptySection } from '../../ducks/Watchlists/Cards/MyWatchlist'
 import {
@@ -13,6 +15,10 @@ import {
   useUserScreeners
 } from '../../ducks/Watchlists/gql/queries'
 import NewWatchlistCard from '../../ducks/Watchlists/Cards/NewCard'
+import {
+  withRenderQueueProvider,
+  useRenderQueueItem
+} from '../../ducks/Watchlists/Cards/marketcapRenderQueue'
 import MobileAnonBanner from '../../ducks/Watchlists/Templates/Anon/WatchlistsAnon'
 import InlineBanner from '../../components/banners/feature/InlineBanner'
 import styles from './index.module.scss'
@@ -27,10 +33,23 @@ const LoginBanner = ({ isDesktop }) =>
     <MobileAnonBanner isFullScreen wrapperClassName={styles.login} />
   )
 
+const Card = props => {
+  const { isRendered, onLoad } = useRenderQueueItem()
+
+  return (
+    <WatchlistCard
+      {...props}
+      skipMarketcap={!isRendered}
+      onMarketcapLoad={onLoad}
+    />
+  )
+}
+
 const Cards = ({ type, path, watchlists }) => (
   <>
     <WatchlistCards
       className={styles.card}
+      Card={Card}
       watchlists={watchlists}
       path={path}
     />
@@ -82,7 +101,7 @@ const Watchlists = ({ isDesktop }) => {
 
       <DesktopOnly>
         <Section isGrid title='Explore watchlists'>
-          <FeaturedWatchlistCards />
+          <FeaturedWatchlistCards Card={Card} />
         </Section>
       </DesktopOnly>
 
@@ -104,4 +123,4 @@ const Watchlists = ({ isDesktop }) => {
   )
 }
 
-export default Watchlists
+export default withRenderQueueProvider(Watchlists)


### PR DESCRIPTION
## Changes
Loading watchlist card's marketcap data by chunks.

## Notion's card
https://www.notion.so/santiment/Watchlists-page-queue-renderer-ebcebc25f67f4e5f9a5bbabb30ca51b8

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (Santiment Academy: Keyboard shortcuts or Account Settings)
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes in module from other person, I've asked how to use it or request a review