### PR TITLE
app name uncommented

### DIFF
--- a/src/components/Navbar/SantimentProductsTooltip/Logo.js
+++ b/src/components/Navbar/SantimentProductsTooltip/Logo.js
@@ -59,8 +59,8 @@ const Logo = ({ className }) => (
         fill='#D2D6E7'
         d='M16 30.83a14.83 14.83 0 100-29.66 14.83 14.83 0 000 29.66zM32 16a16 16 0 11-32 0 16 16 0 0132 0z'
       />
-    </svg>
-    <span className={styles.logoText}>Sanbase</span> */}
+    </svg> */}
+    <span className={styles.logoText}>Sanbase</span>
   </Link>
 )
 

--- a/src/components/Navbar/SantimentProductsTooltip/Logo.module.scss
+++ b/src/components/Navbar/SantimentProductsTooltip/Logo.module.scss
@@ -3,10 +3,10 @@
 .logo {
   display: inline-flex;
   align-items: center;
-  transform: translateY(-3px);
 
   svg {
     fill: var(--rhino);
+    transform: translateY(-3px);
   }
 
   @include responsive('phone', 'phone-xs', 'laptop', 'tablet') {

--- a/src/components/Navbar/SantimentProductsTooltip/Logo.module.scss
+++ b/src/components/Navbar/SantimentProductsTooltip/Logo.module.scss
@@ -7,7 +7,7 @@
   svg {
     fill: var(--rhino);
     transform: translateY(-3px);
-    margin-right: 10px;
+    margin-right: 2px;
   }
 
   @include responsive('phone', 'phone-xs', 'laptop', 'tablet') {

--- a/src/components/Navbar/SantimentProductsTooltip/Logo.module.scss
+++ b/src/components/Navbar/SantimentProductsTooltip/Logo.module.scss
@@ -7,6 +7,7 @@
   svg {
     fill: var(--rhino);
     transform: translateY(-3px);
+    margin-right: 10px;
   }
 
   @include responsive('phone', 'phone-xs', 'laptop', 'tablet') {
@@ -17,7 +18,7 @@
 .logoText {
   @include text('body-2', 'm');
 
-  margin: 0 8px;
+  margin-right: 8px;
   color: var(--rhino) !important;
 
   @include responsive('phone', 'phone-xs', 'laptop', 'tablet') {

--- a/src/ducks/Alert/AlertModal.js
+++ b/src/ducks/Alert/AlertModal.js
@@ -48,9 +48,8 @@ const AlertModal = ({
           if (signal.settings.target.watchlist_id) {
             return ALERT_TYPES[1]
           }
-        } else {
-          return type.settings.type === signal.settings.type
         }
+        return type.settings.type === signal.settings.type
       })
     : defaultType
 

--- a/src/ducks/Alert/AlertModalForm.js
+++ b/src/ducks/Alert/AlertModalForm.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Form } from 'formik'
 import AlertModalSidebar from './components/AlertModalSidebar/AlertModalSidebar'
 import AlertModalContent from './components/AlertModalContent/AlertModalContent'


### PR DESCRIPTION
## Changes

- Revert back app name beside logo (it was commented before)
- Linting errors fixed

## Notion's card

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

![image](https://user-images.githubusercontent.com/6568353/147470406-e7898764-8df5-4c83-899b-2039ca671b01.png)
