### PR TITLE
fix/top-token-transactions-etherscan-link

### DIFF
--- a/src/components/Tables/TopTokenTransactions/columns.js
+++ b/src/components/Tables/TopTokenTransactions/columns.js
@@ -1,8 +1,22 @@
 import React from 'react'
-import { formatNumber } from '../../../utils/formatting'
 import WalletLink from '../../WalletLink/WalletLink'
+import { formatNumber } from '../../../utils/formatting'
+import styles from '../../WalletLink/WalletLink.module.scss'
 
-const TrxAddressCell = ({ value }) => <WalletLink {...value} />
+const AddressCell = ({ value }) => <WalletLink {...value} />
+
+const TrxCell = ({ value }) => (
+  <div className={styles.trx}>
+    <a
+      className={styles.link}
+      href={`https://etherscan.io/tx/${value}`}
+      target='_blank'
+      rel='noopener noreferrer'
+    >
+      {value}
+    </a>
+  </div>
+)
 
 export const DEFAULT_SORTING = [
   {
@@ -25,20 +39,19 @@ export const COLUMNS = [
   {
     Header: 'From',
     accessor: 'fromAddress',
-    Cell: TrxAddressCell,
+    Cell: AddressCell,
     disableSortBy: true
   },
   {
     Header: 'To',
     accessor: 'toAddress',
-    Cell: TrxAddressCell,
+    Cell: AddressCell,
     disableSortBy: true
   },
   {
     Header: 'TxHash',
     accessor: 'trxHash',
-    Cell: ({ value }) =>
-      TrxAddressCell({ value: { address: value, isTx: true } }),
+    Cell: TrxCell,
     disableSortBy: true
   }
 ]

--- a/src/components/WalletLink/WalletLink.module.scss
+++ b/src/components/WalletLink/WalletLink.module.scss
@@ -29,3 +29,9 @@
   flex-wrap: wrap;
   padding-right: 4px;
 }
+
+.trx {
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/pages/Studio/index.js
+++ b/src/pages/Studio/index.js
@@ -27,7 +27,7 @@ export default ({ location }) => {
     const templateId = getIdFromSEOLink(pathname)
 
     if (Number.isFinite(templateId)) {
-      return getTemplate(templateId)
+      getTemplate(templateId)
         .then(template => {
           setParsedUrl({
             settings: template.project,
@@ -35,6 +35,7 @@ export default ({ location }) => {
           })
         })
         .catch(console.error)
+      return
     }
 
     setParsedUrl(parseUrlV2(search)) // TODO: Delete after enabling short urls [@vanguard | Mar  3, 2021]


### PR DESCRIPTION
## Changes
Displaying etherscan link without action popup, since it's the same action.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<img width="1515" alt="image" src="https://user-images.githubusercontent.com/25135650/110453135-ed729c00-80d6-11eb-9bd3-9aa82a258973.png">

