### PR TITLE
fix/alert-zero-value

### DIFF
--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/TriggerFormMetricValues.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/TriggerFormMetricValues.js
@@ -3,10 +3,14 @@ import cx from 'classnames'
 import FormikSelect from '../../../../../components/formik-santiment-ui/FormikSelect'
 import FormikInput from '../../../../../components/formik-santiment-ui/FormikInput'
 import FormikLabel from '../../../../../components/formik-santiment-ui/FormikLabel'
-import { PRICE, TIME_WINDOW_UNITS } from '../../../utils/constants'
+import { TIME_WINDOW_UNITS } from '../../../utils/constants'
 import { LastPriceComponent } from './TriggerLastPrice'
 import MetricOptionsRenderer from './metricOptions/MetricOptionsRenderer'
-import { mapTargetObject, targetMapper } from '../../../utils/utils'
+import {
+  isPriceMetric,
+  mapTargetObject,
+  targetMapper
+} from '../../../utils/utils'
 import { isDailyMetric } from './metricTypes/metrics'
 import styles from '../signal/TriggerForm.module.scss'
 
@@ -23,8 +27,8 @@ export const TriggerFormMetricValues = ({
   metaFormSettings,
   typeSelectors
 }) => {
-  const { key, value } = metric
-  const isPriceMetric = value === PRICE
+  const { key } = metric
+  const isPrice = isPriceMetric(metric)
 
   const mappedTargets = mapTargetObject(target, targetMapper)
   const slugName = !Array.isArray(mappedTargets) ? mappedTargets : undefined
@@ -54,14 +58,14 @@ export const TriggerFormMetricValues = ({
 
           {type && blocks.includes('absoluteThreshold') && (
             <div className={styles.Field}>
-              <FormikLabel text={isPriceMetric ? 'Price limit' : 'Limit'} />
+              <FormikLabel text={isPrice ? 'Price limit' : 'Limit'} />
               <FormikInput
                 name='absoluteThreshold'
                 type='number'
                 placeholder='Absolute value'
-                prefix={isPriceMetric ? '$' : ''}
+                prefix={isPrice ? '$' : ''}
               />
-              {isPriceMetric && <LastPriceComponent slugTitle={slugName} />}
+              {isPrice && <LastPriceComponent slugTitle={slugName} />}
             </div>
           )}
         </>
@@ -70,7 +74,7 @@ export const TriggerFormMetricValues = ({
       {type && blocks.includes('absoluteBorders') && (
         <div className={styles.flexRow}>
           <AbsoluteBorders
-            isPriceMetric={isPriceMetric}
+            isPriceMetric={isPrice}
             absoluteBorderRight={absoluteBorderRight}
             absoluteBorderLeft={absoluteBorderLeft}
             slugName={slugName}
@@ -79,7 +83,7 @@ export const TriggerFormMetricValues = ({
       )}
 
       {type && blocks.includes('percentThreshold') && (
-        <PercentThreshold isPriceMetric={isPriceMetric} slugName={slugName} />
+        <PercentThreshold isPriceMetric={isPrice} slugName={slugName} />
       )}
 
       {type &&
@@ -87,7 +91,7 @@ export const TriggerFormMetricValues = ({
         blocks.includes('percentThresholdRight') && (
         <div className={styles.flexRow}>
           <PercentThresholdByBorders
-            isPriceMetric={isPriceMetric}
+            isPriceMetric={isPrice}
             slugName={slugName}
           />
         </div>


### PR DESCRIPTION
## Changes

Allow 0 as metric value for some metrics in alert form

## Notion's card

https://www.notion.so/santiment/Allow-0-in-alerts-d378a62c99c44578ba1d5fa70f49e79a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs

![image](https://user-images.githubusercontent.com/14061779/116685365-e3746780-a9ba-11eb-9427-6ed73a877610.png)


