### PR TITLE
enhance/historical-balance-assets-distribution

### DIFF
--- a/src/ducks/HistoricalBalance/Address/AssetsDistribution.js
+++ b/src/ducks/HistoricalBalance/Address/AssetsDistribution.js
@@ -19,12 +19,12 @@ const COLORS = [
 const MAX_COLOR_PROJECTS = COLORS.length
 const MAX_DESCRIBED_PROJECTS = 6
 
-const distributionSorter = ({ balanceUsd: a }, { balanceUsd: b }) => b - a
+export const existingAssetsFilter = ({ balanceUsd }) => balanceUsd
+export const distributionSorter = ({ balanceUsd: a }, { balanceUsd: b }) =>
+  b - a
 const checkIsSmallDistribution = percent => percent < 0.5
 const smallDistributionFinder = ({ percent }) =>
   checkIsSmallDistribution(percent)
-
-export const existingAssetsFilter = ({ balanceUsd }) => balanceUsd
 
 function useDistributions (walletAssets) {
   const { projects } = useProjects()
@@ -33,10 +33,11 @@ function useDistributions (walletAssets) {
     () => {
       if (projects.length === 0) return []
 
-      const filteredWalletAssets = walletAssets.filter(existingAssetsFilter)
-      const { length } = filteredWalletAssets
+      const sortedAssets = walletAssets
+        .filter(existingAssetsFilter)
+        .sort(distributionSorter)
+      const { length } = sortedAssets
       const distributions = new Array(length)
-      const sortedAssets = filteredWalletAssets.sort(distributionSorter)
       let totalBalance = 0
 
       for (let i = 0; i < length; i++) {

--- a/src/ducks/HistoricalBalance/Address/AssetsDistribution.module.scss
+++ b/src/ducks/HistoricalBalance/Address/AssetsDistribution.module.scss
@@ -36,12 +36,15 @@
     background: var(--white);
   }
 
-  &:last-child::after {
-    display: none;
+  &:last-child {
+    flex: 1;
+
+    &::after {
+      display: none;
+    }
   }
 
   &_other {
-    flex: 1;
     background: var(--mystic);
   }
 }

--- a/src/ducks/HistoricalBalance/Address/CurrentBalance.js
+++ b/src/ducks/HistoricalBalance/Address/CurrentBalance.js
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import cx from 'classnames'
 import {
+  distributionSorter,
   existingAssetsFilter,
   CollapsedDistributions
 } from './AssetsDistribution'
@@ -9,17 +10,17 @@ import { millify } from '../../../utils/formatting'
 import styles from './CurrentBalance.module.scss'
 
 const MAX_DISTRIBUTIONS = 5
-const distributionSorter = ({ balanceUsd: a }, { balanceUsd: b }) => b - a
 const intlFormatter = new Intl.NumberFormat('en-EN', {
   style: 'currency',
   currency: 'USD'
 })
 
-const Distribution = ({ ticker, balance }) => (
-  <div className={styles.project}>
-    {ticker} {balance}
-  </div>
-)
+const Distribution = ({ ticker, balance }) =>
+  ticker ? (
+    <div className={styles.project}>
+      {ticker} {balance}
+    </div>
+  ) : null
 
 const Distributions = ({ distributions }) =>
   distributions.map((distribution, i) => (
@@ -69,8 +70,11 @@ const CurrentBalance = ({ walletAssets, className }) => {
 
   if (!totalBalance) return null
 
-  const biggestDistributions = distributions.slice(0, MAX_DISTRIBUTIONS)
   const hiddenProjects = distributions.slice(MAX_DISTRIBUTIONS)
+  const biggestDistributions = distributions.slice(
+    0,
+    MAX_DISTRIBUTIONS + (hiddenProjects.length === 1)
+  )
 
   return (
     <div className={cx(styles.wrapper, className)}>
@@ -81,13 +85,9 @@ const CurrentBalance = ({ walletAssets, className }) => {
       </div>
 
       <div className={styles.projects}>
-        {biggestDistributions.map(({ ticker, balance }) =>
-          ticker ? (
-            <Distribution key={ticker} ticker={ticker} balance={balance} />
-          ) : null
-        )}
+        <Distributions distributions={biggestDistributions} />
 
-        {hiddenProjects.length !== 0 && (
+        {hiddenProjects.length > 1 && (
           <CollapsedDistributions
             distributions={hiddenProjects}
             Items={Distributions}

--- a/src/ducks/HistoricalBalance/Address/CurrentBalance.js
+++ b/src/ducks/HistoricalBalance/Address/CurrentBalance.js
@@ -1,14 +1,30 @@
 import React, { useMemo } from 'react'
 import cx from 'classnames'
+import {
+  existingAssetsFilter,
+  CollapsedDistributions
+} from './AssetsDistribution'
 import { useProjects, getProjectInfo } from '../../../stores/projects'
 import { millify } from '../../../utils/formatting'
 import styles from './CurrentBalance.module.scss'
 
+const MAX_DISTRIBUTIONS = 5
 const distributionSorter = ({ balanceUsd: a }, { balanceUsd: b }) => b - a
 const intlFormatter = new Intl.NumberFormat('en-EN', {
   style: 'currency',
   currency: 'USD'
 })
+
+const Distribution = ({ ticker, balance }) => (
+  <div className={styles.project}>
+    {ticker} {balance}
+  </div>
+)
+
+const Distributions = ({ distributions }) =>
+  distributions.map((distribution, i) => (
+    <Distribution key={i} {...distribution} />
+  ))
 
 function useCurrentBalance (walletAssets) {
   const { projects } = useProjects()
@@ -18,9 +34,8 @@ function useCurrentBalance (walletAssets) {
       if (projects.length === 0) return { distributions: [] }
 
       const sortedAssets = walletAssets
-        .slice()
+        .filter(existingAssetsFilter)
         .sort(distributionSorter)
-        .slice(0, 5)
       const { length } = sortedAssets
       const distributions = new Array(length)
 
@@ -30,12 +45,12 @@ function useCurrentBalance (walletAssets) {
       }
 
       for (let i = 0; i < length; i++) {
-        const { slug, balance } = sortedAssets[i]
+        const { slug, balanceUsd } = sortedAssets[i]
         const { ticker } = getProjectInfo(projects, slug) || {}
 
         distributions[i] = {
           ticker,
-          balance: millify(balance, balance < 1 ? 3 : 1)
+          balance: '$' + millify(balanceUsd, balanceUsd < 1 ? 3 : 1)
         }
       }
 
@@ -54,6 +69,9 @@ const CurrentBalance = ({ walletAssets, className }) => {
 
   if (!totalBalance) return null
 
+  const biggestDistributions = distributions.slice(0, MAX_DISTRIBUTIONS)
+  const hiddenProjects = distributions.slice(MAX_DISTRIBUTIONS)
+
   return (
     <div className={cx(styles.wrapper, className)}>
       <div className={styles.title}>Current balance</div>
@@ -63,12 +81,17 @@ const CurrentBalance = ({ walletAssets, className }) => {
       </div>
 
       <div className={styles.projects}>
-        {distributions.map(({ ticker, balance }) =>
+        {biggestDistributions.map(({ ticker, balance }) =>
           ticker ? (
-            <div key={ticker} className={styles.project}>
-              {ticker} {balance}
-            </div>
+            <Distribution key={ticker} ticker={ticker} balance={balance} />
           ) : null
+        )}
+
+        {hiddenProjects.length !== 0 && (
+          <CollapsedDistributions
+            distributions={hiddenProjects}
+            Items={Distributions}
+          />
         )}
       </div>
     </div>

--- a/src/ducks/HistoricalBalance/LatestTransactions/index.js
+++ b/src/ducks/HistoricalBalance/LatestTransactions/index.js
@@ -7,7 +7,8 @@ import styles from './index.module.scss'
 
 const PAGE_SIZES = buildPageSizes([20, 50])
 
-const getItemKey = ({ trxHash, slug }) => trxHash + slug
+const getItemKey = ({ trxHash, toAddress, slug, trxValue }) =>
+  trxHash + toAddress.address + slug + trxValue
 
 const LatestTransactions = ({ settings }) => {
   const pagesItems = useRef([]).current


### PR DESCRIPTION
## Changes
Displaying USD assets distributions.

## Notion's card

https://www.notion.so/santiment/Historical-Balance-assets-distribution-e49b02a75ce44640aea81b08008545fd

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<img width="720" alt="image" src="https://user-images.githubusercontent.com/25135650/111458178-32777d80-872a-11eb-9e90-cd132bc9f7e2.png">


