### PR TITLE
fix/price-usd-alert-target

### DIFF
--- a/src/ducks/Chart/Signals/index.js
+++ b/src/ducks/Chart/Signals/index.js
@@ -57,6 +57,7 @@ const DEFAULT_SIGNALS = []
 const Signals = ({
   width,
   slug,
+  asset,
   selector = 'slug',
   chart,
   data,
@@ -191,6 +192,7 @@ const Signals = ({
           hoverPoint={hoverPoint}
           slug={slug}
           selector={selector}
+          asset={asset}
           data={data}
           createAlert={createSignal}
           onDialogClose={onMouseLeave}

--- a/src/ducks/Signals/utils/utils.js
+++ b/src/ducks/Signals/utils/utils.js
@@ -1881,7 +1881,7 @@ export const buildValueChangeSignal = (slug, value, type, metric, selector) => {
       absoluteThreshold: value,
       metric
     },
-    selector
+    metric.key === 'price_usd' ? 'slug' : selector
   )
 }
 

--- a/src/ducks/Studio/Alerts/suggestions/helpers.js
+++ b/src/ducks/Studio/Alerts/suggestions/helpers.js
@@ -14,15 +14,21 @@ export const VALUE_IFS = ['drops below', 'rises above']
 
 export const createSuggestion = (alert, render) => ({ alert, render })
 
-export const buildValueChangeSuggester = metric => {
+const defaultTransformer = data => data
+export const buildValueChangeSuggester = (
+  metric,
+  transformer = defaultTransformer
+) => {
   const { formatter = FORMATTER, label } = metric
 
-  return ({ slug, asset = slug, value, lastValue, selector }) => {
+  return alert => {
+    const { value, lastValue } = alert
     const isAbove = value > lastValue
     const type = PRICE_CHANGE_TYPES[isAbove ? SIGNAL_ABOVE : SIGNAL_BELOW]
+    const { slug, selector } = transformer(alert)
 
     return createSuggestion(
-      buildValueChangeSignal(asset, roundNumber(value), type, metric, selector),
+      buildValueChangeSignal(slug, roundNumber(value), type, metric, selector),
       <>
         {label} {VALUE_IFS[+isAbove]} <Value>{formatter(value)}</Value>
       </>
@@ -30,14 +36,20 @@ export const buildValueChangeSuggester = metric => {
   }
 }
 
-export const buildPercentUpSuggester = metric => {
+export const buildPercentUpSuggester = (
+  metric,
+  transformer = defaultTransformer
+) => {
   const { label } = metric
 
-  return ({ slug, asset = slug, selector }) =>
-    createSuggestion(
-      buildPercentUpDownSignal(asset, metric, selector),
+  return alert => {
+    const { slug, selector } = transformer(alert)
+
+    return createSuggestion(
+      buildPercentUpDownSignal(slug, metric, selector),
       <>
         {label} moves up or down by <Value>10%</Value>
       </>
     )
+  }
 }

--- a/src/ducks/Studio/Alerts/suggestions/helpers.js
+++ b/src/ducks/Studio/Alerts/suggestions/helpers.js
@@ -17,12 +17,12 @@ export const createSuggestion = (alert, render) => ({ alert, render })
 export const buildValueChangeSuggester = metric => {
   const { formatter = FORMATTER, label } = metric
 
-  return ({ slug, value, lastValue, selector }) => {
+  return ({ slug, asset = slug, value, lastValue, selector }) => {
     const isAbove = value > lastValue
     const type = PRICE_CHANGE_TYPES[isAbove ? SIGNAL_ABOVE : SIGNAL_BELOW]
 
     return createSuggestion(
-      buildValueChangeSignal(slug, roundNumber(value), type, metric, selector),
+      buildValueChangeSignal(asset, roundNumber(value), type, metric, selector),
       <>
         {label} {VALUE_IFS[+isAbove]} <Value>{formatter(value)}</Value>
       </>
@@ -33,9 +33,9 @@ export const buildValueChangeSuggester = metric => {
 export const buildPercentUpSuggester = metric => {
   const { label } = metric
 
-  return ({ slug, selector }) =>
+  return ({ slug, asset = slug, selector }) =>
     createSuggestion(
-      buildPercentUpDownSignal(slug, metric, selector),
+      buildPercentUpDownSignal(asset, metric, selector),
       <>
         {label} moves up or down by <Value>10%</Value>
       </>

--- a/src/ducks/Studio/Alerts/suggestions/index.js
+++ b/src/ducks/Studio/Alerts/suggestions/index.js
@@ -2,12 +2,17 @@ import { buildPercentUpSuggester, buildValueChangeSuggester } from './helpers'
 import { dailyActiveAddressesSuggesters } from './dailyActiveAddresses'
 import { Metric } from '../../../dataHub/metrics'
 
+const priceTransformer = ({ slug, asset = slug }) => ({
+  slug: asset,
+  selector: 'slug'
+})
+
 export const Suggestion = Object.assign(Object.create(null), {
   price_usd: {
     title: 'Price',
     suggesters: [
-      buildValueChangeSuggester(Metric.price_usd),
-      buildPercentUpSuggester(Metric.price_usd)
+      buildValueChangeSuggester(Metric.price_usd, priceTransformer),
+      buildPercentUpSuggester(Metric.price_usd, priceTransformer)
     ]
   },
   daily_active_addresses: {


### PR DESCRIPTION
## Changes
Forcing `price_usd` alert to use `slug` selector.

## Notion's card

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)


