### PR TITLE
fix/studio-area-closest-data

### DIFF
--- a/src/ducks/Chart/Areas.js
+++ b/src/ducks/Chart/Areas.js
@@ -5,6 +5,7 @@ import { buildPlotter } from './context'
 export default buildPlotter(({ plotter }) => {
   useEffect(() => {
     plotter.register('areas', (chart, scale, data, colors, { areas }) => {
+      chart.ctx.lineWidth = 1.5
       plotAreas(chart, data, areas, scale, colors, colors)
     })
   }, [])

--- a/src/ducks/Chart/nodes.js
+++ b/src/ducks/Chart/nodes.js
@@ -1,7 +1,8 @@
 const LineNode = {
   LINE: 'line',
   FILLED_LINE: 'filledLine',
-  GRADIENT_LINE: 'gradientLine'
+  GRADIENT_LINE: 'gradientLine',
+  AREA: 'area'
 }
 
 const BarNode = {
@@ -10,10 +11,6 @@ const BarNode = {
   GREEN_RED_BAR: 'greenRedBar'
 }
 
-export const Node = Object.assign(
-  { CANDLES: 'candle', AREA: 'area' },
-  LineNode,
-  BarNode
-)
+export const Node = Object.assign({ CANDLES: 'candle' }, LineNode, BarNode)
 export const LINES = new Set(Object.values(LineNode))
 export const BARS = new Set(Object.values(BarNode))

--- a/src/ducks/Studio/timeseries/hooks.js
+++ b/src/ducks/Studio/timeseries/hooks.js
@@ -177,9 +177,10 @@ export function useTimeseries (
                 return newState
               })
               setTimeseries(() => {
-                mergedData = mergeTimeseries([mergedData, data]).map(
-                  normalizeDatetimes
-                )
+                mergedData = mergeTimeseries([
+                  mergedData,
+                  data.map(normalizeDatetimes)
+                ])
                 return mergedData
               })
             })


### PR DESCRIPTION
## Changes
Marking `Area` metrics as a part of the`LineNode`'s, so the closest value function can be applied

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)


