### PR TITLE
fix/address-watchlists-dublicates

### DIFF
--- a/src/ducks/Watchlists/Actions/Edit/EditAddresses/EditAddresses.js
+++ b/src/ducks/Watchlists/Actions/Edit/EditAddresses/EditAddresses.js
@@ -18,6 +18,7 @@ const updateWatchlist = ({ id, listItems }) =>
   updateWatchlistShort({ id: +id, listItems })
 
 export const NOT_VALID_ADDRESS = 'Not supported ETH address'
+export const ALREADY_ADDED_ADDRESS = 'This address was added'
 
 const extractAddress = ({ blockchainAddress }) => blockchainAddress
 
@@ -88,15 +89,38 @@ const EditAddresses = ({ trigger, watchlist }) => {
     })
   }
 
+  function isAdded (address) {
+    return watchlist.listItems.some(
+      item =>
+        item.blockchainAddress && item.blockchainAddress.address === address
+    )
+  }
+
   const onInputChangeDebounced = ({ target: { value } }) => {
     const infrastructure = getAddressInfrastructure(value)
-    const valid = infrastructure && infrastructure === Infrastructure.ETH
-    if (valid && !items.find(x => x === value)) {
-      setCurrentValue(value)
-    }
+
+    const valid =
+      infrastructure && infrastructure === Infrastructure.ETH && !isAdded(value)
+
+    setCurrentValue(value)
 
     setError(!value || !valid)
   }
+
+  const errorText = useMemo(
+    () => {
+      if (!error) {
+        return
+      }
+
+      if (isAdded(currentAddress)) {
+        return ALREADY_ADDED_ADDRESS
+      }
+
+      return NOT_VALID_ADDRESS
+    },
+    [error, currentAddress]
+  )
 
   if (!isAuthor) {
     return null
@@ -118,7 +142,7 @@ const EditAddresses = ({ trigger, watchlist }) => {
               className={styles.input}
               placeholder='Wallet address'
               onChange={onInputChangeDebounced}
-              errorText={error && NOT_VALID_ADDRESS}
+              errorText={errorText}
               isError={!!error}
             />
           </div>


### PR DESCRIPTION
## Changes

Fix: check dublicates for address watchlists


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
![image](https://user-images.githubusercontent.com/14061779/112798750-09ce7c80-9076-11eb-9472-97b808525964.png)


