### PR TITLE
Updated Readme and config for development under HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ app.sublime-workspace
 
 public/san-sonar-service-worker.js
 .node_modules.tar.gz
+.cert/*

--- a/README.md
+++ b/README.md
@@ -31,18 +31,6 @@ To start your local development you need to:
    `HTTPS=true`<br />
    `HOST='dev.mylocalsite.com'`
 3. Install [mkcert](https://github.com/FiloSottile/mkcert)
-   * MacOS
-      * `brew install mkcert`
-      * `brew install nss` if you use Firefox
-   * Windows
-      * `choco install mkcert` <br /> _или_ <br /> `scoop install mkcert`
-   * Linux
-      * `sudo apt install libnss3-tools` <br />
-        _или_ <br />
-        `sudo yum install nss-tools` <br />
-        _или_ <br />
-        `sudo pacman -S nss`
-      * `brew install mkcert`
 4. Create your own certificate authority on your system <br />
    `mkcert -install`
 5. Create a certificate for your custom domain and concatenate the two files <br />

--- a/README.md
+++ b/README.md
@@ -20,6 +20,37 @@
 3. Wait until first build and install has completed (note: this can take a while - it might also help to increase the memory docker has been allocated)
 4. Open Terminal within VSCode (ctrl-`)
 
+## Local development (under HTTPS)
+
+To start your local development you need to:
+1. Whitelist your domain
+   1. Open `/etc/hosts`
+   2. Add the following line: `127.0.0.1 dev.mylocalsite.com`
+   3. Save the file
+2. In `.env.local` add the following lines <br />
+   `HTTPS=true`<br />
+   `HOST='dev.mylocalsite.com'`
+3. Install [mkcert](https://github.com/FiloSottile/mkcert)
+   * MacOS
+      * `brew install mkcert`
+      * `brew install nss` if you use Firefox
+   * Windows
+      * `choco install mkcert` <br /> _или_ <br /> `scoop install mkcert`
+   * Linux
+      * `sudo apt install libnss3-tools` <br />
+        _или_ <br />
+        `sudo yum install nss-tools` <br />
+        _или_ <br />
+        `sudo pacman -S nss`
+      * `brew install mkcert`
+4. Create your own certificate authority on your system <br />
+   `mkcert -install`
+5. Create a certificate for your custom domain and concatenate the two files <br />
+   `mkcert "127.0.0.1" "localhost" "dev.mylocalsite.com"` <br />
+   `cat *-key.pem *.pem > server.pem`
+6. Create /.cert folder and move the server.pem file into it in app root directory
+7. Run `npm run start`
+
 ## Lint/Format
 We use prettier-standard. eslint rules from standard and format by prettier.
 Setup your editor with prettier-standard lint rules - https://github.com/sheerun/prettier-standard

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "prestart": "rm ./node_modules/webpack-dev-server/ssl/server.pem && cp -f .cert/server.pem ./node_modules/webpack-dev-server/ssl",
     "start": "node scripts && REACT_APP_VERSION=$(node -pe 'require(\"./package.json\").version')-$(echo $GIT_HEAD) react-app-rewired start",
     "format:js": "prettier-standard 'src/**/*.js'",
     "format:css": "stylelint src/*{sass,scss} --syntax scss --fix",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "prestart": "rm ./node_modules/webpack-dev-server/ssl/server.pem && cp -f .cert/server.pem ./node_modules/webpack-dev-server/ssl",
+    "prestart": "rm -f ./node_modules/webpack-dev-server/ssl/server.pem && cp -f .cert/server.pem ./node_modules/webpack-dev-server/ssl",
     "start": "node scripts && REACT_APP_VERSION=$(node -pe 'require(\"./package.json\").version')-$(echo $GIT_HEAD) react-app-rewired start",
     "format:js": "prettier-standard 'src/**/*.js'",
     "format:css": "stylelint src/*{sass,scss} --syntax scss --fix",


### PR DESCRIPTION
## Changes

I've updated ReadMe with instructions how to setup local development under HTTPS
Added new "prestart" script for changing ssl certificate in development mode

<!--- Describe your changes -->

## Notion's card

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

