### PR TITLE
Dropdown bug on home page Keystakeholders fixed

### DIFF
--- a/src/components/AssetsSelector/AssetsSelector.js
+++ b/src/components/AssetsSelector/AssetsSelector.js
@@ -1,11 +1,11 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useState, useRef } from 'react'
 import cx from 'classnames'
-import ContextMenu from '@santiment-network/ui/ContextMenu'
 import Panel from '@santiment-network/ui/Panel'
 import Input from '@santiment-network/ui/Input'
 import Item from '../../ducks/Watchlists/Widgets/Filter/EntryPoint/Item'
 import { useProject } from '../../hooks/project'
 import { toggleByKey } from '../../pages/Index/Section/KeystackeholdersEvents/StakeholderLabels/StakeholderLabels'
+import { useOnClickOutside } from '../../hooks/click'
 import styles from './AssetsSelector.module.scss'
 
 const ProjectItem = ({
@@ -27,12 +27,16 @@ const ProjectItem = ({
       name={name}
       ticker={ticker}
       id={targetSlug}
+      className={styles.item}
     />
   )
 }
 
 const AssetsSelector = ({ onChange, selected, projects, slugs, className }) => {
   const [searchTerm, setSearchTerm] = useState('')
+  const [showPanel, setShowPanel] = useState(false)
+  const ref = useRef()
+  useOnClickOutside(ref, () => setShowPanel(false))
 
   function onChangeSearch (e) {
     setSearchTerm(e.target.value)
@@ -64,102 +68,96 @@ const AssetsSelector = ({ onChange, selected, projects, slugs, className }) => {
   const isResetVisible = selectableAssets.length > 0
 
   return (
-    <div className={styles.wrapper}>
-      <ContextMenu
-        passOpenStateAs='data-isactive'
-        position='bottom'
-        align='end'
-        className={styles.dropdown}
-        trigger={
-          <div className={cx(styles.trigger, className)}>
-            All assets
-            {countSelected > 0 ? `: ${countSelected}` : ''}
-          </div>
-        }
+    <div className={styles.wrapper} ref={ref}>
+      <div
+        className={cx(styles.trigger, className)}
+        onClick={() => setShowPanel(old => !old)}
       >
-        <Panel className={styles.panel}>
-          <div className={styles.content}>
-            <Input
-              type='text'
-              onChange={onChangeSearch}
-              defaultValue={searchTerm}
-              className={styles.search}
-              placeholder='Search for asset'
-            />
+        All assets
+        {countSelected > 0 ? `: ${countSelected}` : ''}
+      </div>
+      <Panel className={cx(styles.panel, showPanel && styles.panel_show)}>
+        <div className={styles.content}>
+          <Input
+            type='text'
+            onChange={onChangeSearch}
+            defaultValue={searchTerm}
+            className={styles.search}
+            placeholder='Search for asset'
+          />
 
-            <div className={styles.scroller}>
-              {countSelected > 0 && (
-                <>
-                  <div className={styles.title}>Selected assets</div>
-                  <div
-                    className={cx(
-                      styles.list,
-                      !isResetVisible && styles.noMargin
-                    )}
-                  >
-                    {selectedAssets.map(slug => {
-                      return (
-                        <ProjectItem
-                          key={slug}
-                          slug={slug}
-                          project={projects[slug]}
-                          addItemInState={addItemInState}
-                          selected={true}
-                        />
-                      )
-                    })}
-                  </div>
-                </>
-              )}
+          <div className={styles.scroller}>
+            {countSelected > 0 && (
+              <>
+                <div className={styles.title}>Selected assets</div>
+                <div
+                  className={cx(
+                    styles.list,
+                    !isResetVisible && styles.noMargin
+                  )}
+                >
+                  {selectedAssets.map(slug => {
+                    return (
+                      <ProjectItem
+                        key={slug}
+                        slug={slug}
+                        project={projects[slug]}
+                        addItemInState={addItemInState}
+                        selected={true}
+                      />
+                    )
+                  })}
+                </div>
+              </>
+            )}
 
-              {selectableAssets.length > 0 && (
-                <>
-                  <div className={styles.title}>Assets</div>
-                  <div className={cx(styles.list, styles.noMargin)}>
-                    {selectableAssets.map(slug => {
-                      return (
-                        <ProjectItem
-                          key={slug}
-                          slug={slug}
-                          project={projects[slug]}
-                          addItemInState={addItemInState}
-                          selected={false}
-                        />
-                      )
-                    })}
-                  </div>
-                </>
-              )}
-            </div>
+            {selectableAssets.length > 0 && (
+              <>
+                <div className={styles.title}>Assets</div>
+                <div className={cx(styles.list, styles.noMargin)}>
+                  {selectableAssets.map(slug => {
+                    return (
+                      <ProjectItem
+                        key={slug}
+                        slug={slug}
+                        project={projects[slug]}
+                        addItemInState={addItemInState}
+                        selected={false}
+                      />
+                    )
+                  })}
+                </div>
+              </>
+            )}
           </div>
+        </div>
 
-          {isResetVisible ? (
-            <div
-              className={styles.reset}
-              onClick={() => {
-                onChange(
-                  slugs.reduce((acc, s) => {
-                    acc[s] = true
+        {isResetVisible ? (
+          <div
+            className={styles.reset}
+            onClick={() => {
+              onChange(
+                slugs.reduce((acc, s) => {
+                  acc[s] = true
 
-                    return acc
-                  }, {})
-                )
-              }}
-            >
-              Select all
-            </div>
-          ) : (
-            <div
-              className={styles.reset}
-              onClick={() => {
-                onChange({})
-              }}
-            >
-              Deselect all
-            </div>
-          )}
-        </Panel>
-      </ContextMenu>
+                  return acc
+                }, {})
+              )
+            }}
+          >
+            Select all
+          </div>
+        ) : (
+          <div
+            className={styles.reset}
+            onClick={() => {
+              onChange({})
+            }}
+          >
+            Deselect all
+          </div>
+        )}
+      </Panel>
     </div>
   )
 }

--- a/src/components/AssetsSelector/AssetsSelector.module.scss
+++ b/src/components/AssetsSelector/AssetsSelector.module.scss
@@ -1,5 +1,11 @@
 @import '~@santiment-network/ui/mixins';
 
+@mixin itemFont {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+}
+
 .wrapper {
   display: flex;
   align-items: baseline;
@@ -11,6 +17,18 @@
 .panel {
   width: 280px;
   padding: 12px 0 0 0;
+  opacity: 0;
+  position: absolute;
+  right: 0;
+  top: 130%;
+  transform: scale(0);
+  transition: opacity 0.15s ease-in-out;
+}
+
+.panel_show {
+  opacity: 1;
+  transform: scale(1);
+  z-index: 1000;
 }
 
 .trigger {
@@ -55,6 +73,8 @@
 }
 
 .reset {
+  @include itemFont;
+
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -82,4 +102,8 @@
   border: 1px solid var(--porcelain);
   box-sizing: border-box;
   border-radius: $border-radius;
+}
+
+.item {
+  @include itemFont;
 }

--- a/src/hooks/click.js
+++ b/src/hooks/click.js
@@ -1,0 +1,18 @@
+import { useEffect } from 'react'
+
+export function useOnClickOutside (ref, handler) {
+  useEffect(() => {
+    const listener = event => {
+      if (!ref.current || ref.current.contains(event.target)) {
+        return
+      }
+      handler(event)
+    }
+    document.addEventListener('mousedown', listener)
+    document.addEventListener('touchstart', listener)
+    return () => {
+      document.removeEventListener('mousedown', listener)
+      document.removeEventListener('touchstart', listener)
+    }
+  }, [ref, handler])
+}


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Dropdown bug on home page Keystakeholders fixed.
Bug: dropdown moved by window scroll, They want it has fixed position on the bottom.

## Notion's card

<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/Dropdown-bug-on-home-page-Keystakeholders-f8933c407ccb4e099e64b6a9d125f76f

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

![image](https://user-images.githubusercontent.com/6568353/145554550-089c90ea-e1fe-43e1-9ba8-d0d12ef78d9a.png)

![image](https://user-images.githubusercontent.com/6568353/145554894-c3e3a231-6604-4169-8893-f36950b32583.png)
