### PR TITLE
enhance/studio-last-template

### DIFF
--- a/src/ducks/Studio/Template/gql/hooks.js
+++ b/src/ducks/Studio/Template/gql/hooks.js
@@ -12,7 +12,6 @@ import {
 import {
   buildTemplateMetrics,
   getAvailableTemplate,
-  getLastTemplate,
   getTemplateIdFromURL,
   saveLastTemplate
 } from '../utils'
@@ -98,12 +97,11 @@ export function useSelectedTemplate (templates, selectTemplate) {
   const [loading, setLoading] = useState()
 
   const loadTemplate = () => {
-    if (loading) {
+    if (loading || !urlId) {
       return
     }
 
-    const targetTemplate = urlId ? { id: urlId } : getLastTemplate()
-    if (!targetTemplate) return
+    const targetTemplate = { id: urlId }
 
     setSelectedTemplate(targetTemplate)
 


### PR DESCRIPTION
## Changes
Disabling last template opening on Studio launch.

## Notion's card
https://www.notion.so/santiment/Do-not-show-last-used-chart-layout-on-Studio-open-03df15192c72446790664c27ffb395e6

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [ ] If I make changes to another person's module, I've asked how to use it or request a review
- [ ] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [ ] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [ ] I've added tests (if necessary)


