### PR TITLE
feature/studio-multi-y-axes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@apollo/react-testing": "^3.1.3",
     "@bitquery/graph": "https://github.com/bitquery/graphs#9d0d6e2",
     "@nivo/chord": "^0.62.0",
-    "@santiment-network/chart": "^0.9.1",
+    "@santiment-network/chart": "^0.9.2",
     "@santiment-network/ui": "^0.5.221",
     "@sentry/react": "^5.24.2",
     "@trainline/react-skeletor": "^1.0.2",

--- a/src/ducks/Chart/Axes/helpers.js
+++ b/src/ducks/Chart/Axes/helpers.js
@@ -44,7 +44,7 @@ function yFormatter (value) {
   return Math.trunc(value)
 }
 
-const selectYFormatter = metricKey =>
+export const selectYFormatter = metricKey =>
   mirroredMetrics.includes(metricKey)
     ? value => yFormatter(Math.abs(value))
     : (TooltipSetting[metricKey] && TooltipSetting[metricKey].axisFormatter) ||

--- a/src/ducks/Chart/Drawer/events.js
+++ b/src/ducks/Chart/Drawer/events.js
@@ -73,7 +73,7 @@ export function handleLineCreation (
 
 export function handleLineHover (chart) {
   return e => {
-    const { isDrawing, drawer } = chart
+    const { isDrawing, drawer, tooltip } = chart
     if (isDrawing) return
 
     const { drawings, ctx } = drawer
@@ -93,11 +93,9 @@ export function handleLineHover (chart) {
     }
 
     drawer.mouseover = hoveredLine
-    if (hoveredLine) {
-      document.body.style.cursor = 'pointer'
-    } else {
-      document.body.style.cursor = ''
-    }
+
+    const { canvas, cursor } = tooltip || chart
+    canvas.style.cursor = hoveredLine ? 'pointer' : cursor
 
     drawer.redraw()
   }

--- a/src/ducks/Chart/MultiAxes/helpers.js
+++ b/src/ducks/Chart/MultiAxes/helpers.js
@@ -4,13 +4,44 @@ import {
   drawAxisLine,
   drawYAxisTicks
 } from '@santiment-network/chart/axes'
+import { drawValueBubbleY } from '@santiment-network/chart/tooltip'
 import { dayTicksPaintConfig, dayAxesColor } from '../paintConfigs'
 import {
   isDayInterval,
   getDateDayMonthYear,
-  getDateHoursMinutes
+  getDateHoursMinutes,
+  yBubbleFormatter
 } from '../utils'
 import { selectYFormatter } from '../Axes/helpers'
+
+function getLastMetricPoint (chart, domain) {
+  const { points, axesMetricKeys } = chart
+  const LastMetricPoint = {}
+  let unfoundMetricKeys = axesMetricKeys.slice()
+
+  for (let i = axesMetricKeys.length - 1; i >= 0; i--) {
+    const domainDependencies = domain[axesMetricKeys[i]]
+    if (domainDependencies) {
+      unfoundMetricKeys = unfoundMetricKeys.concat(domainDependencies)
+    }
+  }
+
+  for (let i = points.length - 1; i >= 0 && unfoundMetricKeys.length; i--) {
+    const point = points[i]
+
+    for (let j = unfoundMetricKeys.length - 1; j >= 0; j--) {
+      const metricKey = unfoundMetricKeys[j]
+      const metricPoint = point[metricKey]
+
+      if (metricPoint && Number.isFinite(metricPoint.value)) {
+        LastMetricPoint[metricKey] = metricPoint
+        unfoundMetricKeys.splice(j, 1)
+      }
+    }
+  }
+
+  return LastMetricPoint
+}
 
 function getDomainObject (domainGroups) {
   const domain = {}
@@ -23,6 +54,32 @@ function getDomainObject (domainGroups) {
   }
 
   return domain
+}
+
+function plotMetricLastValueBubble (
+  chart,
+  LastMetricPoint,
+  metricKey,
+  offset,
+  bgColor
+) {
+  const metricPoint = LastMetricPoint[metricKey]
+  if (!metricPoint) return
+
+  const { y, value } = metricPoint
+  const { ctx, bubblesPaintConfig } = chart
+  const paintConfig = Object.assign({}, bubblesPaintConfig, {
+    bgColor
+  })
+
+  drawValueBubbleY(
+    chart,
+    ctx,
+    yBubbleFormatter(value, metricKey),
+    y,
+    paintConfig,
+    offset
+  )
 }
 
 function plotXAxis (chart, formatter) {
@@ -52,10 +109,14 @@ function plotYAxes (chart, scale) {
 
   const domain = getDomainObject(domainGroups)
   let offset = right
+  let lastValueOffset = 0
   ctx.textAlign = 'left'
 
+  const LastMetricPoint = getLastMetricPoint(chart, domain)
+
   axesMetricKeys.forEach(metricKey => {
-    drawAxisLine(ctx, colors[metricKey], offset, top, offset, bottom)
+    const color = colors[metricKey]
+    drawAxisLine(ctx, color, offset, top, offset, bottom)
 
     const domainDependencies = domain[metricKey]
     if (domainDependencies) {
@@ -63,14 +124,17 @@ function plotYAxes (chart, scale) {
 
       domainDependencies.forEach(domainMetricKey => {
         const resultOffset = offset + domainOffset
-        drawAxisLine(
-          ctx,
-          colors[domainMetricKey],
-          resultOffset,
-          top,
-          resultOffset,
-          bottom
+        const color = colors[domainMetricKey]
+
+        drawAxisLine(ctx, color, resultOffset, top, resultOffset, bottom)
+        plotMetricLastValueBubble(
+          chart,
+          LastMetricPoint,
+          domainMetricKey,
+          lastValueOffset,
+          color
         )
+
         domainOffset += 2
       })
     }
@@ -83,8 +147,16 @@ function plotYAxes (chart, scale) {
       offset + 6,
       yAxesTicks
     )
+    plotMetricLastValueBubble(
+      chart,
+      LastMetricPoint,
+      metricKey,
+      lastValueOffset,
+      color
+    )
 
     offset += 50
+    lastValueOffset += 50
   })
 }
 

--- a/src/ducks/Chart/MultiAxes/helpers.js
+++ b/src/ducks/Chart/MultiAxes/helpers.js
@@ -12,6 +12,19 @@ import {
 } from '../utils'
 import { selectYFormatter } from '../Axes/helpers'
 
+function getDomainObject (domainGroups) {
+  const domain = {}
+
+  for (let i = domainGroups.length - 1; i >= 0; i--) {
+    const group = domainGroups[i]
+    if (group) {
+      domain[group[0]] = group.slice(1)
+    }
+  }
+
+  return domain
+}
+
 function plotXAxis (chart, formatter) {
   const { axesColor = dayAxesColor, xAxesTicks = 10, scale } = chart
 
@@ -32,10 +45,12 @@ function plotYAxes (chart, scale) {
     bottom,
     colors,
     axesMetricKeys,
+    domainGroups,
     yAxesTicks = 8
   } = chart
   if (!axesMetricKeys) return
 
+  const domain = getDomainObject(domainGroups)
   let offset = right
   ctx.textAlign = 'left'
 
@@ -49,6 +64,24 @@ function plotYAxes (chart, scale) {
       yAxesTicks
     )
     drawAxisLine(ctx, colors[metricKey], offset, top, offset, bottom)
+
+    const domainDependencies = domain[metricKey]
+    if (domainDependencies) {
+      let domainOffset = 2
+
+      domainDependencies.forEach(domainMetricKey => {
+        const resultOffset = offset + domainOffset
+        drawAxisLine(
+          ctx,
+          colors[domainMetricKey],
+          resultOffset,
+          top,
+          resultOffset,
+          bottom
+        )
+        domainOffset += 2
+      })
+    }
 
     offset += 50
   })

--- a/src/ducks/Chart/MultiAxes/helpers.js
+++ b/src/ducks/Chart/MultiAxes/helpers.js
@@ -55,14 +55,6 @@ function plotYAxes (chart, scale) {
   ctx.textAlign = 'left'
 
   axesMetricKeys.forEach(metricKey => {
-    drawYAxisTicks(
-      chart,
-      metricKey,
-      selectYFormatter(metricKey),
-      scale,
-      offset + 6,
-      yAxesTicks
-    )
     drawAxisLine(ctx, colors[metricKey], offset, top, offset, bottom)
 
     const domainDependencies = domain[metricKey]
@@ -82,6 +74,15 @@ function plotYAxes (chart, scale) {
         domainOffset += 2
       })
     }
+
+    drawYAxisTicks(
+      chart,
+      metricKey,
+      selectYFormatter(metricKey),
+      scale,
+      offset + 6,
+      yAxesTicks
+    )
 
     offset += 50
   })

--- a/src/ducks/Chart/MultiAxes/helpers.js
+++ b/src/ducks/Chart/MultiAxes/helpers.js
@@ -1,0 +1,70 @@
+import {
+  drawAxes,
+  drawXAxisTicks,
+  drawAxisLine,
+  drawYAxisTicks
+} from '@santiment-network/chart/axes'
+import { dayTicksPaintConfig, dayAxesColor } from '../paintConfigs'
+import {
+  isDayInterval,
+  getDateDayMonthYear,
+  getDateHoursMinutes
+} from '../utils'
+import { selectYFormatter } from '../Axes/helpers'
+
+function plotXAxis (chart, formatter) {
+  const { axesColor = dayAxesColor, xAxesTicks = 10, scale } = chart
+
+  drawXAxisTicks(
+    chart,
+    isDayInterval(chart) ? getDateHoursMinutes : getDateDayMonthYear,
+    scale,
+    xAxesTicks
+  )
+  drawAxes(chart, axesColor)
+}
+
+function plotYAxes (chart, scale) {
+  const {
+    ctx,
+    top,
+    right,
+    bottom,
+    colors,
+    axesMetricKeys,
+    yAxesTicks = 8
+  } = chart
+  if (!axesMetricKeys) return
+
+  let offset = right
+  ctx.textAlign = 'left'
+
+  axesMetricKeys.forEach(metricKey => {
+    drawYAxisTicks(
+      chart,
+      metricKey,
+      selectYFormatter(metricKey),
+      scale,
+      offset + 6,
+      yAxesTicks
+    )
+    drawAxisLine(ctx, colors[metricKey], offset, top, offset, bottom)
+
+    offset += 50
+  })
+}
+
+export function plotAxes (chart, scale) {
+  const { ctx, ticksPaintConfig = dayTicksPaintConfig } = chart
+
+  ctx.save()
+
+  const { color, font } = ticksPaintConfig
+  ctx.fillStyle = color
+  ctx.font = font
+
+  plotXAxis(chart, scale)
+  plotYAxes(chart, scale)
+
+  ctx.restore()
+}

--- a/src/ducks/Chart/MultiAxes/index.js
+++ b/src/ducks/Chart/MultiAxes/index.js
@@ -9,6 +9,7 @@ const MultiAxes = buildPlotter(({ plotter }, { metrics, xTicks, yTicks }) => {
         chart.axesMetricKeys = metrics
         chart.xAxesTicks = xTicks
         chart.yAxesTicks = yTicks
+        chart.isMultiAxes = true
 
         plotAxes(chart, scale)
       })

--- a/src/ducks/Chart/MultiAxes/index.js
+++ b/src/ducks/Chart/MultiAxes/index.js
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+import { plotAxes } from './helpers'
+import { buildPlotter } from '../context'
+
+const MultiAxes = buildPlotter(({ plotter }, { metrics, xTicks, yTicks }) => {
+  useEffect(
+    () => {
+      plotter.register('axes', (chart, scale) => {
+        chart.axesMetricKeys = metrics
+        chart.xAxesTicks = xTicks
+        chart.yAxesTicks = yTicks
+
+        plotAxes(chart, scale)
+      })
+    },
+    [metrics, xTicks, yTicks]
+  )
+})
+
+MultiAxes.defaultProps = {
+  xTicks: 10,
+  yTicks: 8
+}
+
+export default MultiAxes

--- a/src/ducks/Chart/Tooltip/helpers.js
+++ b/src/ducks/Chart/Tooltip/helpers.js
@@ -112,6 +112,8 @@ export function setupTooltip (chart, marker) {
 export function plotTooltip (chart, marker, point, event) {
   const {
     tooltip: { ctx },
+    scale,
+    minMaxes,
     cursorType,
     tooltipKey,
     axesMetricKeys,
@@ -121,8 +123,10 @@ export function plotTooltip (chart, marker, point, event) {
   } = chart
   let metricPoint = point[tooltipKey]
   if (!metricPoint || isNaN(metricPoint.y)) {
-    metricPoint =
-      point[axesMetricKeys.find(key => point[key] && !isNaN(point[key].y))]
+    axesMetricKeys.some(key => {
+      metricPoint = point[key]
+      return metricPoint && !isNaN(metricPoint.y)
+    })
     if (!metricPoint) return
   }
 
@@ -151,14 +155,11 @@ export function plotTooltip (chart, marker, point, event) {
   drawTooltip(ctx, point, TooltipSetting, marker, tooltipPaintConfig)
 
   let offset = 0
+  const isLogScale = scale === logScale
   axesMetricKeys.forEach((metricKey, i) => {
-    const { min, max } = chart.minMaxes[metricKey]
-    const value = (chart.scale === logScale ? valueByLogY : valueByY)(
-      chart,
-      y,
-      min,
-      max
-    )
+    const { min, max } = minMaxes[metricKey]
+    const valueScaler = isLogScale ? valueByLogY : valueByY
+    const value = valueScaler(chart, y, min, max)
 
     drawValueBubbleY(
       chart,

--- a/src/ducks/Chart/Tooltip/helpers.js
+++ b/src/ducks/Chart/Tooltip/helpers.js
@@ -109,6 +109,9 @@ export function setupTooltip (chart, marker) {
   }
 }
 
+const checkIsValidMetricPoint = metricPoint =>
+  metricPoint && Number.isFinite(metricPoint.y)
+
 export function plotTooltip (chart, marker, point, event) {
   const {
     tooltip: { ctx },
@@ -122,12 +125,12 @@ export function plotTooltip (chart, marker, point, event) {
     bubblesPaintConfig
   } = chart
   let metricPoint = point[tooltipKey]
-  if (!metricPoint || isNaN(metricPoint.y)) {
+  if (!checkIsValidMetricPoint(metricPoint)) {
     axesMetricKeys.some(key => {
       metricPoint = point[key]
-      return metricPoint && !isNaN(metricPoint.y)
+      return checkIsValidMetricPoint(metricPoint)
     })
-    if (!metricPoint) return
+    if (!checkIsValidMetricPoint(metricPoint)) return
   }
 
   clearCtx(chart, ctx)

--- a/src/ducks/Chart/Tooltip/helpers.js
+++ b/src/ducks/Chart/Tooltip/helpers.js
@@ -25,8 +25,6 @@ import {
 import { CursorType } from '../cursor'
 import { TooltipSetting } from '../../dataHub/tooltipSettings'
 
-const metricValueAccessor = ({ value }) => value || value === 0
-
 export function setupTooltip (chart, marker) {
   const { canvas, ctx } = chart.tooltip
 

--- a/src/ducks/Chart/Tooltip/index.js
+++ b/src/ducks/Chart/Tooltip/index.js
@@ -34,18 +34,22 @@ const Tooltip = ({
   chart.onRangeSelected = onRangeSelected
 
   useEffect(() => {
-    const { canvas } = initTooltip(chart).tooltip
+    const { tooltip } = initTooltip(chart)
+    const { canvas } = tooltip
 
-    return observePressedModifier(
-      ({ altKey }) =>
-        (canvas.style.cursor = (altKey
-          ? FlippedCursorTypeStyle
-          : CursorTypeStyle)[chart.cursorType])
-    )
+    return observePressedModifier(({ altKey }) => {
+      const cursor = (altKey ? FlippedCursorTypeStyle : CursorTypeStyle)[
+        chart.cursorType
+      ]
+
+      tooltip.cursor = cursor
+      canvas.style.cursor = cursor
+    })
   }, [])
 
   useEffect(
     () => {
+      chart.tooltip.cursor = CursorTypeStyle[cursorType]
       chart.tooltip.canvas.style.cursor = CursorTypeStyle[cursorType]
     },
     [cursorType]

--- a/src/ducks/Chart/hooks.js
+++ b/src/ducks/Chart/hooks.js
@@ -5,6 +5,7 @@ import { checkIfAreMirrored } from '../dataHub/metrics/mirrored'
 
 const splitByComma = str => str.split(',')
 const lineMetricsFilter = ({ node }) => LINES.has(node)
+const getKey = ({ key }) => key
 const getDomainGroup = ({ key, domainGroup = key }) => domainGroup
 const checkIfIsIndicatorOf = ({ key }, { indicator, queryKey }) =>
   indicator && key === queryKey
@@ -132,6 +133,43 @@ export function useTooltipMetricKey (metrics) {
       return tooltipKey.key
     },
     [metrics]
+  )
+}
+
+function getDomainDependencies (domainGroups) {
+  let domain = []
+
+  const { length } = domainGroups
+  for (let i = 0; i < length; i++) {
+    const domainGroup = domainGroups[i]
+    if (domainGroup) {
+      domain = domain.concat(domainGroup.slice(1))
+    }
+  }
+
+  return domain
+}
+
+export function useMultiAxesMetricKeys (metrics, domainGroups) {
+  return useMemo(
+    () => {
+      if (!domainGroups.length) return metrics.map(getKey)
+
+      const axesMetrics = []
+      const domainDependencies = new Set(getDomainDependencies(domainGroups))
+
+      const { length } = metrics
+      for (let i = 1; i < length; i++) {
+        const metric = metrics[i]
+
+        if (domainDependencies.has(metric)) continue
+
+        axesMetrics.push(metric)
+      }
+
+      return axesMetrics.map(getKey)
+    },
+    [metrics, domainGroups]
   )
 }
 

--- a/src/ducks/Chart/hooks.js
+++ b/src/ducks/Chart/hooks.js
@@ -150,21 +150,23 @@ function getDomainDependencies (domainGroups) {
   return domain
 }
 
+// TODO: Refactor [@vanguard | Feb 17, 2021]
 export function useMultiAxesMetricKeys (widget, metrics, domainGroups) {
   const { axesMetricSet, disabledAxesMetricSet } = widget
 
   return useMemo(
     () => {
       let axesMetrics
+      let domainDependencies = new Set()
 
       if (!domainGroups.length) {
         axesMetrics = metrics
       } else {
         axesMetrics = []
-        const domainDependencies = new Set(getDomainDependencies(domainGroups))
+        domainDependencies = new Set(getDomainDependencies(domainGroups))
 
         const { length } = metrics
-        for (let i = 1; i < length; i++) {
+        for (let i = 0; i < length; i++) {
           const metric = metrics[i]
 
           if (domainDependencies.has(metric)) continue
@@ -180,11 +182,17 @@ export function useMultiAxesMetricKeys (widget, metrics, domainGroups) {
       })
 
       const result = [...metricSet]
+
       if (result.length !== axesMetricSet.size && axesMetricSet.size < 3) {
         result.forEach(metric => axesMetricSet.add(metric))
       }
 
-      return result.filter(metric => axesMetricSet.has(metric)).map(getKey)
+      return result
+        .filter(
+          metric =>
+            axesMetricSet.has(metric) && !domainDependencies.has(metric.key)
+        )
+        .map(getKey)
     },
     [axesMetricSet, metrics, domainGroups]
   )

--- a/src/ducks/Chart/hooks.js
+++ b/src/ducks/Chart/hooks.js
@@ -150,26 +150,43 @@ function getDomainDependencies (domainGroups) {
   return domain
 }
 
-export function useMultiAxesMetricKeys (metrics, domainGroups) {
+export function useMultiAxesMetricKeys (widget, metrics, domainGroups) {
+  const { axesMetricSet, disabledAxesMetricSet } = widget
+
   return useMemo(
     () => {
-      if (!domainGroups.length) return metrics.map(getKey)
+      let axesMetrics
 
-      const axesMetrics = []
-      const domainDependencies = new Set(getDomainDependencies(domainGroups))
+      if (!domainGroups.length) {
+        axesMetrics = metrics
+      } else {
+        axesMetrics = []
+        const domainDependencies = new Set(getDomainDependencies(domainGroups))
 
-      const { length } = metrics
-      for (let i = 1; i < length; i++) {
-        const metric = metrics[i]
+        const { length } = metrics
+        for (let i = 1; i < length; i++) {
+          const metric = metrics[i]
 
-        if (domainDependencies.has(metric)) continue
+          if (domainDependencies.has(metric)) continue
 
-        axesMetrics.push(metric)
+          axesMetrics.push(metric)
+        }
       }
 
-      return axesMetrics.map(getKey)
+      const metricSet = new Set(axesMetrics)
+
+      disabledAxesMetricSet.forEach(disabledMetric => {
+        metricSet.delete(disabledMetric)
+      })
+
+      const result = [...metricSet]
+      if (result.length !== axesMetricSet.size && axesMetricSet.size < 3) {
+        result.forEach(metric => axesMetricSet.add(metric))
+      }
+
+      return result.filter(metric => axesMetricSet.has(metric)).map(getKey)
     },
-    [metrics, domainGroups]
+    [axesMetricSet, metrics, domainGroups]
   )
 }
 

--- a/src/ducks/SANCharts/ChartDownloadBtn.js
+++ b/src/ducks/SANCharts/ChartDownloadBtn.js
@@ -4,6 +4,7 @@ import { initChart, updateChartState } from '@santiment-network/chart'
 import { paintConfigs } from '../Chart/paintConfigs'
 import { metricsToPlotCategories } from '../Chart/Synchronizer'
 import { domainModifier } from '../Chart/domain'
+import { getMultiAxesChartPadding } from '../Studio/Chart/Canvas'
 import { getDateFormats, getTimeFormats } from '../../utils/dates'
 import { useTheme } from '../../stores/ui/theme'
 import { mirage } from '@santiment-network/ui/variables.scss'
@@ -69,7 +70,7 @@ function downloadChart (
   MetricNode,
   isNightMode
 ) {
-  const { scale, colors, domainGroups, plotter } = chart
+  const { scale, colors, domainGroups, plotter, axesMetricKeys } = chart
   const { brushPaintConfig, ...rest } = paintConfigs[+isNightMode]
 
   const categories = metricsToPlotCategories(metrics, MetricNode)
@@ -78,11 +79,17 @@ function downloadChart (
   const dpr = window.devicePixelRatio || 1
   window.devicePixelRatio = 2
   const pngCanvas = document.createElement('canvas')
-  const pngChart = initChart(pngCanvas, PNG_WIDTH, PNG_HEIGHT, CHART_PADDING)
+  const pngChart = initChart(
+    pngCanvas,
+    PNG_WIDTH,
+    PNG_HEIGHT,
+    chart.isMultiAxes ? getMultiAxesChartPadding(axesMetricKeys) : CHART_PADDING
+  )
   window.devicePixelRatio = dpr
 
   Object.assign(pngChart, rest)
-  pngChart.axesMetricKeys = chart.axesMetricKeys
+  pngChart.axesMetricKeys = axesMetricKeys
+  pngChart.domainGroups = domainGroups
   pngChart.colors = chart.colors
   pngChart.ticksPaintConfig = {
     ...pngChart.ticksPaintConfig,
@@ -136,6 +143,7 @@ const ChartDownloadBtn = ({
         try {
           downloadChart(chartRef, title, metrics, data, MetricNode, isNightMode)
         } catch (e) {
+          console.error(e)
           alert("Can't download this chart")
         }
       }}

--- a/src/ducks/Studio/Chart/Canvas.js
+++ b/src/ducks/Studio/Chart/Canvas.js
@@ -60,7 +60,6 @@ const Canvas = ({
   ...props
 }) => {
   const axesMetricKeys = useMultiAxesMetricKeys(metrics, props.domainGroups)
-
   const padding = useChartPadding(axesMetricKeys)
   const isDrawing = isDrawingState[0]
   const { from, to } = settings

--- a/src/ducks/Studio/Chart/Canvas.js
+++ b/src/ducks/Studio/Chart/Canvas.js
@@ -38,6 +38,7 @@ function useChartPadding (axesMetricKeys) {
 }
 
 const Canvas = ({
+  widget,
   data,
   brushData,
   metrics,
@@ -59,7 +60,11 @@ const Canvas = ({
   setIsICOPriceDisabled,
   ...props
 }) => {
-  const axesMetricKeys = useMultiAxesMetricKeys(metrics, props.domainGroups)
+  const axesMetricKeys = useMultiAxesMetricKeys(
+    widget,
+    metrics,
+    props.domainGroups
+  )
   const padding = useChartPadding(axesMetricKeys)
   const isDrawing = isDrawingState[0]
   const { from, to } = settings

--- a/src/ducks/Studio/Chart/Canvas.js
+++ b/src/ducks/Studio/Chart/Canvas.js
@@ -23,19 +23,16 @@ const PADDING = {
   left: 5
 }
 
-function useChartPadding (axesMetricKeys) {
-  return useMemo(
-    () =>
-      Object.assign(
-        {
-          right: axesMetricKeys.length * 50
-        },
-        PADDING
-      ),
-
-    [axesMetricKeys]
+export const getMultiAxesChartPadding = (axesMetricKeys, axesOffset = 50) =>
+  Object.assign(
+    {
+      right: axesMetricKeys.length * axesOffset
+    },
+    PADDING
   )
-}
+
+const useChartPadding = axesMetricKeys =>
+  useMemo(() => getMultiAxesChartPadding(axesMetricKeys), [axesMetricKeys])
 
 const Canvas = ({
   widget,

--- a/src/ducks/Studio/Chart/Canvas.js
+++ b/src/ducks/Studio/Chart/Canvas.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import Insights from './Insights'
 import IcoPrice from './IcoPrice'
 import LastDayPrice from './LastDayPrice'
@@ -9,9 +9,9 @@ import Bars from '../../Chart/Bars'
 import GreenRedBars from '../../Chart/GreenRedBars'
 import Tooltip from '../../Chart/Tooltip'
 import Drawer from '../../Chart/Drawer'
-import Axes from '../../Chart/Axes'
+import Axes from '../../Chart/MultiAxes'
 import CartesianGrid from '../../Chart/CartesianGrid'
-import { useAxesMetricsKey } from '../../Chart/hooks'
+import { useMultiAxesMetricKeys } from '../../Chart/hooks'
 import Watermark from '../../Chart/Watermark'
 import Brush from '../../Chart/Brush'
 import Signals from '../../Chart/Signals'
@@ -19,14 +19,22 @@ import styles from './index.module.scss'
 
 const PADDING = {
   top: 10,
-  right: 50,
   bottom: 73,
   left: 5
 }
 
-const DOUBLE_AXIS_PADDING = {
-  ...PADDING,
-  left: 50
+function useChartPadding (axesMetricKeys) {
+  return useMemo(
+    () =>
+      Object.assign(
+        {
+          right: axesMetricKeys.length * 50
+        },
+        PADDING
+      ),
+
+    [axesMetricKeys]
+  )
 }
 
 const Canvas = ({
@@ -51,7 +59,9 @@ const Canvas = ({
   setIsICOPriceDisabled,
   ...props
 }) => {
-  const axesMetricKeys = useAxesMetricsKey(metrics, isDomainGroupingActive)
+  const axesMetricKeys = useMultiAxesMetricKeys(metrics, props.domainGroups)
+
+  const padding = useChartPadding(axesMetricKeys)
   const isDrawing = isDrawingState[0]
   const { from, to } = settings
   const {
@@ -61,11 +71,7 @@ const Canvas = ({
   } = options
 
   return (
-    <ResponsiveChart
-      padding={axesMetricKeys[1] ? DOUBLE_AXIS_PADDING : PADDING}
-      {...props}
-      data={data}
-    >
+    <ResponsiveChart padding={padding} {...props} data={data}>
       <Watermark light={isWatermarkLighter} show={isWatermarkVisible} />
       <GreenRedBars />
       <Bars />

--- a/src/ducks/Studio/Chart/Fullscreen/index.js
+++ b/src/ducks/Studio/Chart/Fullscreen/index.js
@@ -133,6 +133,7 @@ const FullscreenChart = ({
       />
       <ChartCanvas
         className={styles.chart}
+        widget={widget}
         options={options}
         settings={settings}
         categories={categories}

--- a/src/ducks/Studio/Chart/MetricSettings/ShowAxisSetting.js
+++ b/src/ducks/Studio/Chart/MetricSettings/ShowAxisSetting.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Checkbox } from '@santiment-network/ui/Checkboxes'
+import Setting from './Setting'
+import styles from './index.module.scss'
+
+export const ShowAxisSetting = ({ metric, widget, rerenderWidgets }) => {
+  const { axesMetricSet } = widget
+  const isActive = axesMetricSet.has(metric)
+  const isDisabled = isActive && axesMetricSet.size < 2
+
+  function onClick () {
+    if (isDisabled) return
+
+    const newSet = new Set(axesMetricSet)
+    if (isActive) {
+      newSet.delete(metric)
+      widget.disabledAxesMetricSet.add(metric)
+    } else {
+      newSet.add(metric)
+      widget.disabledAxesMetricSet.delete(metric)
+    }
+
+    widget.axesMetricSet = newSet
+    rerenderWidgets()
+  }
+
+  return (
+    <Setting isDropdown={false} onClick={onClick}>
+      Show axis
+      <Checkbox
+        isActive={isActive}
+        disabled={isDisabled}
+        className={styles.arrow}
+      />
+    </Setting>
+  )
+}
+
+export default ShowAxisSetting

--- a/src/ducks/Studio/Chart/MetricSettings/index.js
+++ b/src/ducks/Studio/Chart/MetricSettings/index.js
@@ -6,6 +6,7 @@ import ColorSetting from './ColorSetting'
 import IntervalSetting from './IntervalSetting'
 import ExchangeSetting from './ExchangeSetting'
 import IndicatorsSetting from './IndicatorsSetting'
+import ShowAxisSetting from './ShowAxisSetting'
 import { Metric } from '../../../dataHub/metrics'
 import { MetricSettings } from '../../../dataHub/metrics/settings'
 import { Node } from '../../../Chart/nodes'
@@ -49,6 +50,7 @@ const Settings = ({ className, metric, ...props }) => {
       {isIndicatorAssignable(metric) && (
         <IndicatorsSetting metric={metric} {...props} />
       )}
+      <ShowAxisSetting metric={metric} {...props} />
       {settings &&
         settings.map(({ key }) => {
           const Setting = SettingToComponent[key]

--- a/src/ducks/Studio/Chart/index.js
+++ b/src/ducks/Studio/Chart/index.js
@@ -17,7 +17,7 @@ import { useMetricCategories } from '../../Chart/Synchronizer'
 import { useDomainGroups } from '../../Chart/hooks'
 import { useHighlightMetricColor } from '../../Chart/colors'
 import { extractMirrorMetricsDomainGroups } from '../../Chart/utils'
-import { useChartCursorType } from '../../Chart/cursor'
+import { CursorType, useChartCursorType } from '../../Chart/cursor'
 import { useUser } from '../../../stores/user'
 import { getTimeIntervalFromToday, DAY } from '../../../utils/dates'
 import styles from './index.module.scss'
@@ -55,7 +55,7 @@ const Chart = ({
   syncTooltips
 }) => {
   const { isLoggedIn } = useUser()
-  const chartCursor = useChartCursorType()
+  const chartCursor = useChartCursorType(CursorType.FREE)
   const isNewDrawingState = useState(false)
   const isDrawingState = useState(false)
   const selectedLineState = useState()

--- a/src/ducks/Studio/Chart/index.js
+++ b/src/ducks/Studio/Chart/index.js
@@ -228,6 +228,7 @@ const Chart = ({
       <ChartCanvas
         className={cx(styles.chart, isBlurred && styles.blur)}
         chartRef={chartRef}
+        widget={widget}
         data={data}
         brushData={allTimeData}
         categories={categories}

--- a/src/ducks/Studio/Widget/ChartWidget.js
+++ b/src/ducks/Studio/Widget/ChartWidget.js
@@ -165,6 +165,14 @@ export const Chart = ({
       toggleIndicatorMetric(newMetric)
     }
 
+    if (widget.axesMetricSet.has(metric)) {
+      widget.axesMetricSet.delete(metric)
+      widget.axesMetricSet.add(newMetric)
+    } else {
+      widget.disabledAxesMetricSet.delete(metric)
+      widget.disabledAxesMetricSet.add(newMetric)
+    }
+
     const newMap = new Map(widget.MetricSettingMap)
     newMap.set(newMetric, getMetricSetting(newMap, metric))
     newMap.delete(metric)

--- a/src/ducks/Studio/Widget/ChartWidget.js
+++ b/src/ducks/Studio/Widget/ChartWidget.js
@@ -216,6 +216,8 @@ const newChartWidget = (props, widget = ChartWidget) =>
   newWidget(widget, {
     metrics: [Metric.price_usd],
     comparedMetrics: [],
+    axesMetricSet: new Set(),
+    disabledAxesMetricSet: new Set(),
     MetricSettingMap: new Map(),
     MetricIndicators: {},
     MetricColor: {},

--- a/src/ducks/Studio/index.js
+++ b/src/ducks/Studio/index.js
@@ -97,8 +97,9 @@ export const Studio = ({
       : deduceItems(widget.metrics, metric)
 
     if (metrics.length < widget.metrics.length) {
-      widget.MetricSettingMap.delete(metric)
-      // TODO: delete color [@vanguard | Nov  3, 2020]
+      widget.MetricSettingMap.delete(metric) // TODO: delete color [@vanguard | Nov  3, 2020]
+      widget.axesMetricSet.delete(metric)
+      widget.disabledAxesMetricSet.delete(metric)
     }
 
     if (
@@ -220,7 +221,13 @@ export const Studio = ({
 
     const newMetrics = new Set([...widget.metrics, ...appliedMetrics])
 
-    widget.metrics = [...newMetrics]
+    if (newMetrics.has(Metric.price_usd)) {
+      newMetrics.delete(Metric.price_usd)
+      widget.metrics = [Metric.price_usd, ...newMetrics]
+    } else {
+      widget.metrics = [...newMetrics]
+    }
+
     widget.connectedWidgets = mergeConnectedWidgetsWithSelected(
       widget.connectedWidgets,
       appliedWidgets
@@ -238,11 +245,19 @@ export const Studio = ({
     appliedMetrics = selectedMetrics,
     scrollIntoViewOnMount
   ) {
+    const metricSet = new Set(appliedMetrics)
+    let metrics = appliedMetrics
+
+    if (metricSet.has(Metric.price_usd)) {
+      metricSet.delete(Metric.price_usd)
+      metrics = [Metric.price_usd, ...metricSet]
+    }
+
     setWidgets([
       ...widgets,
       ChartWidget.new({
         scrollIntoViewOnMount,
-        metrics: appliedMetrics,
+        metrics,
         MetricSettingMap: selectedMetricSettingsMap,
         connectedWidgets: mergeConnectedWidgetsWithSelected([], selectedWidgets)
       })

--- a/src/ducks/Studio/url/generate.js
+++ b/src/ducks/Studio/url/generate.js
@@ -53,6 +53,7 @@ export const normalizeWidget = ({
   MetricSettingMap,
   MetricIndicators,
   drawings,
+  axesMetricSet,
   chartRef
 }) => ({
   widget: WidgetToTypeMap.get(Widget),
@@ -63,7 +64,8 @@ export const normalizeWidget = ({
   colors: MetricColor,
   settings: shareMetricSettings(MetricSettingMap),
   indicators: shareMetricIndicators(MetricIndicators),
-  drawings: shareDrawings(drawings, chartRef.current)
+  drawings: shareDrawings(drawings, chartRef.current),
+  axesMetrics: axesMetricSet && getMetricsKeys([...axesMetricSet])
 })
 
 export const normalizeWidgets = widgets => widgets.map(normalizeWidget)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1641,10 +1641,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@santiment-network/chart@^0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@santiment-network/chart/-/chart-0.9.1.tgz#40598f589a9d12f01e0d80a4b6b1b2d506131ec8"
-  integrity sha512-B+2RWy/8ef+FzQn6aDDxZZorbEkmb8QvzPIn0lS6C0gCH58KkxlzniDRtBdv53Ch3+fhvIb8ylSgeHO12Z05vQ==
+"@santiment-network/chart@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@santiment-network/chart/-/chart-0.9.2.tgz#7218b5b64feec907d7b9ac0a083b1208958e3b5f"
+  integrity sha512-UMo2rAeCnuwAJRgTq7Mj9Zc6B+WO2BvUrsRayWVvdK/2iu5cdLDKxkCx8tebh5MLH43QJQRVswz9aYHDQGoISw==
 
 "@santiment-network/ui@^0.5.177":
   version "0.5.189"


### PR DESCRIPTION
## Changes
- All axes are now placed on the right side;
- Allowing to manually show/hide metric's axis;
- Displaying metric's last value;

## Notion's card
https://www.notion.so/santiment/Dynamic-multi-axes-1d4bf81526ae4bcc983a320fbdc31afb

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
https://user-images.githubusercontent.com/25135650/108331409-ca438380-71df-11eb-8ade-0669f703ae45.mp4




