### PR TITLE
Hiding non intraday mvrv

### DIFF
--- a/src/ducks/Studio/Sidebar/index.module.scss
+++ b/src/ducks/Studio/Sidebar/index.module.scss
@@ -47,7 +47,7 @@
   color: var(--waterloo);
   fill: var(--waterloo);
   top: 68px;
-  left: -38px;
+  left: -49px;
   padding: 0 8px 3px;
   cursor: pointer;
 
@@ -71,7 +71,7 @@
   }
 
   &::before {
-    content: 'Lock sidebar';
+    content: 'Lock MetricsTree';
   }
 
   &:hover {
@@ -100,7 +100,7 @@
   top: 0;
 
   .close::before {
-    content: 'Hide sidebar';
+    content: 'Hide MetricsTree';
   }
 
   .icon {

--- a/src/ducks/Studio/Sidebar/index.module.scss
+++ b/src/ducks/Studio/Sidebar/index.module.scss
@@ -71,7 +71,7 @@
   }
 
   &::before {
-    content: 'Lock metrics';
+    content: 'Lock sidebar';
   }
 
   &:hover {
@@ -100,7 +100,7 @@
   top: 0;
 
   .close::before {
-    content: 'Hide metrics';
+    content: 'Hide sidebar';
   }
 
   .icon {

--- a/src/ducks/Studio/withMetrics.js
+++ b/src/ducks/Studio/withMetrics.js
@@ -3,9 +3,10 @@ import gql from 'graphql-tag'
 import { useQuery } from '@apollo/react-hooks'
 import { getCategoryGraph } from './Sidebar/utils'
 import { getMarketSegment } from './timeseries/marketSegments'
+import { useIsBetaMode } from '../../stores/ui'
+import { Metric } from '../dataHub/metrics'
 import { getMergedTimeboundSubmetrics } from '../dataHub/timebounds'
 import { getAssetNewMetrics } from '../dataHub/metrics/news'
-import { useIsBetaMode } from '../../stores/ui'
 
 const PROJECT_METRICS_QUERIES_SEGMENTS_BY_SLUG_QUERY = gql`
   query projectBySlug($slug: String!) {
@@ -53,13 +54,19 @@ export const DEFAULT_METRICS = [
   'social_volume_total'
 ]
 
+const DEFAULT_HIDDEN_METRICS = [Metric.mvrv_usd]
+
 const DEFAULT_STATE = {
   Submetrics: [],
   availableMetrics: [],
   categories: getCategoryGraph(DEFAULT_METRICS)
 }
 
-export function useProjectMetrics (slug, hiddenMetrics, noMarketSegments) {
+export function useProjectMetrics (
+  slug,
+  hiddenMetrics = DEFAULT_HIDDEN_METRICS,
+  noMarketSegments
+) {
   const isBeta = useIsBetaMode()
   const { data } = useQuery(PROJECT_METRICS_QUERIES_SEGMENTS_BY_SLUG_QUERY, {
     variables: { slug }

--- a/src/ducks/Studio/withMetrics.js
+++ b/src/ducks/Studio/withMetrics.js
@@ -3,10 +3,10 @@ import gql from 'graphql-tag'
 import { useQuery } from '@apollo/react-hooks'
 import { getCategoryGraph } from './Sidebar/utils'
 import { getMarketSegment } from './timeseries/marketSegments'
-import { useIsBetaMode } from '../../stores/ui'
 import { Metric } from '../dataHub/metrics'
 import { getMergedTimeboundSubmetrics } from '../dataHub/timebounds'
 import { getAssetNewMetrics } from '../dataHub/metrics/news'
+import { useIsBetaMode } from '../../stores/ui'
 
 const PROJECT_METRICS_QUERIES_SEGMENTS_BY_SLUG_QUERY = gql`
   query projectBySlug($slug: String!) {


### PR DESCRIPTION
## Changes
Hiding non-intraday mvrv metric.

## Notion's card
https://www.notion.so/santiment/Hide-non-intraday-mvrv-metric-950cd405362d4d1da67fe9b6e6c64f3e

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<img width="248" alt="image" src="https://user-images.githubusercontent.com/25135650/108999832-f1082b00-76b3-11eb-9c6b-772ea5f41a3d.png">


