### PR TITLE
enhance/studio-weighted-sentiment-interval

### DIFF
--- a/src/ducks/Studio/Widget/ChartWidget.js
+++ b/src/ducks/Studio/Widget/ChartWidget.js
@@ -11,9 +11,9 @@ import StudioChart from '../Chart'
 import { dispatchWidgetMessage } from '../widgetMessage'
 import { DEFAULT_OPTIONS } from '../defaults'
 import { getMetricSetting, calculateMovingAverageFromInterval } from '../utils'
+import { useMetricSettingsAdjuster } from '../hooks'
 import { convertBaseProjectMetric } from '../metrics'
 import { useTimeseries } from '../timeseries/hooks'
-import { useMetricSettingsAdjuster } from '../timeseries/candles'
 import { useEdgeGaps, useClosestValueData } from '../../Chart/hooks'
 import { useSyncDateEffect } from '../../Chart/sync'
 import { Metric } from '../../dataHub/metrics'
@@ -34,7 +34,8 @@ export const Chart = ({
   const [options, setOptions] = useState(DEFAULT_OPTIONS)
   const MetricSettingMap = useMetricSettingsAdjuster(
     widget.MetricSettingMap,
-    settings
+    settings,
+    metrics
   )
   const MetricTransformer = useMirroredTransformer(metrics)
   const MetricNode = useMetricNodeOverwrite(MetricSettingMap)

--- a/src/ducks/Studio/hooks.js
+++ b/src/ducks/Studio/hooks.js
@@ -1,4 +1,6 @@
-import { useEffect } from 'react'
+import { useMemo, useEffect } from 'react'
+import { useCandleMetricSettings } from './timeseries/candles'
+import { MetricIntervalGetter } from '../dataHub/metrics/intervals'
 
 export function useKeyDown (clb, key) {
   useEffect(() => {
@@ -32,4 +34,25 @@ export function useKeyboardCmdShortcut (key, clb, target = window) {
     },
     [clb, target]
   )
+}
+
+export function useMetricSettingsAdjuster (MetricSettingMap, settings, metrics) {
+  const { from, to } = settings
+  useMemo(
+    () => {
+      metrics.forEach(metric => {
+        const intervalGetter = MetricIntervalGetter[metric.key]
+        if (!intervalGetter) return
+
+        const metricSettings = MetricSettingMap.get(metric) || {}
+        metricSettings.interval = intervalGetter(from, to)
+        MetricSettingMap.set(metric, metricSettings)
+      })
+    },
+    [MetricSettingMap, metrics, from, to]
+  )
+
+  useCandleMetricSettings(MetricSettingMap, settings)
+
+  return MetricSettingMap
 }

--- a/src/ducks/Studio/hooks.js
+++ b/src/ducks/Studio/hooks.js
@@ -45,6 +45,11 @@ export function useMetricSettingsAdjuster (MetricSettingMap, settings, metrics) 
         if (!intervalGetter) return
 
         const metricSettings = MetricSettingMap.get(metric) || {}
+        const { interval } = metricSettings
+        if (interval && !intervalGetter.intervals.has(interval)) {
+          return // NOTE: Won't apply auto interval if user set his own [@vanguard | Apr 16, 2021]
+        }
+
         metricSettings.interval = intervalGetter(from, to)
         MetricSettingMap.set(metric, metricSettings)
       })

--- a/src/ducks/Studio/timeseries/candles.js
+++ b/src/ducks/Studio/timeseries/candles.js
@@ -7,7 +7,7 @@ import {
   getCandlesMinInterval
 } from '../Chart/MetricSettings/hooks'
 
-export function useMetricSettingsAdjuster (MetricSettingMap, { from, to }) {
+export function useCandleMetricSettings (MetricSettingMap, { from, to }) {
   return useMemo(
     () => {
       MetricSettingMap.forEach((MetricSettings, metric) => {

--- a/src/ducks/Studio/timeseries/hooks.js
+++ b/src/ducks/Studio/timeseries/hooks.js
@@ -177,9 +177,10 @@ export function useTimeseries (
                 return newState
               })
               setTimeseries(() => {
-                mergedData = mergeTimeseries([mergedData, data])
-
-                return mergedData.map(normalizeDatetimes)
+                mergedData = mergeTimeseries([mergedData, data]).map(
+                  normalizeDatetimes
+                )
+                return mergedData
               })
             })
             .catch(({ message }) => {

--- a/src/ducks/dataHub/metrics/intervals.js
+++ b/src/ducks/dataHub/metrics/intervals.js
@@ -2,8 +2,8 @@ import { Metric } from './index'
 import { INTERVAL_ALIAS } from '../../SANCharts/IntervalSelector'
 import { dateDifference, DAY } from '../../../utils/dates'
 
-function newCustomInterval (clb) {
-  return (from, to) => {
+function newCustomInterval (intervals, clb) {
+  const getter = (from, to) => {
     const interval = clb(
       dateDifference({
         from: new Date(from),
@@ -13,9 +13,11 @@ function newCustomInterval (clb) {
     )
     return INTERVAL_ALIAS[interval] || interval
   }
+  getter.intervals = new Set(intervals)
+  return getter
 }
 
-const getWeightedSocialIntervals = newCustomInterval(diff =>
+const getWeightedSocialIntervals = newCustomInterval(['1h', '1d'], diff =>
   diff < 33 ? '1h' : '1d'
 )
 

--- a/src/ducks/dataHub/metrics/intervals.js
+++ b/src/ducks/dataHub/metrics/intervals.js
@@ -1,0 +1,27 @@
+import { Metric } from './index'
+import { INTERVAL_ALIAS } from '../../SANCharts/IntervalSelector'
+import { dateDifference, DAY } from '../../../utils/dates'
+
+function newCustomInterval (clb) {
+  return (from, to) => {
+    const interval = clb(
+      dateDifference({
+        from: new Date(from),
+        to: new Date(to),
+        format: DAY
+      }).diff
+    )
+    return INTERVAL_ALIAS[interval] || interval
+  }
+}
+
+const getWeightedSocialIntervals = newCustomInterval(diff =>
+  diff < 33 ? '1h' : '1d'
+)
+
+export const MetricIntervalGetter = {
+  [Metric.sentiment_volume_consumed_total.key]: getWeightedSocialIntervals,
+  [Metric.sentiment_volume_consumed_telegram.key]: getWeightedSocialIntervals,
+  [Metric.sentiment_volume_consumed_reddit.key]: getWeightedSocialIntervals,
+  [Metric.sentiment_volume_consumed_twitter.key]: getWeightedSocialIntervals
+}


### PR DESCRIPTION
## Changes
Custom intervals for `Weighted Sentiment` metrics:
- When data period is less than `1 month`, metric is fetched using `1 hour` interval;
- When data period is more than `1 month`, metric is fetched using `1 day` interval;
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/Weighted-Sentiment-custom-intervals-71545e3bb4f84b15a71ff15cf2f7808f

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [ ] If I make changes to another person's module, I've asked how to use it or request a review
- [ ] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [ ] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [ ] I've added tests (if necessary)

## Screenshots or GIFs
<img width="975" alt="image" src="https://user-images.githubusercontent.com/25135650/115003760-cb76f100-9eae-11eb-8e3b-ede55809f975.png">


