### PR TITLE
fix/studio-fullscreen

### DIFF
--- a/src/ducks/Chart/hooks.js
+++ b/src/ducks/Chart/hooks.js
@@ -154,7 +154,7 @@ function getDomainDependencies (domainGroups) {
 export function useMultiAxesMetricKeys (
   widget,
   metrics,
-  ErrorMsg,
+  ErrorMsg = {},
   domainGroups
 ) {
   const { axesMetricSet, disabledAxesMetricSet } = widget

--- a/src/ducks/Studio/Chart/Canvas.js
+++ b/src/ducks/Studio/Chart/Canvas.js
@@ -126,7 +126,8 @@ const Canvas = ({
 }
 
 Canvas.defaultProps = {
-  domainGroups: []
+  domainGroups: [],
+  ErrorMsg: {}
 }
 
 export default Canvas

--- a/src/ducks/Studio/Chart/Fullscreen/index.js
+++ b/src/ducks/Studio/Chart/Fullscreen/index.js
@@ -28,6 +28,7 @@ const FullscreenChart = ({
   metrics,
   brushData,
   MetricColor,
+  ErrorMsg,
   shareLink,
   drawings,
   selectedLineState,
@@ -143,6 +144,7 @@ const FullscreenChart = ({
         data={data}
         brushData={brushData}
         drawings={drawings}
+        ErrorMsg={ErrorMsg}
         domainGroups={
           isDomainGroupingActive ? domainGroups : mirrorDomainGroups
         }

--- a/src/ducks/Studio/Chart/index.js
+++ b/src/ducks/Studio/Chart/index.js
@@ -181,6 +181,7 @@ const Chart = ({
             scale={scale}
             brushData={allTimeData}
             MetricColor={MetricColor}
+            ErrorMsg={ErrorMsg}
             shareLink={shareLink}
             drawings={widget.drawings}
             selectedLineState={selectedLineState}


### PR DESCRIPTION
## Changes
Fixing fullscreen chart crash by massing missing `ErorrMsg` object.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

