### PR TITLE
refactor/homepage-trends-table

### DIFF
--- a/src/components/WordCloud/WordCloud.js
+++ b/src/components/WordCloud/WordCloud.js
@@ -4,29 +4,29 @@ import { useWordCloud } from './hooks'
 import Skeleton from '../Skeleton/Skeleton'
 import styles from './WordCloud.module.scss'
 
-export const WordCloud = ({ word, from, to, size, className, onLoad }) => {
-  const { cloud, loading } = useWordCloud({ size, from, to, word, onLoad })
-
-  return (
-    <div className={className}>
-      {loading && (
-        <Skeleton
-          centered
-          className={styles.skeleton}
-          show={loading}
-          repeat={1}
-        />
-      )}
-      <WordCloudContent
-        cloud={cloud}
-        className={className}
-        bigLimit={1}
-        mediumLimit={3}
-        padding={8}
-        showBadge={false}
+export const WordCloud = ({ cloud, className, isLoading }) => (
+  <div className={className}>
+    {isLoading && (
+      <Skeleton
+        centered
+        className={styles.skeleton}
+        show={isLoading}
+        repeat={1}
       />
-    </div>
-  )
-}
+    )}
+    <WordCloudContent
+      cloud={cloud}
+      className={className}
+      bigLimit={1}
+      mediumLimit={3}
+      padding={8}
+      showBadge={false}
+    />
+  </div>
+)
 
-export default WordCloud
+export default props => {
+  const { cloud, loading } = useWordCloud(props)
+
+  return <WordCloud {...props} cloud={cloud} isLoading={loading} />
+}

--- a/src/ducks/TrendsTable/columns.js
+++ b/src/ducks/TrendsTable/columns.js
@@ -1,14 +1,18 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import Icon from '@santiment-network/ui/Icon'
-import { useTrendSocialVolume, useTrendSocialVolumeChange } from './hooks'
+import {
+  useTrendWordContext,
+  useTrendSocialVolume,
+  useTrendSocialVolumeChange
+} from './hooks'
 import { prepareColumns } from '../_Table'
 import { INDEX_COLUMN } from '../_Table/columns'
 import { useRenderQueueItem } from '../renderQueue/sized'
 import { Skeleton } from '../../components/Skeleton'
 import MiniChart from '../../components/MiniChart'
 import PercentChanges from '../../components/PercentChanges'
-import WordCloud from '../../components/WordCloud/WordCloud'
+import { WordCloud } from '../../components/WordCloud/WordCloud'
 import { useUserSubscriptionStatus } from '../../stores/user/subscriptions'
 import styles from './index.module.scss'
 
@@ -69,17 +73,14 @@ const TrendingChart = ({ trend }) => {
 }
 
 const ConnectedWords = ({ word }) => {
-  const { isRendered, onLoad } = useRenderQueueItem()
+  const { data, isLoading } = useTrendWordContext(word)
 
-  return isRendered ? (
+  return (
     <WordCloud
       className={styles.cloud__words}
-      size={6}
-      word={word}
-      onLoad={onLoad}
+      cloud={data}
+      isLoading={isLoading}
     />
-  ) : (
-    <Loader />
   )
 }
 

--- a/src/ducks/TrendsTable/hooks.js
+++ b/src/ducks/TrendsTable/hooks.js
@@ -2,13 +2,14 @@ import { useMemo } from 'react'
 import { useQuery } from '@apollo/react-hooks'
 import {
   TRENDING_WORDS_QUERY,
+  TRENDING_WORDS_CONTEXT_QUERY,
   SOCIAL_VOLUME_QUERY,
   LAST_DAY_SOCIAL_VOLUME_QUERY
 } from './queries'
 import { calcPercentageChange } from '../../utils/utils'
 
 const ARRAY = []
-export const useTrendingWords = variables => {
+export function useTrendingWords (variables) {
   const { data, loading } = useQuery(TRENDING_WORDS_QUERY, { variables })
 
   let trendingWords = ARRAY
@@ -22,7 +23,7 @@ export const useTrendingWords = variables => {
   return { trendingWords, isLoading: loading }
 }
 
-export const useTrendSocialVolumeChange = (trend, skip, onLoad) => {
+export function useTrendSocialVolumeChange (trend, skip, onLoad) {
   const { data } = useQuery(LAST_DAY_SOCIAL_VOLUME_QUERY, {
     skip,
     variables: trend
@@ -54,7 +55,7 @@ const LOADING = {
   data: ARRAY,
   isLoading: true
 }
-export const useTrendSocialVolume = (trend, skip, onLoad) => {
+export function useTrendSocialVolume (trend, skip, onLoad) {
   const { data } = useQuery(SOCIAL_VOLUME_QUERY, { skip, variables: trend })
 
   return useMemo(
@@ -65,6 +66,25 @@ export const useTrendSocialVolume = (trend, skip, onLoad) => {
       const socialVolumes = data.getMetric.timeseriesData
       return {
         data: [...socialVolumes, { value: trend.score }],
+        isLoading: false
+      }
+    },
+    [data]
+  )
+}
+
+export function useTrendWordContext (trend) {
+  const { data } = useQuery(TRENDING_WORDS_CONTEXT_QUERY)
+  return useMemo(
+    () => {
+      if (!data) return LOADING
+
+      const trendWord = data.getTrendingWords[0].topWords.find(
+        ({ word }) => word === trend
+      )
+
+      return {
+        data: trendWord ? trendWord.context.slice(0, 6) : ARRAY,
         isLoading: false
       }
     },

--- a/src/ducks/TrendsTable/queries.js
+++ b/src/ducks/TrendsTable/queries.js
@@ -14,6 +14,23 @@ export const TRENDING_WORDS_QUERY = gql`
     }
   }
 `
+export const TRENDING_WORDS_CONTEXT_QUERY = gql`
+  query getTrendingWords(
+    $from: DateTime = "utc_now-1h"
+    $to: DateTime = "utc_now"
+    $interval: interval = "1h"
+  ) {
+    getTrendingWords(size: 10, from: $from, to: $to, interval: $interval) {
+      topWords {
+        word
+        context {
+          word
+          score
+        }
+      }
+    }
+  }
+`
 
 const newSocialVolumeQuery = (from, interval = '1d') => gql`
   query getMetric($word: String!) {


### PR DESCRIPTION
## Changes
Reducing `WordContext` queries for trend words to the single query.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<img width="811" alt="image" src="https://user-images.githubusercontent.com/25135650/106903857-95c5c700-670b-11eb-8e7a-cc468600d9f3.png">

