### PR TITLE
Add commit hash after version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV REACT_APP_BACKEND_URL=${REACT_APP_BACKEND_URL}
 ARG GIT_HEAD
 RUN GIT_HEAD=$GIT_HEAD
 # Tini - https://github.com/krallin/tini#why-tini
-RUN apk add --no-cache tini
+RUN apk --no-cache add git tini
 ENTRYPOINT ["/sbin/tini", "--"]
 WORKDIR /opt/san/app
 COPY . /opt/san/app
@@ -24,14 +24,11 @@ RUN test -s .node_modules.tar.gz \
 
 # ---- Deps ----
 FROM base AS deps
-RUN apk --no-cache add git
 # Install library dependencies
-RUN npm config set depth 0
-RUN npm config set package-lock true
+RUN npm config set depth 0 && npm config set package-lock true
 ENV NODE_ENV=development
 RUN if [ "$CI" = "true" ] ; then npm ci --no-audit --progress=false; else npm i --no-progress --no-audit --prefer-offline; fi
-RUN npx patch-package
-RUN npm cache clean --force
+RUN npx patch-package && npm cache clean --force
 
 # ---- Execution Dev ----
 FROM base AS dev

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,11 @@ build:
 dev:
 	docker-compose up -d frontend
 
-log:
+logs:
 	docker-compose logs -f
+
+format:
+	docker-compose exec frontend npm run format
 
 test:
 	docker-compose up --build test

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 
 * `make start` - Start your docker container with dev server
 * `make sh` - Bash in your dev container
-* `make log` - Show logs
+* `make logs` - Show logs
+* `make format` - Run `npm run format`
 
 ### VSCODE
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "prestart": "rm -f ./node_modules/webpack-dev-server/ssl/server.pem && cp -f .cert/server.pem ./node_modules/webpack-dev-server/ssl",
-    "start": "node scripts && REACT_APP_VERSION=$(node -pe 'require(\"./package.json\").version')-$(echo $GIT_HEAD) react-app-rewired start",
+    "start": "node scripts && REACT_APP_VERSION=$(node -pe 'require(\"./package.json\").version')-$(git rev-parse --short=7 HEAD) react-app-rewired start",
     "format:js": "prettier-standard 'src/**/*.js'",
     "format:css": "stylelint src/*{sass,scss} --syntax scss --fix",
     "format": "npm run format:js && npm run format:css",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "npm run lint:js && npm run lint:css",
     "precommit": "lint-staged",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "build": "node scripts && npm run build:sw && REACT_APP_VERSION=$(node -pe 'require(\"./package.json\").version')-$(echo $GIT_HEAD) react-app-rewired build",
+    "build": "node scripts && npm run build:sw && REACT_APP_VERSION=$(node -pe 'require(\"./package.json\").version')-$(git rev-parse --short=7 HEAD) react-app-rewired build",
     "test:js": "react-scripts test",
     "test": "CI=true npm run test:js",
     "eject": "react-scripts eject",

--- a/src/components/Version/Version.js
+++ b/src/components/Version/Version.js
@@ -6,17 +6,15 @@ export const VersionLabel = ({ className }) => (
   <span className={className}>{process.env.REACT_APP_VERSION}</span>
 )
 
-const Version = ({ classes = {} }) => {
-  return (
-    <div className={styles.wrapper}>
-      <span className={cx(styles.versionDivider, classes.footerVersionDivider)}>
-        |
-      </span>
-      <span className={cx(styles.version, classes.version)}>
-        Ver. <VersionLabel />
-      </span>
-    </div>
-  )
-}
+const Version = ({ classes = {} }) => (
+  <div className={styles.wrapper}>
+    <span className={cx(styles.versionDivider, classes.footerVersionDivider)}>
+      |
+    </span>
+    <span className={cx(styles.version, classes.version)}>
+      Ver. <VersionLabel />
+    </span>
+  </div>
+)
 
 export default Version


### PR DESCRIPTION
## Changes
- `build` and `start` scripts in `package.json` file edited to get commit hash correctly with this command `git rev-parse --short=7 HEAD`
- `Dockerfile` updated, merged a few `RUN` commands and added `git` installation in the base
- `Make` updated, added a few useful commands.

## Notion's card
https://www.notion.so/santiment/Add-commit-hash-after-version-a9ebfd042ee34f068fcd697f33b24665

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
![image](https://user-images.githubusercontent.com/6568353/143550625-9ee2446b-a2b0-4c1e-ad5b-979c2bf30600.png)

