### PR TITLE
hotfix/infographics-speed

### DIFF
--- a/src/components/PercentChanges.js
+++ b/src/components/PercentChanges.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ValueChange from './ValueChange/ValueChange'
 import { millify } from '../utils/formatting'
 
-function render (change) {
+export function renderPercent (change) {
   const isMillify = Math.abs(change) > 1000
   const withFloatPart = Math.abs(change) < 100
   return `${
@@ -13,7 +13,7 @@ function render (change) {
 }
 
 const PercentChanges = ({ className, changes }) => (
-  <ValueChange className={className} change={changes} render={render} />
+  <ValueChange className={className} change={changes} render={renderPercent} />
 )
 
 export default PercentChanges

--- a/src/ducks/SANCharts/tooltip/CommonChartTooltip.js
+++ b/src/ducks/SANCharts/tooltip/CommonChartTooltip.js
@@ -115,7 +115,7 @@ export const ProjectsChartTooltip = ({
                     <div key={labelKey} className={styles.row}>
                       <span className={styles.key}>{label}</span>
                       <span className={styles.value}>
-                        {formatter(original[labelKey])}
+                        {formatter(100 * original[labelKey])}
                       </span>
                     </div>
                   )

--- a/src/ducks/Watchlists/Widgets/VolumeChart/CustomizedTreeMapContent.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/CustomizedTreeMapContent.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { formatProjectTreeMapValue, getFontSize, getWordLength } from './utils'
+import { getFontSize, getWordLength } from './utils'
+import { renderPercent } from '../../../../components/PercentChanges'
 
 const CustomizedTreeMapContent = props => {
   const {
@@ -18,7 +19,7 @@ const CustomizedTreeMapContent = props => {
 
   const item = children[index]
   const { ticker = '', color } = item
-  const value = formatProjectTreeMapValue(item[dataKey])
+  const value = renderPercent(100 * item[dataKey])
 
   const fontSize = getFontSize(index, children.length)
 

--- a/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.js
@@ -107,7 +107,7 @@ const ProjectsChart = ({
         color: getBarColor(item[key])
       }))
     },
-    [data, sortByKey, desc]
+    [data]
   )
 
   const onProjectClick = useCallback(

--- a/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.js
@@ -51,7 +51,7 @@ const renderCustomizedLabel = props => {
 }
 
 const ProjectsChart = ({
-  assets,
+  listId,
   redirect,
   settings,
   onChangeInterval,
@@ -60,13 +60,12 @@ const ProjectsChart = ({
   const { sorter: { sortBy = 'marketcapUsd', desc: sortDesc } = {} } = settings
   const defaultIndex = useMemo(
     () => {
-      return (
-        SORT_RANGES.findIndex(
-          ({ key, desc }) => key === sortBy && desc === sortDesc
-        ) || 0
+      const index = SORT_RANGES.findIndex(
+        ({ key, desc }) => key === sortBy && desc === sortDesc
       )
+      return index >= 0 ? index : 0
     },
-    [sortBy]
+    [sortBy, sortDesc]
   )
 
   const [sortedByIndex, setSortedByIndex] = useState(defaultIndex)
@@ -91,8 +90,7 @@ const ProjectsChart = ({
     label,
     key
   } = useProjectRanges({
-    assets,
-    limit: 100,
+    listId,
     ranges: PRICE_CHANGE_RANGES,
     sortByKey,
     desc,
@@ -120,7 +118,7 @@ const ProjectsChart = ({
 
   const datakey = 'slug'
 
-  const noData = assets.length === 0
+  const noData = !loading && data.length === 0
 
   return (
     <div className={styles.container}>

--- a/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.js
@@ -29,7 +29,9 @@ import {
 import styles from './ProjectsChart.module.scss'
 
 const renderCustomizedLabel = props => {
-  const { x, y, width, value, fill } = props
+  const { x, y, width, value: source, fill } = props
+
+  const value = source * 100
 
   const fontSize = width < 20 ? 7 : 14
   const position = +value >= 0 ? -1 * (fontSize / 2) : fontSize
@@ -92,7 +94,7 @@ const ProjectsChart = ({
   } = useProjectRanges({
     listId,
     ranges: PRICE_CHANGE_RANGES,
-    sortByKey,
+    sortByMetric: sortByKey,
     desc,
     settings,
     onChangeInterval
@@ -105,7 +107,7 @@ const ProjectsChart = ({
         color: getBarColor(item[key])
       }))
     },
-    [data]
+    [data, sortByKey, desc]
   )
 
   const onProjectClick = useCallback(

--- a/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.module.scss
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.module.scss
@@ -48,6 +48,8 @@
 
 .sortedByLabel {
   margin-right: 4px;
+  display: flex;
+  align-items: center;
 }
 
 .range {

--- a/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsTreeMap.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsTreeMap.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import { ResponsiveContainer, Tooltip, Treemap } from 'recharts'
 import Range from '../WatchlistOverview/WatchlistAnomalies/Range'
 import Skeleton from '../../../../components/Skeleton/Skeleton'
@@ -8,7 +8,6 @@ import NoDataCharts from './NoDataCharts'
 import ScreenerChartTitle from './ScreenerChartTitle'
 import { useProjectRanges, useWithColors } from './hooks'
 import {
-  getPriceSorter,
   getTooltipLabels,
   PRICE_CHANGE_RANGES,
   tooltipLabelFormatter
@@ -70,7 +69,7 @@ const ProjectsTreeMap = ({
 }) => {
   const noData = !loading && data.length === 0
 
-  const dataByColors = useWithColors(data, key)
+  const colored = useWithColors(data, key)
 
   return (
     <div className={className}>
@@ -112,7 +111,7 @@ const ProjectsTreeMap = ({
         <div className={styles.treeMap}>
           <ResponsiveContainer width='100%' height='100%'>
             <Treemap
-              data={dataByColors}
+              data={colored}
               dataKey={'marketcapUsd'}
               fill='var(--jungle-green)'
               isAnimationActive={false}

--- a/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsTreeMap.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsTreeMap.js
@@ -16,16 +16,15 @@ import {
 import CustomizedTreeMapContent from './CustomizedTreeMapContent'
 import styles from './ProjectsChart.module.scss'
 
-const noop = () => true
-
 export const ProjectsMapWrapper = ({
-  assets,
+  listId,
   ranges,
   className,
   title,
   isSocialVolume = false,
   settings,
-  onChangeInterval
+  onChangeInterval,
+  sortByMetric
 }) => {
   const {
     data,
@@ -35,20 +34,17 @@ export const ProjectsMapWrapper = ({
     label,
     key
   } = useProjectRanges({
-    assets,
+    listId,
     ranges,
-    limit: 100,
-    sortByKey: 'marketcapUsd',
     isSocialVolume,
     settings,
-    onChangeInterval
+    onChangeInterval,
+    sortByMetric
   })
 
   return (
     <ProjectsTreeMap
-      assets={assets}
       ranges={ranges}
-      sortByKey={'marketcapUsd'}
       className={className}
       title={title}
       data={data}
@@ -62,10 +58,8 @@ export const ProjectsMapWrapper = ({
 }
 
 const ProjectsTreeMap = ({
-  assets,
   ranges,
   className,
-  sortByKey,
   title,
   data,
   loading,
@@ -74,22 +68,9 @@ const ProjectsTreeMap = ({
   label,
   dataKey: key
 }) => {
-  const sorter = useMemo(
-    () => {
-      return sortByKey ? getPriceSorter(sortByKey) : noop
-    },
-    [sortByKey]
-  )
+  const noData = !loading && data.length === 0
 
-  const sortedByChange = useWithColors(data, key, sorter)
-  const sortedByMarketcap = useMemo(
-    () => {
-      return sortedByChange.sort(sorter)
-    },
-    [sortedByChange]
-  )
-
-  const noData = assets.length === 0
+  const dataByColors = useWithColors(data, key)
 
   return (
     <div className={className}>
@@ -131,7 +112,7 @@ const ProjectsTreeMap = ({
         <div className={styles.treeMap}>
           <ResponsiveContainer width='100%' height='100%'>
             <Treemap
-              data={sortedByMarketcap}
+              data={dataByColors}
               dataKey={'marketcapUsd'}
               fill='var(--jungle-green)'
               isAnimationActive={false}

--- a/src/ducks/Watchlists/Widgets/VolumeChart/ScreenerChartTitle.module.scss
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/ScreenerChartTitle.module.scss
@@ -3,10 +3,16 @@
 .title {
   color: var(--fiord);
   margin-left: 8px;
+  display: flex;
+  align-items: center;
 
-  @include text('caption'); }
+  @include text('caption');
+}
 
 .type {
   color: var(--rhino);
+  display: flex;
+  align-items: center;
 
-  @include text('caption', 'm'); }
+  @include text('caption', 'm');
+}

--- a/src/ducks/Watchlists/Widgets/VolumeChart/hooks.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/hooks.js
@@ -76,6 +76,8 @@ export const useProjectRanges = ({
     })
   }
 
+  console.log(sortByMetric, metric, desc, settings)
+
   const [data, loading] = isSocialVolume
     ? useProjectsSocialVolumeChanges(hookProps)
     : useProjectPriceChanges(hookProps)

--- a/src/ducks/Watchlists/Widgets/VolumeChart/hooks.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/hooks.js
@@ -76,8 +76,6 @@ export const useProjectRanges = ({
     })
   }
 
-  console.log(sortByMetric, metric, desc, settings)
-
   const [data, loading] = isSocialVolume
     ? useProjectsSocialVolumeChanges(hookProps)
     : useProjectPriceChanges(hookProps)

--- a/src/ducks/Watchlists/Widgets/VolumeChart/utils.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/utils.js
@@ -34,6 +34,10 @@ export const PRICE_CHANGE_RANGES = [
   {
     label: '7d',
     key: 'price_usd_change_7d'
+  },
+  {
+    label: '30d',
+    key: 'price_usd_change_30d'
   }
 ]
 

--- a/src/ducks/Watchlists/Widgets/VolumeChart/utils.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/utils.js
@@ -2,14 +2,6 @@ import memoize from 'lodash.memoize'
 import { formatNumber, millify } from '../../../../utils/formatting'
 import { getTreeMapColor } from './ColorsExplanation'
 
-export const getPriceSorter = memoize(({ sortKey, desc }) => (a, b) => {
-  if (desc) {
-    return +b[sortKey] - +a[sortKey]
-  } else {
-    return +a[sortKey] - +b[sortKey]
-  }
-})
-
 export function getBarColor (val) {
   return +val > 0 ? 'var(--jungle-green)' : 'var(--persimmon)'
 }
@@ -37,13 +29,11 @@ export const getTooltipLabels = memoize(({ key, label }) => {
 export const PRICE_CHANGE_RANGES = [
   {
     label: '24h',
-    key: 'percentChange24h',
-    metric: 'price_usd_change_1d'
+    key: 'price_usd_change_1d'
   },
   {
     label: '7d',
-    key: 'percentChange7d',
-    metric: 'price_usd_change_7d'
+    key: 'price_usd_change_7d'
   }
 ]
 
@@ -65,12 +55,12 @@ export const SOCIAL_VOLUME_CHANGE_RANGES = [
 export const SORT_RANGES = [
   {
     label: 'Marketcap  ⬆️',
-    key: 'marketcapUsd',
+    key: 'marketcap_usd',
     desc: false
   },
   {
     label: 'Marketcap  ⬇️',
-    key: 'marketcapUsd',
+    key: 'marketcap_usd',
     desc: true
   },
   {

--- a/src/ducks/Watchlists/Widgets/VolumeChart/utils.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/utils.js
@@ -34,62 +34,54 @@ export const getTooltipLabels = memoize(({ key, label }) => {
   ]
 })
 
-export const formatProjectTreeMapValue = val =>
-  val
-    ? formatNumber(val, {
-      maximumFractionDigits: 2,
-      directionSymbol: true
-    }) + '%'
-    : null
-
 export const PRICE_CHANGE_RANGES = [
   {
-    label: '1h',
-    key: 'percentChange1h'
-  },
-  {
     label: '24h',
-    key: 'percentChange24h'
+    key: 'percentChange24h',
+    metric: 'price_usd_change_1d'
   },
   {
     label: '7d',
-    key: 'percentChange7d'
+    key: 'percentChange7d',
+    metric: 'price_usd_change_7d'
   }
 ]
 
 export const SOCIAL_VOLUME_CHANGE_RANGES = [
   {
     label: '24h',
-    key: 'change1d'
+    key: 'social_volume_total_change_1d'
   },
   {
     label: '7d',
-    key: 'change7d'
+    key: 'social_volume_total_change_7d'
   },
   {
     label: '30d',
-    key: 'change30d'
+    key: 'social_volume_total_change_30d'
   }
 ]
 
 export const SORT_RANGES = [
   {
     label: 'Marketcap  ⬆️',
-    key: 'marketcapUsd'
-  },
-  {
-    label: 'Marketcap  ⬇️',
     key: 'marketcapUsd',
     desc: false
   },
   {
+    label: 'Marketcap  ⬇️',
+    key: 'marketcapUsd',
+    desc: true
+  },
+  {
     label: `Price changes  ⬆️`,
-    key: ''
+    key: '',
+    desc: false
   },
   {
     label: 'Price changes  ⬇️',
     key: '',
-    desc: false
+    desc: true
   }
 ]
 
@@ -111,7 +103,7 @@ export const getFontSize = (index, length) => {
 export const mapToColors = (data, key) => {
   return data.map(item => {
     const value = +item[key]
-    const color = getTreeMapColor(value)
+    const color = getTreeMapColor(100 * value)
     return {
       ...item,
       color

--- a/src/ducks/Watchlists/gql/allProjectsGQL.js
+++ b/src/ducks/Watchlists/gql/allProjectsGQL.js
@@ -73,9 +73,18 @@ export const ALL_PROJECTS_PRICE_CHANGES_QUERY = gql`
         slug
         ticker
         name
-        percentChange1h
-        percentChange24h
-        percentChange7d
+        price_usd_change_1d: aggregatedTimeseriesData(
+          metric: "price_usd_change_1d"
+          from: "utc_now-1d"
+          to: "utc_now"
+          aggregation: LAST
+        )
+        price_usd_change_7d: aggregatedTimeseriesData(
+          metric: "price_usd_change_7d"
+          from: "utc_now-7d"
+          to: "utc_now"
+          aggregation: LAST
+        )
         marketcapUsd
         priceUsd
       }
@@ -93,19 +102,19 @@ export const ALL_PROJECTS_SOCIAL_VOLUME_CHANGES_QUERY = gql`
         slug
         marketcapUsd
         priceUsd
-        change1d: aggregatedTimeseriesData(
+        social_volume_total_change_1d: aggregatedTimeseriesData(
           metric: "social_volume_total_change_1d"
           from: "utc_now-1d"
           to: "utc_now"
           aggregation: LAST
         )
-        change7d: aggregatedTimeseriesData(
+        social_volume_total_change_7d: aggregatedTimeseriesData(
           metric: "social_volume_total_change_7d"
           from: "utc_now-7d"
           to: "utc_now"
           aggregation: LAST
         )
-        change30d: aggregatedTimeseriesData(
+        social_volume_total_change_30d: aggregatedTimeseriesData(
           metric: "social_volume_total_change_30d"
           from: "utc_now-30d"
           to: "utc_now"

--- a/src/ducks/Watchlists/gql/allProjectsGQL.js
+++ b/src/ducks/Watchlists/gql/allProjectsGQL.js
@@ -85,6 +85,12 @@ export const ALL_PROJECTS_PRICE_CHANGES_QUERY = gql`
           to: "utc_now"
           aggregation: LAST
         )
+        price_usd_change_30d: aggregatedTimeseriesData(
+          metric: "price_usd_change_30d"
+          from: "utc_now-30d"
+          to: "utc_now"
+          aggregation: LAST
+        )
         marketcapUsd
         priceUsd
       }

--- a/src/hooks/project.js
+++ b/src/hooks/project.js
@@ -29,54 +29,32 @@ export function useProject (slug) {
   return [data ? data.projectBySlug : undefined, loading, error]
 }
 
-const prepare = ({ items, limit, sorter, key }) =>
-  items
-    .sort(sorter)
-    .slice(0, limit)
-    .map(item => ({
-      ...item,
-      [key]: +item[key]
-    }))
-
-export function useProjectPriceChanges ({ key, assets, sorter, limit = 100 }) {
-  const query = useQuery(ALL_PROJECTS_PRICE_CHANGES_QUERY, {
-    variables: {
-      fn: JSON.stringify({
-        args: {
-          slugs: assets
-        },
-        name: 'slugs'
-      })
-    }
-  })
-
-  return useMemo(
-    () => {
-      const { data, loading, error } = query
-      const items = data ? data.allProjectsByFunction.projects : []
-
-      const mapped = prepare({ items, limit, sorter, key })
-
-      return [mapped, loading, error]
+const makeFn = ({ limit, listId, orderBy }) => {
+  return JSON.stringify({
+    args: {
+      pagination: {
+        page: 1,
+        pageSize: limit
+      },
+      baseProjects: [
+        {
+          watchlistId: listId
+        }
+      ],
+      orderBy: orderBy
     },
-    [query, limit, sorter, key]
-  )
+    name: 'selector'
+  })
 }
 
 export function useProjectsSocialVolumeChanges ({
-  interval,
-  assets,
-  sorter,
+  listId,
+  orderBy,
   limit = 100
 }) {
   const query = useQuery(ALL_PROJECTS_SOCIAL_VOLUME_CHANGES_QUERY, {
     variables: {
-      fn: JSON.stringify({
-        args: {
-          slugs: assets.slice(0, limit)
-        },
-        name: 'slugs'
-      })
+      fn: makeFn({ listId, limit, orderBy })
     }
   })
 
@@ -85,12 +63,26 @@ export function useProjectsSocialVolumeChanges ({
       const { data, loading, error } = query
       const items = data ? data.allProjectsByFunction.projects : []
 
-      const key = `change${interval}`
-
-      const mapped = prepare({ items, limit, sorter, key })
-
-      return [mapped, loading, error]
+      return [items, loading, error]
     },
-    [query, interval, sorter, limit]
+    [query]
+  )
+}
+
+export function useProjectPriceChanges ({ listId, orderBy, limit = 100 }) {
+  const query = useQuery(ALL_PROJECTS_PRICE_CHANGES_QUERY, {
+    variables: {
+      fn: makeFn({ listId, limit, orderBy })
+    }
+  })
+
+  return useMemo(
+    () => {
+      const { data, loading, error } = query
+      const items = data ? data.allProjectsByFunction.projects : []
+
+      return [items, loading, error]
+    },
+    [query]
   )
 }

--- a/src/hooks/project.js
+++ b/src/hooks/project.js
@@ -73,7 +73,7 @@ export function useProjectsSocialVolumeChanges ({
     variables: {
       fn: JSON.stringify({
         args: {
-          slugs: assets
+          slugs: assets.slice(0, limit)
         },
         name: 'slugs'
       })

--- a/src/pages/Watchlist/Infographics/index.js
+++ b/src/pages/Watchlist/Infographics/index.js
@@ -42,11 +42,12 @@ const Infographics = ({
       {isPriceTreeMap && (
         <div className={styles.treeMaps}>
           <ProjectsMapWrapper
+            listId={listId}
             className={styles.containerTreeMap}
-            assets={assets}
             title='Price Changes'
             ranges={PRICE_CHANGE_RANGES}
             settings={priceTreeMap}
+            sortByMetric='marketcap_usd'
             onChangeInterval={value => onChangeInterval('priceTreeMap', value)}
           />
         </div>
@@ -55,12 +56,13 @@ const Infographics = ({
         <div className={styles.treeMaps}>
           {isPro ? (
             <ProjectsMapWrapper
+              listId={listId}
               className={styles.containerTreeMap}
-              assets={assets}
               title='Social Volume Changes'
               ranges={SOCIAL_VOLUME_CHANGE_RANGES}
               isSocialVolume={true}
               settings={socialVolumeTreeMap}
+              sortByMetric='marketcap_usd'
               onChangeInterval={value =>
                 onChangeInterval('socialVolumeTreeMap', value)
               }
@@ -72,7 +74,7 @@ const Infographics = ({
       )}
       {isPriceChartActive && (
         <ProjectsChart
-          assets={assets}
+          listId={listId}
           settings={priceBarChart}
           onChangeInterval={value => onChangeInterval('priceBarChart', value)}
           onChangeSorter={value => onChangeSorter('priceBarChart', value)}


### PR DESCRIPTION
## Changes

Optimize infographics loading (loading by id of watchlist, sorters/orders by BE functions)

## Notion's card

https://www.notion.so/santiment/Loading-of-infographics-very-slow-0e5dee4a4a74473f983f44d952e96762

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
![image](https://user-images.githubusercontent.com/14061779/108626916-b27c3180-7463-11eb-81dd-c8a2f48784cb.png)

