### PR TITLE
feature/price-columns-30d-1d

### DIFF
--- a/src/ducks/Watchlists/Widgets/Table/Columns/builder.js
+++ b/src/ducks/Watchlists/Widgets/Table/Columns/builder.js
@@ -106,6 +106,23 @@ export const buildAssetColumns = projects => {
   })
 }
 
+const addByChart = ({ interval, key, group, category, shortLabel, label }) => {
+  const chartKey = `${key}_chart_${interval}`
+
+  Column[chartKey] = {
+    key: chartKey,
+    group,
+    category,
+    shortLabel,
+    isChart: true,
+    accessor: chartKey,
+    disableSortBy: true,
+    Cell: CHART_LINE_CELL,
+    label: `${label} chart, ${interval}`,
+    Header: `${shortLabel} chart, ${interval}`
+  }
+}
+
 export const buildColumns = (baseMetrics, allMetrics, restrictedMetrics) => {
   const allMetricsSet = new Set(allMetrics)
   const restrictedMetricsSet = new Set(restrictedMetrics)
@@ -159,20 +176,9 @@ export const buildColumns = (baseMetrics, allMetrics, restrictedMetrics) => {
       }
 
       if (withChart) {
-        const chartKey = `${key}_chart_7d`
-
-        Column[chartKey] = {
-          key: chartKey,
-          group,
-          category,
-          shortLabel,
-          isChart: true,
-          accessor: chartKey,
-          disableSortBy: true,
-          Cell: CHART_LINE_CELL,
-          label: `${label} chart, 7d`,
-          Header: `${shortLabel} chart, 7d`
-        }
+        addByChart({ interval: '7d', key, group, category, shortLabel, label })
+        addByChart({ interval: '1d', key, group, category, shortLabel, label })
+        addByChart({ interval: '30d', key, group, category, shortLabel, label })
       }
     }
 

--- a/src/ducks/Watchlists/Widgets/Table/PriceGraph/hooks.js
+++ b/src/ducks/Watchlists/Widgets/Table/PriceGraph/hooks.js
@@ -26,12 +26,13 @@ const PRICE_GRAPH_QUERY = gql`
 
 const PRICE_RANGES = {
   '1d': '40m',
-  '7d': '5h'
+  '7d': '5h',
+  '30d': '24h'
 }
 
-export function usePriceGraph ({ slugs, range = '7d' }) {
+export function usePriceGraph ({ slugs, range = '7d', skip = false }) {
   const { data = {}, loading } = useQuery(PRICE_GRAPH_QUERY, {
-    skip: slugs.length === 0,
+    skip: slugs.length === 0 || skip,
     variables: {
       selector: { slugs },
       from: `utc_now-${range}`,

--- a/src/ducks/Watchlists/Widgets/Table/index.js
+++ b/src/ducks/Watchlists/Widgets/Table/index.js
@@ -11,6 +11,13 @@ import styles from './index.module.scss'
 const DEFAULT_ITEMS = []
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100]
 
+const price_usd_chart_1d = 'price_usd_chart_1d'
+const price_usd_chart_7d = 'price_usd_chart_7d'
+const price_usd_chart_30d = 'price_usd_chart_30d'
+
+const hasColumn = (columns, key) =>
+  columns.find(({ accessor }) => accessor === key)
+
 const AssetsTable = ({
   items,
   allItems,
@@ -38,11 +45,33 @@ const AssetsTable = ({
   ])
   const { comparingAssets = [], updateAssets } = useComparingAssets()
   const slugs = useMemo(() => items.map(({ slug }) => slug), [items])
-  const [graphData] = usePriceGraph({ slugs })
-  const data = useMemo(() => normalizeData(graphData, items), [
-    graphData,
-    items
-  ])
+
+  const [graphData1d] = usePriceGraph({
+    slugs,
+    range: '1d',
+    skip: !hasColumn(activeColumns, price_usd_chart_1d)
+  })
+  const [graphData7d] = usePriceGraph({
+    slugs,
+    range: '7d',
+    skip: !hasColumn(activeColumns, price_usd_chart_7d)
+  })
+  const [graphData30d] = usePriceGraph({
+    slugs,
+    range: '30d',
+    skip: !hasColumn(activeColumns, price_usd_chart_30d)
+  })
+
+  const data = useMemo(
+    () => {
+      let result = normalizeData(graphData1d, items, price_usd_chart_1d)
+      result = normalizeData(graphData7d, result, price_usd_chart_7d)
+      result = normalizeData(graphData30d, result, price_usd_chart_30d)
+
+      return result
+    },
+    [graphData7d, graphData1d, graphData30d, items]
+  )
 
   return (
     <>


### PR DESCRIPTION
## Changes

Add price change columns with 30d/1d ranges

## Notion's card

https://www.notion.so/santiment/Minichart-timeframes-for-watchlists-screeners-c8c95b945153484fb7dda79114a4dd3b

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [ ] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs

![image](https://user-images.githubusercontent.com/14061779/116570963-54f8db00-a913-11eb-8549-acc79b7cf3c7.png)


