### PR TITLE
enhance/historical-balance-layout

### DIFF
--- a/src/components/ActionsMenu/index.js
+++ b/src/components/ActionsMenu/index.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import cx from 'classnames'
+import Icon from '@santiment-network/ui/Icon'
+import Panel from '@santiment-network/ui/Panel/Panel'
+import ContextMenu from '@santiment-network/ui/ContextMenu'
+import { useControlledModal, newModalController } from '../../hooks/modal'
+import styles from './index.module.scss'
+
+const Button = ({
+  forwardedRef,
+  children,
+  Trigger,
+  isOpened,
+  open,
+  onClick
+}) => (
+  <div className={styles.btn} ref={forwardedRef}>
+    <Trigger className={styles.trigger} onClick={onClick}>
+      {children}
+    </Trigger>
+
+    <div className={cx(styles.more, isOpened && styles.more_opened)}>
+      <Icon type='arrow-down' className={styles.arrow} onClick={open} />
+    </div>
+  </div>
+)
+Button.defaultProps = {
+  Trigger: 'div'
+}
+
+const actionsMenuController = newModalController(
+  'ActionsMenu',
+  ({ children, trigger, Trigger, onTriggerClick, ...props }) => {
+    const { open: isOpened, onOpen } = props
+
+    return (
+      <ContextMenu
+        align='end'
+        {...props}
+        trigger={
+          <Button
+            Trigger={Trigger}
+            isOpened={isOpened}
+            open={onOpen}
+            onClick={onTriggerClick}
+          >
+            {trigger}
+          </Button>
+        }
+      >
+        <Panel variant='modal' className={styles.modal}>
+          {children}
+        </Panel>
+      </ContextMenu>
+    )
+  }
+)
+
+export const useControlledActionsMenu = () =>
+  useControlledModal(actionsMenuController)
+
+const ActionsMenu = props => {
+  const Controller = useControlledActionsMenu().ActionsMenu
+  return <Controller {...props} />
+}
+
+export default ActionsMenu

--- a/src/components/ActionsMenu/index.module.scss
+++ b/src/components/ActionsMenu/index.module.scss
@@ -1,0 +1,48 @@
+.btn {
+  border: 1px solid var(--porcelain);
+  border-radius: 4px;
+  display: flex;
+  cursor: pointer;
+  height: 32px;
+}
+
+.trigger {
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+
+  &:hover {
+    color: var(--jungle-green);
+  }
+}
+
+.arrow {
+  box-sizing: content-box;
+  padding: 13px 12px;
+  fill: var(--waterloo);
+  transition: transform 0.2s ease-in-out;
+
+  &:hover {
+    fill: var(--jungle-green);
+  }
+}
+
+.more {
+  transition: background 0.2s ease-in-out;
+  border-left: 1px solid var(--porcelain);
+
+  &_opened {
+    background: var(--jungle-green-light-2);
+
+    .arrow {
+      fill: var(--jungle-green);
+      transform: rotate(180deg);
+    }
+  }
+}
+
+.modal {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/components/banners/feature/PopupBanner.js
+++ b/src/components/banners/feature/PopupBanner.js
@@ -7,7 +7,13 @@ import { PATHS } from '../../../paths'
 import { useUser } from '../../../stores/user'
 import styles from './PopupBanner.module.scss'
 
-const PopupBanner = ({ trigger: Trigger, children, className, ...props }) => {
+const PopupBanner = ({
+  trigger: Trigger,
+  children,
+  className,
+  noContainer,
+  ...props
+}) => {
   const { isLoggedIn } = useUser()
 
   if (isLoggedIn) {
@@ -19,7 +25,9 @@ const PopupBanner = ({ trigger: Trigger, children, className, ...props }) => {
       {...props}
       title=''
       classes={{ title: styles.header }}
-      trigger={Trigger ? <Trigger /> : <div>{children}</div>}
+      trigger={
+        Trigger ? <Trigger /> : noContainer ? children : <div>{children}</div>
+      }
     >
       <div className={cx(styles.wrapper, className)}>
         <h3 className={styles.heading}>Log in to use this feature!</h3>

--- a/src/ducks/HistoricalBalance/Address/Actions.js
+++ b/src/ducks/HistoricalBalance/Address/Actions.js
@@ -3,24 +3,35 @@ import Button from '@santiment-network/ui/Button'
 import Icon from '@santiment-network/ui/Icon'
 import CreateAlert from './CreateAlert'
 import AddToWatchlist from './AddToWatchlist'
+import ActionsMenu from '../../../components/ActionsMenu'
 import styles from './index.module.scss'
+
+const CreateAlertTrigger = ({ className, assets, address, isWithIcon }) => (
+  <CreateAlert
+    assets={assets}
+    address={address}
+    trigger={
+      isWithIcon ? (
+        <Button className={styles.btn}>
+          <Icon type='signal' className={styles.btn__icon} /> Create Alert
+        </Button>
+      ) : (
+        <div className={className}>Create Alert</div>
+      )
+    }
+  />
+)
 
 const Actions = ({ address, infrastructure, assets }) => (
   <div className={styles.actions}>
-    <CreateAlert
-      assets={assets}
-      address={address}
-      trigger={
-        <Button className={styles.btn}>
-          <Icon type='signal' className={styles.btn__icon} />
-          Create Alert
-        </Button>
-      }
-    />
-
-    <div className={styles.divider} />
-
-    <AddToWatchlist address={address} infrastructure={infrastructure} />
+    <ActionsMenu
+      Trigger={props => (
+        <CreateAlertTrigger {...props} assets={assets} address={address} />
+      )}
+    >
+      <CreateAlertTrigger assets={assets} address={address} isWithIcon />
+      <AddToWatchlist address={address} infrastructure={infrastructure} />
+    </ActionsMenu>
   </div>
 )
 

--- a/src/ducks/HistoricalBalance/Address/Actions.js
+++ b/src/ducks/HistoricalBalance/Address/Actions.js
@@ -3,7 +3,7 @@ import Button from '@santiment-network/ui/Button'
 import Icon from '@santiment-network/ui/Icon'
 import CreateAlert from './CreateAlert'
 import AddToWatchlist from './AddToWatchlist'
-import ActionsMenu from '../../../components/ActionsMenu'
+import { useControlledActionsMenu } from '../../../components/ActionsMenu'
 import styles from './index.module.scss'
 
 const CreateAlertTrigger = ({ className, assets, address, isWithIcon }) => (
@@ -22,17 +22,33 @@ const CreateAlertTrigger = ({ className, assets, address, isWithIcon }) => (
   />
 )
 
-const Actions = ({ address, infrastructure, assets }) => (
-  <div className={styles.actions}>
-    <ActionsMenu
-      Trigger={props => (
-        <CreateAlertTrigger {...props} assets={assets} address={address} />
-      )}
-    >
-      <CreateAlertTrigger assets={assets} address={address} isWithIcon />
-      <AddToWatchlist address={address} infrastructure={infrastructure} />
-    </ActionsMenu>
-  </div>
-)
+const Actions = ({ address, infrastructure, assets }) => {
+  const { ActionsMenu, close } = useControlledActionsMenu()
+
+  function onCommentClick () {
+    const $comment = document.querySelector('textarea[name="comment"]')
+    if ($comment) {
+      $comment.focus()
+      close()
+    }
+  }
+
+  return (
+    <div className={styles.actions}>
+      <ActionsMenu
+        Trigger={props => (
+          <CreateAlertTrigger {...props} assets={assets} address={address} />
+        )}
+      >
+        <CreateAlertTrigger assets={assets} address={address} isWithIcon />
+        <AddToWatchlist address={address} infrastructure={infrastructure} />
+        <Button className={styles.btn} onClick={onCommentClick}>
+          <Icon type='comment' className={styles.btn__icon} />
+          Comment
+        </Button>
+      </ActionsMenu>
+    </div>
+  )
+}
 
 export default Actions

--- a/src/ducks/HistoricalBalance/Address/AddToWatchlist.js
+++ b/src/ducks/HistoricalBalance/Address/AddToWatchlist.js
@@ -47,8 +47,8 @@ const AddToWatchlist = ({ address, infrastructure }) => {
           className={styles.btn}
           disabled={infrastructure !== Infrastructure.ETH}
         >
-          <Icon type='copy' className={styles.btn__icon} />
-          Add to watchlist
+          <Icon type='plus-round' className={styles.btn__icon} />
+          Add to Watchlist
         </Button>
       }
       getWatchlists={useAddressWatchlists}

--- a/src/ducks/HistoricalBalance/Address/AssetsDistribution.js
+++ b/src/ducks/HistoricalBalance/Address/AssetsDistribution.js
@@ -89,7 +89,7 @@ const CollapsedDistributions = ({ distributions }) => (
   </CollapsedTooltip>
 )
 
-const AssetsDistribution = ({ walletAssets }) => {
+const AssetsDistribution = ({ walletAssets, className }) => {
   const distributions = useDistributions(walletAssets)
   const biggestDistributions = useMemo(
     () => {
@@ -105,7 +105,7 @@ const AssetsDistribution = ({ walletAssets }) => {
   const hiddenProjects = distributions.slice(MAX_DESCRIBED_PROJECTS)
 
   return (
-    <div className={styles.wrapper}>
+    <div className={cx(styles.wrapper, className)}>
       <div className={styles.title}>Assets distribution</div>
       <div className={styles.historgram}>
         {historgramProjects.map(({ name, style }) => (

--- a/src/ducks/HistoricalBalance/Address/AssetsDistribution.module.scss
+++ b/src/ducks/HistoricalBalance/Address/AssetsDistribution.module.scss
@@ -77,4 +77,8 @@
   cursor: pointer;
   text-decoration: underline;
   text-decoration-style: dashed;
+
+  &:hover {
+    color: var(--jungle-green-hover);
+  }
 }

--- a/src/ducks/HistoricalBalance/Address/AssetsDistribution.module.scss
+++ b/src/ducks/HistoricalBalance/Address/AssetsDistribution.module.scss
@@ -4,7 +4,6 @@
   @include text('caption');
 
   color: var(--waterloo);
-  margin-left: 72px;
   width: 336px;
 }
 

--- a/src/ducks/HistoricalBalance/Address/CreateAlert.js
+++ b/src/ducks/HistoricalBalance/Address/CreateAlert.js
@@ -41,6 +41,7 @@ const CreateAlert = ({ assets, address, trigger }) => {
         ...DEFAULTS
       }}
       buttonParams={PARAMS}
+      noLoginPopupContainer
     />
   )
 }

--- a/src/ducks/HistoricalBalance/Address/CurrentBalance.js
+++ b/src/ducks/HistoricalBalance/Address/CurrentBalance.js
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react'
+import cx from 'classnames'
 import { useProjects, getProjectInfo } from '../../../stores/projects'
 import { millify } from '../../../utils/formatting'
 import styles from './CurrentBalance.module.scss'
@@ -48,13 +49,13 @@ function useCurrentBalance (walletAssets) {
   )
 }
 
-const CurrentBalance = ({ walletAssets }) => {
+const CurrentBalance = ({ walletAssets, className }) => {
   const { usd, totalBalance, distributions } = useCurrentBalance(walletAssets)
 
   if (!totalBalance) return null
 
   return (
-    <div className={styles.wrapper}>
+    <div className={cx(styles.wrapper, className)}>
       <div className={styles.title}>Current balance</div>
 
       <div className={styles.balance}>

--- a/src/ducks/HistoricalBalance/Address/CurrentBalance.module.scss
+++ b/src/ducks/HistoricalBalance/Address/CurrentBalance.module.scss
@@ -1,9 +1,7 @@
 @import '~@santiment-network/ui/mixins';
 
 .wrapper {
-  position: relative;
   width: 250px;
-  margin-left: 72px;
 }
 
 .wrapper,

--- a/src/ducks/HistoricalBalance/Address/index.js
+++ b/src/ducks/HistoricalBalance/Address/index.js
@@ -10,6 +10,7 @@ import {
   Infrastructure,
   getAddressInfrastructure
 } from '../../../utils/address'
+import { DesktopOnly } from '../../../components/Responsive'
 import styles from './index.module.scss'
 
 export const AddressSetting = ({
@@ -80,8 +81,18 @@ export const AddressSetting = ({
         assets={chartAssets}
       />
 
-      <AssetsDistribution walletAssets={walletAssets} />
-      <CurrentBalance walletAssets={walletAssets} />
+      <DesktopOnly>
+        <div className={styles.widgets}>
+          <AssetsDistribution
+            walletAssets={walletAssets}
+            className={styles.widget}
+          />
+          <CurrentBalance
+            walletAssets={walletAssets}
+            className={styles.widget}
+          />
+        </div>
+      </DesktopOnly>
     </div>
   )
 }

--- a/src/ducks/HistoricalBalance/Address/index.module.scss
+++ b/src/ducks/HistoricalBalance/Address/index.module.scss
@@ -2,8 +2,6 @@
 
 .wrapper {
   display: flex;
-  background: var(--athens);
-  padding: 16px 24px;
 }
 
 .top,

--- a/src/ducks/HistoricalBalance/Address/index.module.scss
+++ b/src/ducks/HistoricalBalance/Address/index.module.scss
@@ -31,8 +31,13 @@
 
 .btn {
   background: transparent;
-  fill: var(--waterloo);
+  fill: var(--casper);
   white-space: nowrap;
+
+  &:hover {
+    background: var(--athens);
+    fill: var(--waterloo);
+  }
 
   &__icon {
     margin-right: 8px;

--- a/src/ducks/HistoricalBalance/Address/index.module.scss
+++ b/src/ducks/HistoricalBalance/Address/index.module.scss
@@ -2,6 +2,7 @@
 
 .wrapper {
   display: flex;
+  flex-wrap: wrap;
 }
 
 .top,
@@ -54,4 +55,31 @@
 .actions {
   display: flex;
   margin: 16px 0 0 16px;
+}
+
+.widget {
+  margin-left: 72px;
+
+  @media only screen and (max-width: 1360px) {
+    margin-left: 24px;
+  }
+}
+
+.widgets {
+  display: flex;
+
+  @media only screen and (max-width: 1260px) {
+    flex-basis: 100%;
+    margin-top: 24px;
+    justify-content: space-between;
+
+    .widget {
+      flex: 1;
+
+      &:first-child {
+        margin: 0;
+        flex: 2;
+      }
+    }
+  }
 }

--- a/src/ducks/HistoricalBalance/Address/index.module.scss
+++ b/src/ducks/HistoricalBalance/Address/index.module.scss
@@ -75,6 +75,7 @@
 
     .widget {
       flex: 1;
+      margin-left: 10%;
 
       &:first-child {
         margin: 0;

--- a/src/ducks/HistoricalBalance/Chart/index.js
+++ b/src/ducks/HistoricalBalance/Chart/index.js
@@ -10,7 +10,10 @@ import { generateSearchQuery } from '../url'
 import { ShareButton } from '../../Studio/Header/Settings'
 import styles from './index.module.scss'
 
-const Configurations = ({
+const Chart = ({
+  children,
+  className,
+  canvasClassName,
   height,
   settings,
   chartAssets,
@@ -34,7 +37,7 @@ const Configurations = ({
   )
 
   return (
-    <div className={styles.wrapper}>
+    <div className={cx(styles.wrapper, className)}>
       <div className={cx(styles.header, isPhone && styles.header_phone)}>
         <Assets
           className={
@@ -64,14 +67,17 @@ const Configurations = ({
         </div>
       </div>
       <Canvas
+        className={canvasClassName}
         axesTicks={axesTicks}
         height={height}
         scale={isLog ? logScale : linearScale}
         settings={settings}
         metrics={metrics}
       />
+
+      {children}
     </div>
   )
 }
 
-export default Configurations
+export default Chart

--- a/src/ducks/HistoricalBalance/Chart/index.module.scss
+++ b/src/ducks/HistoricalBalance/Chart/index.module.scss
@@ -1,6 +1,6 @@
 .header {
   display: flex;
-  padding: 16px 24px 4px;
+  padding: 0 0 16px;
 
   &_phone {
     flex-direction: column;

--- a/src/ducks/HistoricalBalance/Sankey/index.module.scss
+++ b/src/ducks/HistoricalBalance/Sankey/index.module.scss
@@ -2,7 +2,7 @@
 
 .wrapper {
   border: 1px solid var(--porcelain);
-  margin-top: 30px;
+  margin-top: 16px;
   border-radius: 4px;
 }
 
@@ -28,7 +28,7 @@
   padding: 10px;
   fill: var(--waterloo);
   cursor: pointer;
-  background: var(--athens);
+  background: var(--white);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -39,7 +39,6 @@
   }
 
   &_opened {
-    background: none;
     border-top: 1px solid var(--porcelain);
   }
 }

--- a/src/ducks/HistoricalBalance/index.js
+++ b/src/ducks/HistoricalBalance/index.js
@@ -3,10 +3,10 @@ import cx from 'classnames'
 import { ASSETS_LIMIT, withDefaults } from './defaults'
 import { useSettings, useWalletAssets } from './hooks'
 import Chart from './Chart'
-import Sankey from './Sankey'
 import AddressSetting from './Address'
 import Comments from './Comments'
-import LatestTransactions from './LatestTransactions/index.js'
+import LatestTransactions from './LatestTransactions'
+import Sankey from './Sankey'
 import { withSizes, DesktopOnly } from '../../components/Responsive'
 import { Infrastructure } from '../../utils/address'
 import styles from './index.module.scss'
@@ -79,6 +79,8 @@ const HistoricalBalance = ({
       />
 
       <Chart
+        className={styles.chart}
+        canvasClassName={styles.canvas}
         height={isPhone ? 340 : 450}
         settings={settings}
         chartAssets={chartAssets}
@@ -91,13 +93,13 @@ const HistoricalBalance = ({
         changeTimePeriod={changeTimePeriod}
         setChartAssets={updateChartAssets}
         setIsLog={setIsLog}
-      />
-
-      <DesktopOnly>
-        {settings.infrastructure === Infrastructure.ETH && (
-          <Sankey settings={settings} />
-        )}
-      </DesktopOnly>
+      >
+        <DesktopOnly>
+          {settings.infrastructure === Infrastructure.ETH && (
+            <Sankey settings={settings} />
+          )}
+        </DesktopOnly>
+      </Chart>
 
       <div className={cx(styles.bottom, isPhone && styles.bottom_phone)}>
         <div className={styles.left}>

--- a/src/ducks/HistoricalBalance/index.module.scss
+++ b/src/ducks/HistoricalBalance/index.module.scss
@@ -44,3 +44,15 @@
     }
   }
 }
+
+.chart {
+  margin: 32px -32px 0;
+  padding: 24px 32px;
+  background: var(--athens);
+}
+
+.canvas {
+  background-color: var(--white);
+  border: 1px solid var(--porcelain);
+  border-radius: 4px;
+}

--- a/src/ducks/Signals/signalModal/SignalDialog.js
+++ b/src/ducks/Signals/signalModal/SignalDialog.js
@@ -28,7 +28,8 @@ const SignalDialog = ({
   canRedirect,
   metaFormSettings,
   buttonParams,
-  SignalMaster
+  SignalMaster,
+  noLoginPopupContainer
 }) => {
   const [dialogTitle, onSetDialogTitle] = useState('')
   const [isAnonWarning, setAnonWarning] = useState(false)
@@ -73,7 +74,7 @@ const SignalDialog = ({
 
   if ((isAnonWarning || !canOpen) && !isLoggedIn) {
     return (
-      <LoginPopup>
+      <LoginPopup noContainer={noLoginPopupContainer}>
         {dialogTrigger || signalModalTrigger(enabled, label, variant, border)}
       </LoginPopup>
     )

--- a/src/ducks/Signals/signalModal/SignalMasterModalForm.js
+++ b/src/ducks/Signals/signalModal/SignalMasterModalForm.js
@@ -24,7 +24,8 @@ const SignalMasterModalForm = ({
   redirect,
   previousPage = ALERT_ROUTES.ALERTS,
   defaultOpen = true,
-  onClose
+  onClose,
+  noLoginPopupContainer
 }) => {
   const { id: shareId, isShared: isOldShared } = shareParams
 
@@ -150,6 +151,7 @@ const SignalMasterModalForm = ({
         metaFormSettings={metaFormSettings}
         buttonParams={buttonParams}
         SignalMaster={SignalMaster}
+        noLoginPopupContainer={noLoginPopupContainer}
       />
     </>
   )

--- a/src/hooks/modal.js
+++ b/src/hooks/modal.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react'
+
+export function newModalController (name, Component) {
+  const controller = {
+    [name]: props => (
+      <Component
+        position='bottom'
+        on='click'
+        {...props}
+        open={controller.isOpened}
+        onOpen={controller.open}
+        onClose={controller.close}
+      />
+    )
+  }
+  return controller
+}
+
+export function useControlledModal (modalController, isOpenedDefault) {
+  const [isOpened, setIsOpened] = useState(isOpenedDefault)
+  const controller = useState(modalController)[0]
+
+  controller.isOpened = isOpened
+  controller.open = () => setIsOpened(true)
+  controller.close = () => setIsOpened(false)
+
+  return controller
+}

--- a/src/hooks/modal.js
+++ b/src/hooks/modal.js
@@ -2,6 +2,8 @@ import React, { useState } from 'react'
 
 export function newModalController (name, Component) {
   const controller = {
+    open: () => controller.setIsOpened(true),
+    close: () => controller.setIsOpened(false),
     [name]: props => (
       <Component
         position='bottom'
@@ -21,8 +23,7 @@ export function useControlledModal (modalController, isOpenedDefault) {
   const controller = useState(modalController)[0]
 
   controller.isOpened = isOpened
-  controller.open = () => setIsOpened(true)
-  controller.close = () => setIsOpened(false)
+  controller.setIsOpened = setIsOpened
 
   return controller
 }


### PR DESCRIPTION
## Changes
- `Assets distribution` and `Current balance` responsive layout;
- Actions dropdown

## Notion's card
https://www.notion.so/santiment/Historical-Balance-assets-distribution-e49b02a75ce44640aea81b08008545fd
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<img width="916" alt="image" src="https://user-images.githubusercontent.com/25135650/110954066-20c45d80-8359-11eb-800f-c9d80d16daa1.png">
<img width="366" alt="image" src="https://user-images.githubusercontent.com/25135650/110954446-903a4d00-8359-11eb-858c-abe0008c5cce.png">

