### PR TITLE
fix/pro-plus-alt-plan

### DIFF
--- a/src/utils/plans.js
+++ b/src/utils/plans.js
@@ -8,6 +8,10 @@ export const PLANS = {
   ENTERPRISE: 'ENTERPRISE'
 }
 
+const NormalizedPlanName = {
+  'PRO+': PLANS.PRO_PLUS
+}
+
 export const sanbaseProductId = '2'
 export const neuroProductId = '1'
 
@@ -68,7 +72,7 @@ export const getCurrentSanbaseSubscription = user => {
 
 export const getAlternativeBillingPlan = (plans, oldPlan) => {
   const { name, interval: oldInterval = 'month' } = oldPlan
-  const oldName = name.toUpperCase()
+  const oldName = (NormalizedPlanName[name.toUpperCase()] || name).toUpperCase()
   return plans
     .filter(({ isDeprecated }) => !isDeprecated)
     .find(


### PR DESCRIPTION
## Changes
Fixing the issue with missing alternative billing plan for the `PRO+` subscription.


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [ ] I've added tests (if necessary)

## Screenshots or GIFs
<img width="436" alt="image" src="https://user-images.githubusercontent.com/25135650/108396047-778dba00-7227-11eb-9f30-3a76616bc8b6.png">


