### PR TITLE
fix/watchlist-alerts

### DIFF
--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricTypes/SupportedMetricsList.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricTypes/SupportedMetricsList.js
@@ -23,10 +23,17 @@ export function filterOnlyMetrics (submetrics) {
   return result
 }
 
-const getByAvailable = (availableMetrics = DEFAULT_METRICS) =>
-  SIGNAL_SUPPORTED_METRICS.filter(({ key }) => {
-    return availableMetrics.indexOf(key) !== -1
-  })
+const getByAvailable = (availableMetrics = DEFAULT_METRICS, trigger) => {
+  const { target: { watchlist_id } = {} } = trigger.settings
+
+  if (watchlist_id) {
+    return SIGNAL_SUPPORTED_METRICS
+  } else {
+    return SIGNAL_SUPPORTED_METRICS.filter(({ key }) => {
+      return availableMetrics.indexOf(key) !== -1
+    })
+  }
+}
 
 export function useAvailableMetrics (slug) {
   const { data, loading, error } = useQuery(PROJECT_METRICS_BY_SLUG_QUERY, {
@@ -47,16 +54,20 @@ export function useAvailableMetrics (slug) {
   ]
 }
 
-const SupportedMetricsList = ({ onSelectMetric, availableMetrics, slug }) => {
+const SupportedMetricsList = ({
+  onSelectMetric,
+  availableMetrics,
+  trigger,
+  slug
+}) => {
   const [categories, setCategories] = useState({})
-
   const isBeta = useIsBetaMode()
 
   const metrics = useMemo(
     () => {
-      return getByAvailable(availableMetrics)
+      return getByAvailable(availableMetrics, trigger)
     },
-    [availableMetrics]
+    [availableMetrics, trigger]
   )
   const AllSubmetrics = useMergedTimeboundSubmetrics(availableMetrics)
 
@@ -66,7 +77,7 @@ const SupportedMetricsList = ({ onSelectMetric, availableMetrics, slug }) => {
       const newCategories = getCategoryGraph(metrics, [], submetrics, isBeta)
       setCategories(newCategories)
     },
-    [availableMetrics]
+    [availableMetrics, metrics, isBeta]
   )
 
   const [project] = useProject(slug)

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricTypes/TriggerFormMetricTypes.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricTypes/TriggerFormMetricTypes.js
@@ -130,6 +130,7 @@ const TriggerFormMetricTypes = ({
               slug={slug}
               onSelectMetric={onSelectMetric}
               availableMetrics={availableMetrics}
+              trigger={trigger}
             />
           </div>
         </Dialog.ScrollContent>

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricTypes/TriggerFormMetricTypes.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricTypes/TriggerFormMetricTypes.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { connect } from 'react-redux'
 import Dialog from '@santiment-network/ui/Dialog'
 import {
@@ -17,6 +17,7 @@ import SupportedMetricsList, {
 import { showNotification } from '../../../../../../actions/rootActions'
 import { capitalizeStr } from '../../../../../../utils/utils'
 import { useDialogState } from '../../../../../../hooks/dialog'
+import { Metric } from '../../../../../dataHub/metrics'
 import styles from '../../signal/TriggerForm.module.scss'
 import metricStyles from './TriggerFormMetricTypes.module.scss'
 
@@ -31,11 +32,11 @@ const TriggerFormMetricTypes = ({
   target,
   setFieldValue,
   metaFormSettings,
-  trigger,
-  showErrorAlert
+  trigger
 }) => {
   const defaultMetric = metaFormSettings.metric
 
+  const [error, showErrorAlert] = useState('')
   const { isOpened, openDialog, closeDialog } = useDialogState(false)
 
   const onSelectMetric = newMetric => {
@@ -78,13 +79,15 @@ const TriggerFormMetricTypes = ({
         )
 
         if (notAvailable && notDefined) {
-          onSelectMetric(PRICE_METRIC)
+          const nameOfMetric =
+            (Metric[checking] && Metric[checking].label) || checking
           showErrorAlert(
             `${capitalizeStr(
               slug
-            )} does't support alerts with metric '${checking}'`,
-            `Selected default metric ${PRICE_METRIC.metric}`
+            )} does't support alerts with metric '${nameOfMetric}'`
           )
+        } else {
+          showErrorAlert('')
         }
       }
     },
@@ -108,6 +111,8 @@ const TriggerFormMetricTypes = ({
                 Pick one of the most popular metrics
               </div>
             </div>
+
+            {error && <div className={metricStyles.error}>{error}</div>}
 
             <div className={metricStyles.baseTypes}>
               {METRICS_OPTIONS.map(item => (
@@ -133,21 +138,4 @@ const TriggerFormMetricTypes = ({
   )
 }
 
-const mapDispatchToProps = dispatch => {
-  return {
-    showErrorAlert: (title, description) => {
-      dispatch(
-        showNotification({
-          variant: 'error',
-          title,
-          description
-        })
-      )
-    }
-  }
-}
-
-export default connect(
-  null,
-  mapDispatchToProps
-)(TriggerFormMetricTypes)
+export default TriggerFormMetricTypes

--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricTypes/TriggerFormMetricTypes.module.scss
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/metricTypes/TriggerFormMetricTypes.module.scss
@@ -159,3 +159,10 @@
     height: 40px;
   }
 }
+
+.error {
+  @include text('caption');
+
+  margin: 4px 0 8px 0;
+  color: var(--persimmon);
+}


### PR DESCRIPTION
## Changes

Show error for unsupported metrics in assets for watchlist

## Notion's card
https://www.notion.so/santiment/Error-in-alerts-with-wrong-watchlist-s-assets-e06e45287f684411a451cd980f7a7ceb

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
![image](https://user-images.githubusercontent.com/14061779/115219326-193e6400-a110-11eb-9bab-73a399ed6347.png)

