### PR TITLE
enhance/chart-axis-value-contrast

### DIFF
--- a/src/ducks/Chart/MultiAxes/helpers.js
+++ b/src/ducks/Chart/MultiAxes/helpers.js
@@ -5,7 +5,11 @@ import {
   drawYAxisTicks
 } from '@santiment-network/chart/axes'
 import { drawValueBubbleY } from '@santiment-network/chart/tooltip'
-import { dayTicksPaintConfig, dayAxesColor } from '../paintConfigs'
+import {
+  dayTicksPaintConfig,
+  dayAxesColor,
+  nightBubblesPaintConfig
+} from '../paintConfigs'
 import {
   isDayInterval,
   getDateDayMonthYear,
@@ -56,6 +60,17 @@ function getDomainObject (domainGroups) {
   return domain
 }
 
+// NOTE: http://stackoverflow.com/a/3943023/112731 [@vanguard | Mar  9, 2021]
+function getBubbleFontColorHex (bgColor, isNightMode) {
+  const r = parseInt(bgColor.slice(1, 3), 16)
+  const g = parseInt(bgColor.slice(3, 5), 16)
+  const b = parseInt(bgColor.slice(5, 7), 16)
+
+  const threshold = 150 - (isNightMode ? 12 : 0)
+
+  return r * 0.299 + g * 0.587 + b * 0.114 > threshold ? '#000000' : '#ffffff'
+}
+
 function plotMetricLastValueBubble (
   chart,
   LastMetricPoint,
@@ -69,7 +84,11 @@ function plotMetricLastValueBubble (
   const { y, value } = metricPoint
   const { ctx, bubblesPaintConfig } = chart
   const paintConfig = Object.assign({}, bubblesPaintConfig, {
-    bgColor
+    bgColor,
+    textColor: getBubbleFontColorHex(
+      bgColor,
+      bubblesPaintConfig === nightBubblesPaintConfig
+    )
   })
 
   drawValueBubbleY(


### PR DESCRIPTION
## Changes
Increasing axis values readability by calculating font color.

## Notion's card
https://www.notion.so/santiment/Axis-values-font-color-ae26b4009e8540d58a6ce1d370778e65

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
- Day theme
<img width="213" alt="image" src="https://user-images.githubusercontent.com/25135650/110427394-bc836e80-80b8-11eb-8f22-0ea4b3f398ed.png">

- Night theme
<img width="218" alt="image" src="https://user-images.githubusercontent.com/25135650/110427363-b1c8d980-80b8-11eb-9019-f208154e3e2a.png">


