### PR TITLE
Remove Data Science as a Service from Products

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,13 @@
+FROM node:13
+
+ARG GIT_HEAD
+RUN GIT_HEAD=$GIT_HEAD
+
+WORKDIR /app
+
+COPY ./package.json /app/package.json
+COPY ./yarn.lock /app/yarn.lock
+COPY ./patches /app/patches
+RUN yarn
+
+COPY ./ /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
       - REACT_APP_BACKEND_URL=https://api-stage.santiment.net
     command: yarn test --ci
   frontend:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
     environment:
       - REACT_APP_BACKEND_URL=https://api-stage.santiment.net
     expose:

--- a/src/components/Navbar/SantimentProductsTooltip/Products.js
+++ b/src/components/Navbar/SantimentProductsTooltip/Products.js
@@ -24,7 +24,7 @@ export const BUSINESS_PRODUCTS = [
     img: sanapi,
     title: 'SanAPI',
     description: 'The most comprehensive crypto API on the market',
-    to: 'https://neuro.santiment.net'
+    to: 'https://api.santiment.net'
   }
 ]
 

--- a/src/components/Navbar/SantimentProductsTooltip/Products.js
+++ b/src/components/Navbar/SantimentProductsTooltip/Products.js
@@ -4,7 +4,6 @@ import sanbase from './icons/sanbase.svg'
 import insights from './icons/insights.svg'
 import sansheets from './icons/sansheets.svg'
 import sanhunters from './icons/sanhunters.svg'
-import datascience from './icons/datascience.svg'
 
 export const BUSINESS_PRODUCTS = [
   {
@@ -26,13 +25,6 @@ export const BUSINESS_PRODUCTS = [
     title: 'SanAPI',
     description: 'The most comprehensive crypto API on the market',
     to: 'https://neuro.santiment.net'
-  },
-  {
-    img: datascience,
-    title: 'Data Science as a Service',
-    description: 'Bespoke market intelligence for digital assets',
-    message: 'Talk with expert about Data Science as a Service.',
-    isIntercomButton: true
   }
 ]
 

--- a/src/components/Navbar/SantimentProductsTooltip/ProductsNav.js
+++ b/src/components/Navbar/SantimentProductsTooltip/ProductsNav.js
@@ -3,7 +3,6 @@ import ProductItem from './Product'
 import { ProductsTrigger } from './Trigger'
 import { BUSINESS_PRODUCTS, CHAIN_PRODUCTS } from './Products'
 import SmoothDropdownItem from '../../SmoothDropdown/SmoothDropdownItem'
-import SantimentLogo from './SantimentLogo'
 import styles from './ProductsNav.module.scss'
 
 let timeoutId
@@ -35,7 +34,6 @@ const ProductsNav = () => {
             d='M138.68 193.15C38.87 180.8 34.66 288.15 88 365c53.34 76.85 230.83 161.27 311 14.4 80.15-146.87 34.83-295.18-73-279.9-107.83 15.28-87.5 106-187.32 93.65z'
           />
         </svg>
-        <SantimentLogo className={styles.mainLink} />
         <div className={styles.block}>
           <h3 className={styles.title}>SAN business</h3>
           <div className={styles.products}>


### PR DESCRIPTION
## Changes
  * Remove DaaS logo from the products menu
  * Add Dockerfile-dev for local dev

## Notion's card

<!--- Issue to which the pull request is related -->
(Link)[https://www.notion.so/santiment/Remove-Data-science-as-a-Service-Santiment-logo-and-wave-in-products-list-at-Navigation-ba88712000eb4980b72d3d4ecb2ed5b6]

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

