### PR TITLE
textas-rose-color fixed

### DIFF
--- a/src/components/Navbar/SantimentProductsTooltip/Trigger.module.scss
+++ b/src/components/Navbar/SantimentProductsTooltip/Trigger.module.scss
@@ -21,6 +21,6 @@
   }
 
   :global(.night-mode) & svg {
-    --texas-rose-light-3: #FFD49C;
+    --texas-rose-light-3: #8A6A56;
   }
 }


### PR DESCRIPTION
## Changes

`--texas-rose-light-3` color in the nightmode for the top bar colors changed to `#8A6A56`

## Notion's card

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
![image](https://user-images.githubusercontent.com/6568353/142994017-099fbc89-127f-4fe2-9abf-cd9eadda107d.png)

