### PR TITLE
fix/recent-chart-layouts

### DIFF
--- a/src/ducks/Studio/Template/index.js
+++ b/src/ducks/Studio/Template/index.js
@@ -31,6 +31,7 @@ import { useUser } from '../../../stores/user'
 import { useProjectById } from '../../../hooks/project'
 import { PATHS } from '../../../paths'
 import { useCtrlSPress } from '../../../hooks/eventListeners'
+import { addRecentTemplate } from '../../../utils/recent'
 import styles from './index.module.scss'
 
 const Action = props => <Button {...props} fluid variant='ghost' />
@@ -71,6 +72,7 @@ const Template = ({
     const parseTemplate = props.parseTemplate || getChartWidgetsFromTemplate
     setWidgets(parseTemplate(template))
 
+    addRecentTemplate(template.id)
     track.event(Event.LoadLayout, { id: template.id })
   }
 

--- a/src/pages/Studio/Widget/HoldersDistributionTable.js
+++ b/src/pages/Studio/Widget/HoldersDistributionTable.js
@@ -13,6 +13,7 @@ const HoldersDistributionTableWidget = ({ widget, target, settings }) => {
       widget={widget}
       settings={settings}
       deleteWidget={widget.deleteWithHistory || widget.delete}
+      rerenderWidgets={() => {}}
     />
   )
 }

--- a/src/pages/Studio/index.js
+++ b/src/pages/Studio/index.js
@@ -96,7 +96,13 @@ export default ({ location }) => {
           setShortUrlHash(shortUrlHash)
           if (prevFullUrlRef.current !== fullUrl) {
             prevFullUrlRef.current = fullUrl
-            setParsedUrl(parseUrl(fullUrl))
+            const parsedUrl = parseUrl(fullUrl)
+
+            if (parsedUrl.settings) {
+              setSlug(parsedUrl.settings.slug || '')
+            }
+
+            setParsedUrl(parsedUrl)
           }
         })
         .catch(console.error)

--- a/src/pages/Studio/sharing/parse.js
+++ b/src/pages/Studio/sharing/parse.js
@@ -169,7 +169,7 @@ function tryParseSettings (settings) {
 }
 
 export function parseUrl (url) {
-  const { settings, widgets, sidepanel } = parse(url)
+  const { settings, widgets, sidepanel } = parse(url.slice(url.indexOf('?')))
 
   return {
     settings: settings && tryParseSettings(settings),


### PR DESCRIPTION
## Changes
Saving recently viewed chart layout

## Notion's card
https://www.notion.so/santiment/Recent-Chart-Layouts-is-not-updated-46bb71e6f97f4cb880592b496553d2de

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary
