### PR TITLE
ProductsTrigger nightmode colors fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@bitquery/graph": "https://github.com/bitquery/graphs/archive/9d0d6e2.tar.gz",
     "@nivo/chord": "^0.62.0",
     "@santiment-network/chart": "^0.10.12",
-    "@santiment-network/ui": "^0.5.235",
+    "@santiment-network/ui": "^0.5.237",
     "@sentry/react": "^5.24.2",
     "@trainline/react-skeletor": "^1.0.2",
     "apollo-cache-inmemory": "^1.6.3",

--- a/src/components/Navbar/SantimentProductsTooltip/Trigger.js
+++ b/src/components/Navbar/SantimentProductsTooltip/Trigger.js
@@ -18,11 +18,10 @@ export const ProductsTrigger = ({ isOpen, className }) => (
         width='7'
         height='7'
         y='9'
-        fill='var(--dodger-blue)'
-        opacity='.5'
+        fill='var(--dodger-blue-light-3)'
         rx='1'
       />
-      <circle cx='12.5' cy='3.5' r='3.5' fill='var(--heliotrope-light-2)' />
+      <circle cx='12.5' cy='3.5' r='3.5' fill='var(--heliotrope-light-4)' />
     </svg>
   </div>
 )

--- a/src/components/Navbar/SantimentProductsTooltip/Trigger.module.scss
+++ b/src/components/Navbar/SantimentProductsTooltip/Trigger.module.scss
@@ -10,6 +10,7 @@
 
   & svg {
     transition: transform 0.2s ease-in-out;
+    --heliotrope-light-4: #C1ABFF;
   }
 
   :global(.dd__trigger.active) & {
@@ -23,7 +24,7 @@
   :global(.night-mode) & svg {
     --jungle-green-light-3: #165E55;
     --texas-rose-light-3: #8A6A56;
-    --dodger-blue: #354895;
-    --heliotrope-light-2: #4E3995;
+    --dodger-blue-light-3: #354895;
+    --heliotrope-light-4: #4E3995;
   }
 }

--- a/src/components/Navbar/SantimentProductsTooltip/Trigger.module.scss
+++ b/src/components/Navbar/SantimentProductsTooltip/Trigger.module.scss
@@ -21,9 +21,9 @@
   }
 
   :global(.night-mode) & svg {
-    --jungle-green-light-3: #89e1c9;
-    --texas-rose-light-3: #ffd49c;
-    --dodger-blue: #5275ff;
-    --heliotrope-light-2: #c9c2ff;
+    --jungle-green-light-3: #165E55;
+    --texas-rose-light-3: #8A6A56;
+    --dodger-blue: #354895;
+    --heliotrope-light-2: #4E3995;
   }
 }

--- a/src/components/Navbar/SantimentProductsTooltip/Trigger.module.scss
+++ b/src/components/Navbar/SantimentProductsTooltip/Trigger.module.scss
@@ -19,4 +19,11 @@
       transform: rotate(90deg);
     }
   }
+
+  :global(.night-mode) & svg {
+    --jungle-green-light-3: #89e1c9;
+    --texas-rose-light-3: #ffd49c;
+    --dodger-blue: #5275ff;
+    --heliotrope-light-2: #c9c2ff;
+  }
 }

--- a/src/components/Navbar/SantimentProductsTooltip/Trigger.module.scss
+++ b/src/components/Navbar/SantimentProductsTooltip/Trigger.module.scss
@@ -10,7 +10,6 @@
 
   & svg {
     transition: transform 0.2s ease-in-out;
-    --heliotrope-light-4: #C1ABFF;
   }
 
   :global(.dd__trigger.active) & {
@@ -22,9 +21,6 @@
   }
 
   :global(.night-mode) & svg {
-    --jungle-green-light-3: #165E55;
-    --texas-rose-light-3: #8A6A56;
-    --dodger-blue-light-3: #354895;
-    --heliotrope-light-4: #4E3995;
+    --texas-rose-light-3: #FFD49C;
   }
 }


### PR DESCRIPTION
## Changes

nightmode color styles added to fix current colors.

## Notion's card

https://www.notion.so/santiment/Color-updates-for-nav-icon-7744475598ea42f4a54de67aa0a98c5b

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
![image](https://user-images.githubusercontent.com/6568353/142987395-0cdbbe10-a0e7-460d-a876-070a5b04eae4.png)