### PR TITLE
hotfix/support-old-wallet-alerts

### DIFF
--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricOptions/MetricOptionsRenderer.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricOptions/MetricOptionsRenderer.js
@@ -7,7 +7,10 @@ import outsideSvg from '../../../../../../assets/signals/priceTypes/outside.svg'
 import movingUpSvg from '../../../../../../assets/signals/priceTypes/moving_up.svg'
 import movingDownSvg from '../../../../../../assets/signals/priceTypes/moving_down.svg'
 import someOfSvg from '../../../../../../assets/signals/priceTypes/someOf.svg'
-import { PRICE_CHANGE_TYPES } from '../../../../utils/constants'
+import {
+  ETH_WALLETS_OPERATIONS,
+  PRICE_CHANGE_TYPES
+} from '../../../../utils/constants'
 import { formatTokensCount } from '../../../../../../utils/formatting'
 
 const METRIC_TO_SVG = {
@@ -17,7 +20,9 @@ const METRIC_TO_SVG = {
   [PRICE_CHANGE_TYPES.OUTSIDE_CHANNEL]: outsideSvg,
   [PRICE_CHANGE_TYPES.MOVING_UP]: movingUpSvg,
   [PRICE_CHANGE_TYPES.MOVING_DOWN]: movingDownSvg,
-  [PRICE_CHANGE_TYPES.PERCENT_SOME_OF]: someOfSvg
+  [PRICE_CHANGE_TYPES.PERCENT_SOME_OF]: someOfSvg,
+  [ETH_WALLETS_OPERATIONS.AMOUNT_UP]: aboveSvg,
+  [ETH_WALLETS_OPERATIONS.AMOUNT_DOWN]: belowSvg
 }
 
 const MetricOptionsRenderer = ({

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/signal/TriggerForm.js
@@ -172,7 +172,7 @@ export const TriggerForm = ({
         }
 
         const isValidForm =
-          isValid || !errors || Object.keys(errors).length === 0
+          isValid && (!errors || Object.keys(errors).length === 0)
 
         const showDivider = showTypes || metricValueBlocks
 
@@ -351,8 +351,8 @@ export const TriggerForm = ({
 
               <Button
                 type='submit'
-                disabled={!isValidForm || isSubmitting}
-                isActive={isValidForm && !isSubmitting}
+                disabled={!isValidForm}
+                isActive={isValidForm}
                 variant={'fill'}
                 accent='positive'
                 className={styles.submitButton}

--- a/src/ducks/Signals/signalModal/SignalDialog.js
+++ b/src/ducks/Signals/signalModal/SignalDialog.js
@@ -81,11 +81,11 @@ const SignalDialog = ({
     )
   }
 
+  // GarageInc : 27.02.2021, removed withAnimation={false}
   return (
     <Dialog
       defaultOpen={dialogOpenState}
       open={dialogOpenState}
-      withAnimation={false}
       onOpen={() => {
         // Track opening New signal Dialog
         trackEvent(

--- a/src/ducks/Signals/utils/constants.js
+++ b/src/ducks/Signals/utils/constants.js
@@ -158,6 +158,21 @@ export const PRICE_ABS_CHANGE_OUTSIDE = {
   dependencies: ['absoluteBorders', 'timeWindow']
 }
 
+export const AMOUNT_ABS_CHANGE_UP_MODEL = {
+  metric: PRICE_ABSOLUTE_CHANGE,
+  subMetric: PRICE_ABSOLUTE_CHANGE_SINGLE_BORDER,
+  label: 'Amount up',
+  value: ETH_WALLETS_OPERATIONS.AMOUNT_UP,
+  dependencies: ['absoluteThreshold', 'timeWindow']
+}
+export const AMOUNT_ABS_CHANGE_DOWN_MODEL = {
+  metric: PRICE_ABSOLUTE_CHANGE,
+  subMetric: PRICE_ABSOLUTE_CHANGE_SINGLE_BORDER,
+  label: 'Amount down',
+  value: ETH_WALLETS_OPERATIONS.AMOUNT_DOWN,
+  dependencies: ['absoluteThreshold', 'timeWindow']
+}
+
 export const TRENDING_WORDS_METRIC = {
   label: 'Santrends',
   value: TRENDING_WORDS,
@@ -228,11 +243,22 @@ export const COMMON_PROPS_FOR_METRIC = [
   PRICE_PERCENT_CHANGE_ONE_OF_MODEL
 ]
 
+const WALLET_MOVEMENT_OPTIONS = [
+  ...COMMON_PROPS_FOR_METRIC,
+  {
+    label: 'Amount change',
+    type: 'header',
+    divider: true
+  },
+  AMOUNT_ABS_CHANGE_UP_MODEL,
+  AMOUNT_ABS_CHANGE_DOWN_MODEL
+]
+
 export const METRIC_TO_TYPES = {
   [PRICE]: COMMON_PROPS_FOR_METRIC,
   [DAILY_ACTIVE_ADDRESSES]: PRICE_OPTIONS,
   [PRICE_VOLUME_DIFFERENCE]: [PRICE_VOLUME_DIFFERENCE_METRIC],
-  [ETH_WALLET]: COMMON_PROPS_FOR_METRIC
+  [ETH_WALLET]: WALLET_MOVEMENT_OPTIONS
 }
 
 export const frequencyTymeValueBuilder = value => {


### PR DESCRIPTION
## Changes

1. Temp fixed closing of alert modal after dialog changes in san-ui
2. Creation of daily metric alert
3. Support old settings for historical balance alerts


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
![image](https://user-images.githubusercontent.com/14061779/109381614-72e29900-78ec-11eb-9e8e-94822d44535e.png)


