### PR TITLE
fix/dash-charts-intervals

### DIFF
--- a/src/components/DashboardMetricChart/DashIntervalSettings/DashIntervalSettings.js
+++ b/src/components/DashboardMetricChart/DashIntervalSettings/DashIntervalSettings.js
@@ -7,11 +7,7 @@ import {
 } from '../../../ducks/Studio/Chart/MetricSettings/IntervalSetting'
 import styles from './DashIntervalSettings.module.scss'
 
-const DashIntervalSettings = ({
-  metrics,
-  updateInterval,
-  metricSettingsMap
-}) => {
+const DashIntervalSettings = ({ metrics, updateInterval, settings }) => {
   const metric = useMemo(() => metrics[0], [metrics])
 
   const { activeRef, close, Dropdown } = useDropdown()
@@ -19,12 +15,12 @@ const DashIntervalSettings = ({
 
   const interval = useMemo(
     () => {
-      const { interval } = metricSettingsMap.get(metric) || {}
+      const { interval } = settings || {}
       return isAvailableInterval(interval, intervals)
         ? interval
         : intervals[0].key
     },
-    [metricSettingsMap, intervals, metric]
+    [settings, intervals, metric]
   )
 
   function onChange (newInterval) {

--- a/src/components/DashboardMetricChart/DashboardMetricChart.js
+++ b/src/components/DashboardMetricChart/DashboardMetricChart.js
@@ -93,7 +93,7 @@ const DashboardMetricChart = ({
   projectSelector
 }) => {
   const MetricTransformer = useMirroredTransformer(metrics)
-  const [MetricSettingsMap, setMetricSettingsMap] = useState(new Map())
+  const [MetricSettingsMap] = useState(new Map())
   const domainGroups = useDomainGroups(metrics)
   const mirrorDomainGroups = useMemo(
     () => extractMirrorMetricsDomainGroups(domainGroups),
@@ -103,8 +103,6 @@ const DashboardMetricChart = ({
   useEffect(
     () => {
       updateTooltipSettings(metrics)
-
-      updateSettingsMap()
     },
     [metrics]
   )
@@ -117,18 +115,10 @@ const DashboardMetricChart = ({
   } = useChartSettings(defaultInterval)
 
   function updateSettingsMap ({ interval } = {}) {
-    const map = new Map()
-
-    metrics.forEach(m => {
-      const oldSettings = MetricSettingsMap.get(m)
-
-      map.set(m, {
-        ...oldSettings,
-        interval: interval || settings.interval
-      })
+    setSettings({
+      ...settings,
+      interval: interval || settings.interval
     })
-
-    setMetricSettingsMap(map)
   }
 
   const [disabledMetrics, setDisabledMetrics] = useState({})
@@ -221,7 +211,7 @@ const DashboardMetricChart = ({
           />
           <DashIntervalSettings
             metrics={metrics}
-            metricSettingsMap={MetricSettingsMap}
+            settings={settings}
             updateInterval={updateSettingsMap}
           />
         </div>
@@ -250,7 +240,7 @@ const DashboardMetricChart = ({
         />
         <DashIntervalSettings
           metrics={metrics}
-          metricSettingsMap={MetricSettingsMap}
+          settings={settings}
           updateInterval={updateSettingsMap}
         />
         <DashboardChartMetrics

--- a/src/components/SmoothDropdown/SmoothDropdown.js
+++ b/src/components/SmoothDropdown/SmoothDropdown.js
@@ -250,8 +250,7 @@ class SmoothDropdown extends Component {
       dropdownStyles,
       ddFirstTime,
       arrowCorrectionX,
-      ddItems,
-      currentDropdown
+      ddItems
     } = this.state
 
     const { handleMouseEnter, handleMouseLeave, setupDropdownContent } = this

--- a/src/ducks/Studio/timeseries/hooks.js
+++ b/src/ducks/Studio/timeseries/hooks.js
@@ -87,6 +87,7 @@ export function useTimeseries (
       setLoadings(loadings =>
         loadings.filter(loading => metricsSet.has(loading))
       )
+
       setAbortables(abortRemovedMetrics(abortables, metrics, MetricSettingMap))
     },
     [metricsHash, MetricSettingMap]


### PR DESCRIPTION
## Changes

Fixed loading of dashboards charts before selection of intervals.

Bug from discord channel #bug-report

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (Santiment Academy: Keyboard shortcuts or Account Settings)
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [ ] If I make changes in module from other person, I've asked how to use it or request a review


P.S. Don't forget about naming conventions for PRs, functions and modules.
