### PR TITLE
fix/reset-error-boundary

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -222,10 +222,11 @@ export const App = ({
   token,
   isOffline,
   showFooter,
-  location: { pathname, search }
+  location: { pathname, search },
+  history
 }) => (
   <div className='App'>
-    <ErrorBoundary>
+    <ErrorBoundary history={history}>
       {isOffline && (
         <div className={styles.offline}>
           It looks like you are offline. Some actions might not work.
@@ -239,7 +240,7 @@ export const App = ({
       <GdprRedirector pathname={pathname} />
       {isDesktop && <UrlModals />}
 
-      <ErrorBoundary>
+      <ErrorBoundary history={history}>
         <Switch>
           <Route path={SHARE_PATH} component={PageLoader} />
           {['erc20', 'all', 'list', 'screener'].map(name => (

--- a/src/components/ErrorContent/ErrorBoundary.js
+++ b/src/components/ErrorContent/ErrorBoundary.js
@@ -7,9 +7,25 @@ class ErrorBoundary extends Component {
     error: null
   }
 
-  componentDidCatch (error, errorInfo) {
+  setError (error) {
     this.setState({ error })
+  }
+
+  componentDidCatch (error, errorInfo) {
+    this.setError(error)
     Sentry.captureException(error, { extra: errorInfo })
+  }
+
+  componentWillMount () {
+    this.unlisten = this.props.history.listen((location, action) => {
+      if (this.state.error) {
+        this.setError()
+      }
+    })
+  }
+
+  componentWillUnmount () {
+    this.unlisten()
   }
 
   render () {

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ const main = () => {
             <Router history={history}>
               <Switch>
                 <Route exact path='/chart' component={ChartPage} />
-                <Route path='/' component={App} />
+                <Route path='/' component={App} history={history} />
               </Switch>
             </Router>
           </Provider>


### PR DESCRIPTION
## Changes

Reset error boundary on URL change

Example of bug: https://www.loom.com/share/b7791fd065064694b4e17c6f4bf0a2dc

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)


