### PR TITLE
fix/watchlists-loading

### DIFF
--- a/src/components/Navbar/Watchlists/WatchlistsDropdown.js
+++ b/src/components/Navbar/Watchlists/WatchlistsDropdown.js
@@ -11,17 +11,19 @@ import {
 } from '../../../ducks/Watchlists/utils'
 import { VisibilityIndicator } from '../../VisibilityIndicator'
 import { useUser } from '../../../stores/user'
-import { useUserWatchlists } from '../../../ducks/Watchlists/gql/hooks'
-import { useAddressWatchlists } from '../../../ducks/Watchlists/gql/queries'
+import {
+  useUserAddressWatchlists,
+  useUserWatchlists
+} from '../../../ducks/Watchlists/gql/queries'
 import { getAddressesWatchlistLink } from '../../../ducks/Watchlists/url'
 import { sortById } from '../../../utils/sortMethods'
 import styles from './WatchlistsDropdown.module.scss'
 
 const WatchlistsDropdown = ({ activeLink }) => {
   const [projectsWatchlists, loading] = useUserWatchlists()
-  const addressesWatchlists = useAddressWatchlists().watchlists
+  const [addressesWatchlists, loadingAddresses] = useUserAddressWatchlists()
   const { loading: isLoggedInPending, isLoggedIn } = useUser()
-  const isLoading = loading || isLoggedInPending
+  const isLoading = loading || loadingAddresses || isLoggedInPending
 
   if (isLoading) {
     return <Loader className={styles.loader} />

--- a/src/ducks/Watchlists/gql/queries.js
+++ b/src/ducks/Watchlists/gql/queries.js
@@ -43,8 +43,8 @@ export const FEATURED_WATCHLISTS_QUERY = gql`
 `
 
 export const USER_SHORT_WATCHLISTS_QUERY = gql`
-  query fetchWatchlists {
-    fetchWatchlists {
+  query fetchWatchlists($type: WatchlistTypeEnum) {
+    fetchWatchlists(type: $type) {
       id
       name
       function
@@ -92,10 +92,12 @@ export function useFeaturedWatchlists () {
 
 export const checkIsScreener = ({ function: fn }) => fn.name !== 'empty'
 export const checkIsNotScreener = watchlist => !checkIsScreener(watchlist)
-function useUserShortWatchlists (filter, reduce = noop) {
+
+function useShortWatchlistsLoader (filter, reduce = noop, options) {
   const { isLoggedIn } = useUser()
   const data = useShortWatchlists(USER_SHORT_WATCHLISTS_QUERY, {
-    skip: !isLoggedIn
+    skip: !isLoggedIn,
+    ...options
   })
 
   return useMemo(
@@ -108,7 +110,14 @@ function useUserShortWatchlists (filter, reduce = noop) {
 }
 
 export const useUserWatchlists = () =>
-  useUserShortWatchlists(checkIsNotScreener)
+  useShortWatchlistsLoader(checkIsNotScreener)
+
+export const useUserAddressWatchlists = () =>
+  useShortWatchlistsLoader(checkIsNotScreener, noop, {
+    variables: {
+      type: BLOCKCHAIN_ADDRESS
+    }
+  })
 
 export const DEFAULT_SCREENER_ID = isStage ? 1183 : 5496
 
@@ -120,6 +129,6 @@ const DEFAULT_SCREENERS = [
   }
 ]
 export const useUserScreeners = () =>
-  useUserShortWatchlists(checkIsScreener, watchlists =>
+  useShortWatchlistsLoader(checkIsScreener, watchlists =>
     watchlists.length > 0 ? watchlists : DEFAULT_SCREENERS
   )


### PR DESCRIPTION
## Changes

Fix loading only short watchlists for header dropdown


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs

![image](https://user-images.githubusercontent.com/14061779/108533181-c3089c80-72e9-11eb-962f-6632936e14d0.png)


