### PR TITLE
feature/studio-save-sidebar-locking

### DIFF
--- a/src/ducks/Studio/Sidebar/index.js
+++ b/src/ducks/Studio/Sidebar/index.js
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import { CSSTransition } from 'react-transition-group'
 import Tabs from '@santiment-network/ui/Tabs'
 import Icon from '@santiment-network/ui/Icon'
+import { saveIsSidebarLocked } from './utils'
 import ProjectSelector from './ProjectSelector'
 import MetricSelector from './MetricSelector'
 import InsightAlertSelector from './InsightAlertSelector'
@@ -91,9 +92,10 @@ const Sidebar = ({
   const TabComponent = TabToComponent[activeTab]
 
   useEffect(() => setMetricProject(settings), [settings.slug, settings.name])
+  useEffect(() => saveIsSidebarLocked(isLocked), [isLocked])
 
   return (
-    <CSSTransition in={isPeeked} timeout={150} classNames={TRANSITION_CLASSES}>
+    <CSSTransition in={isPeeked} timeout={200} classNames={TRANSITION_CLASSES}>
       <aside
         className={cx(
           styles.wrapper,

--- a/src/ducks/Studio/Sidebar/index.module.scss
+++ b/src/ducks/Studio/Sidebar/index.module.scss
@@ -13,7 +13,7 @@
 }
 
 .wrapper_transition {
-  transition: transform 150ms;
+  transition: transform 200ms;
 }
 
 .content {
@@ -47,7 +47,7 @@
   color: var(--waterloo);
   fill: var(--waterloo);
   top: 68px;
-  left: -49px;
+  left: -39px;
   padding: 0 8px 3px;
   cursor: pointer;
 
@@ -71,7 +71,7 @@
   }
 
   &::before {
-    content: 'Lock MetricsTree';
+    content: 'Lock Sidebar';
   }
 
   &:hover {
@@ -100,7 +100,7 @@
   top: 0;
 
   .close::before {
-    content: 'Hide MetricsTree';
+    content: 'Hide Sidebar';
   }
 
   .icon {

--- a/src/ducks/Studio/Sidebar/utils.js
+++ b/src/ducks/Studio/Sidebar/utils.js
@@ -115,3 +115,9 @@ export const getCategoryGraph = (
 
   return categories
 }
+
+const LS_IS_SIDEBAR_LOCKED = 'LS_IS_SIDEBAR_LOCKED'
+export const loadIsSidebarLocked = () =>
+  !!localStorage.getItem(LS_IS_SIDEBAR_LOCKED)
+export const saveIsSidebarLocked = state =>
+  localStorage.setItem(LS_IS_SIDEBAR_LOCKED, state ? '+' : '')

--- a/src/ducks/Studio/index.js
+++ b/src/ducks/Studio/index.js
@@ -17,6 +17,7 @@ import PriceDAADivergenceWidget from './Widget/PriceDAADivergenceWidget'
 import AdjustedPriceDAADivergenceWidget from './Widget/PriceDAADivergenceWidget/Adjusted'
 import { mergeConnectedWidgetsWithSelected } from './Widget/helpers'
 import SelectionOverview from './Overview/SelectionOverview'
+import { loadIsSidebarLocked } from './Sidebar/utils'
 import HolderDistributionCombinedBalanceWidget from './Widget/HolderDistributionWidget/CombinedBalance'
 import * as Type from './Sidebar/Button/types'
 import { getNewInterval, INTERVAL_ALIAS } from '../SANCharts/IntervalSelector'
@@ -42,7 +43,7 @@ export const Studio = ({
   const [isICOPriceDisabled, setIsICOPriceDisabled] = useState(true)
   const [isICOPriceActive, setIsICOPriceActive] = useState(false)
   const [isSidebarPeeked, setIsSidebarPeeked] = useState(false)
-  const [isSidebarLocked, setIsSidebarLocked] = useState(false)
+  const [isSidebarLocked, setIsSidebarLocked] = useState(loadIsSidebarLocked)
 
   const { currentPhase, previousPhase, setPhase } = usePhase(Phase.IDLE)
   const PressedModifier = usePressedModifier()


### PR DESCRIPTION
## Changes
- `MetricsTree` renamed to `Sidebar`;
- Saving and loading sidebar's locked state;

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<img width="278" alt="image" src="https://user-images.githubusercontent.com/25135650/109010289-a9d46700-76c0-11eb-9d82-21e98b97979a.png">

