### PR TITLE
enhance/plan-upgrade-info

### DIFF
--- a/src/components/CheckoutForm/Confirmation.js
+++ b/src/components/CheckoutForm/Confirmation.js
@@ -9,6 +9,7 @@ import Dialog from '@santiment-network/ui/Dialog'
 import { useDebounce } from '../../hooks'
 import { formatOnlyPrice, getAlternativeBillingPlan } from '../../utils/plans'
 import { usePlans } from '../../ducks/Plans/hooks'
+import { useUserSubscriptionStatus } from '../../stores/user/subscriptions'
 import PlansDropdown from './PlansDropdown'
 import sharedStyles from './CheckoutForm.module.scss'
 import styles from './Confirmation.module.scss'
@@ -99,7 +100,6 @@ const Confirmation = ({
   price,
   loading,
   changeSelectedPlan,
-  hasCompletedTrial,
   subscription
 }) => {
   const [plans] = usePlans()
@@ -107,6 +107,7 @@ const Confirmation = ({
   const planWithBilling = `${name} ${billing}ly`
   const plan = { name: name.toUpperCase(), interval: billing, amount: price }
   const altPlan = getAlternativeBillingPlan(plans, plan) || {}
+  const { isEligibleForSanbaseTrial } = useUserSubscriptionStatus()
 
   return (
     <div className={sharedStyles.confirmation}>
@@ -174,7 +175,7 @@ const Confirmation = ({
           className={styles.btn}
           fluid
         >
-          Pay
+          {isEligibleForSanbaseTrial ? 'Start 14-Day Free Trial' : 'Pay'}
         </Dialog.Approve>
       </div>
     </div>

--- a/src/components/Navbar/PlanEngage.module.scss
+++ b/src/components/Navbar/PlanEngage.module.scss
@@ -33,7 +33,8 @@
   pointer-events: none;
 
   &,
-  &:active {
+  &:active,
+  &:focus {
     color: var(--texas-rose);
   }
 
@@ -45,14 +46,11 @@
 .free {
   position: relative;
   transition: transform 200ms;
+  transform: translateY(-6px);
 
-  &:hover {
-    transform: translateY(-6px);
-
-    .upgrade {
-      pointer-events: all;
-      opacity: 1;
-    }
+  .upgrade {
+    pointer-events: all;
+    opacity: 1;
   }
 }
 

--- a/src/components/Plans/list.js
+++ b/src/components/Plans/list.js
@@ -21,7 +21,7 @@ const PlanActionDialog = ({ subscription, ...rest }) => {
   return <PlanPaymentDialog subscription={subscription} {...rest} />
 }
 
-export const TRIAL_LABEL = 'Start Free 14-day Trial'
+export const TRIAL_LABEL = 'Start 14-Day Free Trial'
 
 export default {
   FREE: {


### PR DESCRIPTION
## Changes
- Static PlanEngage for update
- Showing 'Start 14-Day Free Trail' for eligible users in checkout dialog

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [ ] If I make changes to another person's module, I've asked how to use it or request a review
- [ ] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [ ] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [ ] I've added tests (if necessary)

## Screenshots or GIFs
![CleanShot 2021-09-03 at 14 42 31@2x](https://user-images.githubusercontent.com/25135650/132000815-343bd602-613d-422e-a0c7-205afb016088.jpg)


