### PR TITLE
feature/trends-table-paywall

### DIFF
--- a/src/ducks/TrendsTable/index.js
+++ b/src/ducks/TrendsTable/index.js
@@ -23,8 +23,10 @@ const TrendsTable = ({
     isCompact ? COMPACT_HIDDEN_COLUMNS : hiddenColumnIds
   )
 
-  function onRowClick (_, { currentTarget }) {
-    currentTarget.querySelector(LINK_SELECTOR).click()
+  function onRowClick (_, { target, currentTarget }) {
+    if (!target.closest('a')) {
+      currentTarget.querySelector(LINK_SELECTOR).click()
+    }
   }
 
   return (

--- a/src/ducks/TrendsTable/index.module.scss
+++ b/src/ducks/TrendsTable/index.module.scss
@@ -79,3 +79,23 @@
     }
   }
 }
+
+.paywall {
+  fill: var(--casper);
+  color: var(--casper);
+  padding: 10px 10px 10px 0;
+
+  &:hover {
+    fill: var(--texas-rose);
+    color: var(--texas-rose);
+
+    .upgrade {
+      display: inline-block;
+    }
+  }
+}
+
+.upgrade {
+  margin-left: 10px;
+  display: none;
+}


### PR DESCRIPTION
## Changes
`Trending chart, 7d` column is hidden behind paywall for free users

## Notion's card
https://www.notion.so/santiment/Trends-table-refactoring-715c8a84d05346ca97a7fb87595e67f4

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (Santiment Academy: Keyboard shortcuts or Account Settings)
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes in module from other person, I've asked how to use it or request a review

## Screenshots or GIFs
<img width="807" alt="image" src="https://user-images.githubusercontent.com/25135650/104903454-15743780-5991-11eb-8118-98043e61832d.png">
