### PR TITLE
account settings fields null value bug fixed

### DIFF
--- a/src/pages/Account/EditableInputSetting.js
+++ b/src/pages/Account/EditableInputSetting.js
@@ -90,7 +90,7 @@ class EditableInputSetting extends PureComponent {
                 )}
                 accent='waterloo'
               >
-                {`${prefix || ''}${defaultValue}` ||
+                {(defaultValue && `${prefix || ''}${defaultValue}`) ||
                   `Please add your ${label.toLowerCase()}`}
               </Label>
             </div>


### PR DESCRIPTION
## Changes
- account settings fields null value bug fixed

## Notion's card

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
![image](https://user-images.githubusercontent.com/6568353/147550844-54292552-126e-447e-a1e2-78a125479c1f.png)

