### PR TITLE
fix/reset-dash-intervals

### DIFF
--- a/src/components/DashboardMetricChart/DashIntervalSettings/DashIntervalSettings.js
+++ b/src/components/DashboardMetricChart/DashIntervalSettings/DashIntervalSettings.js
@@ -7,27 +7,34 @@ import {
 } from '../../../ducks/Studio/Chart/MetricSettings/IntervalSetting'
 import styles from './DashIntervalSettings.module.scss'
 
-const DashIntervalSettings = ({ settings, metric, setSettings }) => {
+const DashIntervalSettings = ({
+  metrics,
+  updateInterval,
+  metricSettingsMap
+}) => {
+  const metric = useMemo(() => metrics[0], [metrics])
+
   const { activeRef, close, Dropdown } = useDropdown()
   const intervals = useMetricIntervals(metric)
+
   const interval = useMemo(
     () => {
-      const interval = settings && settings.interval
+      const { interval } = metricSettingsMap.get(metric) || {}
       return isAvailableInterval(interval, intervals)
         ? interval
         : intervals[0].key
     },
-    [settings, intervals, metric]
+    [metricSettingsMap, intervals, metric]
   )
 
   function onChange (newInterval) {
-    setSettings({
-      ...settings,
+    updateInterval({
       interval: newInterval
     })
 
     close()
   }
+
   return (
     <div className={styles.settings}>
       <IntervalSettingsTemplate

--- a/src/components/DashboardMetricChart/DashboardMetricChart.js
+++ b/src/components/DashboardMetricChart/DashboardMetricChart.js
@@ -93,7 +93,7 @@ const DashboardMetricChart = ({
   projectSelector
 }) => {
   const MetricTransformer = useMirroredTransformer(metrics)
-  const [MetricSettingsMap] = useState(new Map())
+  const [MetricSettingsMap, setMetricSettingsMap] = useState(new Map())
   const domainGroups = useDomainGroups(metrics)
   const mirrorDomainGroups = useMemo(
     () => extractMirrorMetricsDomainGroups(domainGroups),
@@ -103,6 +103,8 @@ const DashboardMetricChart = ({
   useEffect(
     () => {
       updateTooltipSettings(metrics)
+
+      updateSettingsMap()
     },
     [metrics]
   )
@@ -113,6 +115,22 @@ const DashboardMetricChart = ({
     setSettings,
     onChangeInterval
   } = useChartSettings(defaultInterval)
+
+  function updateSettingsMap ({ interval } = {}) {
+    const map = new Map()
+
+    metrics.forEach(m => {
+      const oldSettings = MetricSettingsMap.get(m)
+
+      map.set(m, {
+        ...oldSettings,
+        interval: interval || settings.interval
+      })
+    })
+
+    setMetricSettingsMap(map)
+  }
+
   const [disabledMetrics, setDisabledMetrics] = useState({})
 
   const activeMetrics = useMemo(
@@ -149,8 +167,6 @@ const DashboardMetricChart = ({
     },
     [loadings, allTimeDataLoadings]
   )
-
-  const firstMetric = useMemo(() => metrics[0], [metrics])
 
   return (
     <>
@@ -204,9 +220,9 @@ const DashboardMetricChart = ({
             colors={MetricColor}
           />
           <DashIntervalSettings
-            settings={settings}
-            metric={firstMetric}
-            setSettings={setSettings}
+            metrics={metrics}
+            metricSettingsMap={MetricSettingsMap}
+            updateInterval={updateSettingsMap}
           />
         </div>
       </DesktopOnly>
@@ -233,9 +249,9 @@ const DashboardMetricChart = ({
           intervals={intervals}
         />
         <DashIntervalSettings
-          settings={settings}
-          metric={firstMetric}
-          setSettings={setSettings}
+          metrics={metrics}
+          metricSettingsMap={MetricSettingsMap}
+          updateInterval={updateSettingsMap}
         />
         <DashboardChartMetrics
           metrics={metrics}

--- a/src/components/Navbar/ChartLayouts/NavbarChartsDropdown.js
+++ b/src/components/Navbar/ChartLayouts/NavbarChartsDropdown.js
@@ -13,6 +13,11 @@ import styles from './NavbarChartsDropdown.module.scss'
 
 const DASHBOARDS = [
   {
+    name: 'Ethereum 2.0 Staking Analytics',
+    to: '/eth2',
+    createdAt: '2021-01-20T00:00:00Z'
+  },
+  {
     name: 'Stablecoins',
     to: '/stablecoins',
     createdAt: '2020-10-01T00:00:00Z'

--- a/src/components/Navbar/ChartLayouts/NavbarChartsDropdown.module.scss
+++ b/src/components/Navbar/ChartLayouts/NavbarChartsDropdown.module.scss
@@ -66,3 +66,7 @@
   top: 0;
   width: 100%;
 }
+
+.new {
+  margin-right: 4px;
+}

--- a/src/ducks/Signals/chart/VisualBacktestChart.js
+++ b/src/ducks/Signals/chart/VisualBacktestChart.js
@@ -33,6 +33,7 @@ export function GetReferenceDots (signals, yAxisId) {
     />
   ))
 }
+
 const renderChart = (data, { key, dataKey = key }, markup, referenceDots) => {
   return (
     <ComposedChart data={data} margin={{ left: 0, right: 0, top: 16 }}>


### PR DESCRIPTION
## Changes

Fix: intervals can be reloaded after changing timeframes

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (Santiment Academy: Keyboard shortcuts or Account Settings)
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [ ] If I make changes in module from other person, I've asked how to use it or request a review

## Screenshots or GIFs
![image](https://user-images.githubusercontent.com/14061779/105170119-8d776480-5b2d-11eb-8019-c551f4778413.png)

P.S. Don't forget about naming conventions for PRs, functions and modules.
