### PR TITLE
style: navbar btns, alert modal in feed, fix crashing on close

### DIFF
--- a/src/components/IndexTabs/IndexTab.js
+++ b/src/components/IndexTabs/IndexTab.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import styles from './IndexTab.module.scss'
 import cx from 'classnames'
+import { SignalModal } from '../../pages/SonarFeed/SonarFeedPage'
 
 const IndexTab = ({ tabs }) => {
   const [activeTab, setTab] = useState(0)
@@ -11,23 +12,30 @@ const IndexTab = ({ tabs }) => {
   return (
     <>
       <div className={styles.header}>
-        {tabs.map((item, index) => {
-          if (!item) {
-            return null
-          }
+        <div className={styles.tabs}>
+          {tabs.map((item, index) => {
+            if (!item) {
+              return null
+            }
 
-          const { title } = item
+            const { title } = item
 
-          return (
-            <div
-              key={index}
-              className={cx(styles.title, index === activeTab && styles.active)}
-              onClick={() => setTab(index)}
-            >
-              {title}
-            </div>
-          )
-        })}
+            return (
+              <div
+                key={index}
+                className={cx(
+                  styles.title,
+                  index === activeTab && styles.active
+                )}
+                onClick={() => setTab(index)}
+              >
+                {title}
+              </div>
+            )
+          })}
+        </div>
+
+        <SignalModal canRedirect={false} />
       </div>
       {content}
     </>

--- a/src/components/IndexTabs/IndexTab.module.scss
+++ b/src/components/IndexTabs/IndexTab.module.scss
@@ -23,6 +23,12 @@
   display: flex;
   margin-bottom: 32px;
   color: var(--rhino);
+  justify-content: space-between;
 
   @include text('h4', 'm');
+}
+
+.tabs {
+  display: flex;
+  flex: 1;
 }

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -101,7 +101,7 @@ const rightLinks = [
     children: 'Academy',
     as: ExternalLink,
     Dropdown: NavbarHelpDropdown,
-    className: styles.help
+    className: styles.btn
   },
   {
     to: '/pricing',

--- a/src/components/Navbar/Navbar.module.scss
+++ b/src/components/Navbar/Navbar.module.scss
@@ -17,7 +17,8 @@
 }
 
 .wrapper {
-  padding: 1rem;
+  padding-left: 24px !important;
+  padding-right: 24px !important;
   display: flex;
   align-items: center;
   height: 70px;
@@ -57,6 +58,7 @@
   justify-content: flex-end;
   border-left: 1px solid var(--porcelain);
   padding-left: 24px;
+  margin-left: 2px;
 
   @include responsive('phone', 'phone-xs', 'laptop', 'tablet') {
     margin-left: 24px;
@@ -136,10 +138,6 @@
 
 .center {
   align-items: center;
-}
-
-.help {
-  color: var(--waterloo);
 }
 
 @keyframes shiftDown {

--- a/src/components/Navbar/Search/index.module.scss
+++ b/src/components/Navbar/Search/index.module.scss
@@ -2,6 +2,7 @@
   margin-left: auto;
   transition: width 0.7s;
   width: 320px;
+  margin-right: 30px;
 
   &_focused {
     width: 100%;

--- a/src/ducks/Signals/signalFormManager/sharedForm/SharedTriggerForm.js
+++ b/src/ducks/Signals/signalFormManager/sharedForm/SharedTriggerForm.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { connect } from 'react-redux'
 import Button from '@santiment-network/ui/Button'
 import { couldShowChart } from '../../utils/utils'
 import SignalPreview from '../../chart/preview/SignalPreview'
@@ -7,19 +6,27 @@ import NoSignalPreview from '../../chart/preview/NoSignalPreview'
 import { DesktopOnly, MobileOnly } from '../../../../components/Responsive'
 import CopySignal from '../../../../components/SignalCard/controls/CopySignal'
 import { isStrictTrendingWords } from '../../../../components/SignalCard/card/utils'
+import { useUser } from '../../../../stores/user'
 import styles from './ShareTriggerForm.module.scss'
 
 const SharedTriggerForm = ({
-  id,
   trigger,
   onOpen,
   onCreate,
   settings,
   originalTrigger,
-  isAuthor,
+  userId,
   SignalCard
 }) => {
   const { metric } = settings
+  const { id } = trigger
+
+  const { user } = useUser()
+  const isAuthor = user && +userId === +user.id
+
+  if (!originalTrigger.id) {
+    return null
+  }
 
   const {
     settings: originalSettings,
@@ -104,12 +111,4 @@ const SharedTriggerForm = ({
   )
 }
 
-const mapStateToProps = (state, { userId }) => {
-  const { user: { data: { id } = {} } = {} } = state
-
-  return {
-    isAuthor: +id === +userId
-  }
-}
-
-export default connect(mapStateToProps)(SharedTriggerForm)
+export default SharedTriggerForm

--- a/src/ducks/Signals/signalFormManager/signalMaster/SignalMaster.js
+++ b/src/ducks/Signals/signalFormManager/signalMaster/SignalMaster.js
@@ -73,10 +73,10 @@ const SignalMaster = ({
   redirect,
   updateTrigger,
   createTrigger,
-  isShared = false,
   formChangedCallback,
-  openSharedForm = false,
-  setOpenSharedForm,
+  setSharedPreview,
+  isShared = false,
+  isSharedPreview = false,
   toggleAnon,
   isLoggedIn
 }) => {
@@ -88,7 +88,7 @@ const SignalMaster = ({
     ...propsTrigger
   })
 
-  const [formData, setFormData] = useState(
+  const [formData, setFormData] = useState(() =>
     getFormData(stateTrigger, metaFormSettings)
   )
 
@@ -139,9 +139,11 @@ const SignalMaster = ({
 
   const [settings, metaForm] = formData
 
+  console.log('isSharedPreview', isSharedPreview, stateTrigger)
+
   return (
-    <div className={cx(styles.wrapper, openSharedForm && styles.sharedForm)}>
-      {!openSharedForm && (
+    <div className={cx(styles.wrapper, isSharedPreview && styles.sharedForm)}>
+      {!isSharedPreview && (
         <TriggerForm
           setTitle={setTitle}
           id={stateTrigger.id}
@@ -153,11 +155,10 @@ const SignalMaster = ({
           formChangedCallback={formChangedCallback}
         />
       )}
-      {openSharedForm && (
+      {isSharedPreview && (
         <SharedTriggerForm
-          id={stateTrigger.id}
           trigger={stateTrigger}
-          onOpen={data => (isLoggedIn ? setOpenSharedForm(data) : toggleAnon())}
+          onOpen={data => (isLoggedIn ? setSharedPreview(data) : toggleAnon())}
           onCreate={() =>
             isLoggedIn ? handleSettingsChange(settings) : toggleAnon()
           }

--- a/src/ducks/Signals/signalModal/SignalDialog.js
+++ b/src/ducks/Signals/signalModal/SignalDialog.js
@@ -32,7 +32,7 @@ const SignalDialog = ({
 }) => {
   const [dialogTitle, onSetDialogTitle] = useState('')
   const [isAnonWarning, setAnonWarning] = useState(false)
-  const [openSharedForm, setOpenForm] = useState(isShared)
+  const [isSharedPreview, setSharedPreview] = useState(isShared)
   const [trackEvent] = useTrackEvents()
 
   const { variant, border } = buttonParams
@@ -57,18 +57,16 @@ const SignalDialog = ({
 
   useEffect(
     () => {
-      if (openSharedForm !== isShared) {
-        setOpenForm(isShared)
-      }
+      setSharedPreview(isShared)
     },
     [isShared]
   )
 
   useEffect(
     () => {
-      openSharedForm && onSetDialogTitle('Alert details')
+      isSharedPreview && onSetDialogTitle('Alert details')
     },
-    [openSharedForm]
+    [isSharedPreview]
   )
 
   const canOpen = (isLoggedIn || isShared) && !isAnonWarning
@@ -104,7 +102,7 @@ const SignalDialog = ({
       }
       title={
         <TriggerModalTitle
-          showSharedBtn={isShared && !openSharedForm}
+          showSharedBtn={isShared && !isSharedPreview}
           isError={isError}
           dialogTitle={dialogTitle}
           isLoggedIn={isLoggedIn}
@@ -122,8 +120,8 @@ const SignalDialog = ({
           <>
             {canOpen && (
               <SignalMaster
-                setOpenSharedForm={setOpenForm}
-                openSharedForm={openSharedForm}
+                setSharedPreview={setSharedPreview}
+                isSharedPreview={isSharedPreview}
                 isShared={isShared}
                 trigger={trigger}
                 setTitle={onSetDialogTitle}

--- a/src/pages/SonarFeed/SonarFeedPage.js
+++ b/src/pages/SonarFeed/SonarFeedPage.js
@@ -47,7 +47,7 @@ const ALERTS_MODAL_VIEW = {
 }
 const tabs = [ALERTS_LIST, ALERTS_MODAL_VIEW]
 
-const SignalModal = ({ id: triggerId, params }) => {
+export const SignalModal = ({ id: triggerId, params, ...rest }) => {
   const shareSignalParams = getShareSignalParams(params)
 
   const isOpen = !!triggerId
@@ -76,6 +76,7 @@ const SignalModal = ({ id: triggerId, params }) => {
           id={triggerId}
           shareParams={shareSignalParams}
           defaultOpen={isOpen}
+          {...rest}
         />
       )
     }


### PR DESCRIPTION
## Changes

1. Add signal btn to feed
2. Fix crashes of alert form
3. Navbar styles

## Notion's card

https://www.notion.so/santiment/Navbar-styles-feed-f4f98236e81245c2bcde4e89b59969e0

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [ ] If I make changes to another person's module, I've asked how to use it or request a review
- [ ] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [ ] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [ ] I've added tests (if necessary)

## Screenshots or GIFs
![image](https://user-images.githubusercontent.com/14061779/110465193-2ade2600-80e5-11eb-83ce-06fc8848aae9.png)


