### PR TITLE
assets modal styles fixed

### DIFF
--- a/src/ducks/Watchlists/Actions/Edit/EditForm/Assets.js
+++ b/src/ducks/Watchlists/Actions/Edit/EditForm/Assets.js
@@ -124,7 +124,7 @@ const Assets = ({ watchlist, onChange }) => {
 const AssetItemDropdown = ({ checkedItems }) => (
   <>
     {checkedItems.length === 0 && (
-      <span className={cardStyles.ticker}>Select asset for watchlist</span>
+      <span className={cx(cardStyles.ticker, styles.mlzero)}>Select asset for watchlist</span>
     )}
     {checkedItems.length > 0 &&
       checkedItems.slice(0, VIEW_ITEM_COUNT).map((item, index) => {
@@ -136,7 +136,7 @@ const AssetItemDropdown = ({ checkedItems }) => (
         return (
           <div className={cx(cardStyles.name, styles.mrhalf)} key={item.id}>
             {item.name}{' '}
-            <span className={cx(styles.mlzero, cardStyles.ticker)}>
+            <span className={cx(cardStyles.ticker, styles.mlzero)}>
               {item.ticker}
             </span>{' '}
             {seprator}

--- a/src/ducks/Watchlists/Actions/Edit/EditForm/index.js
+++ b/src/ducks/Watchlists/Actions/Edit/EditForm/index.js
@@ -131,7 +131,7 @@ const EditForm = ({
     >
       <form className={styles.wrapper} onSubmit={onSubmit}>
         <Label accent='waterloo' className={styles.name__label}>
-          {`Name (${formState.name && formState.name.length}/25)`}
+          {`Name (${(formState.name && formState.name.length) || 0}/25)`}
         </Label>
         {isOpen && (
           <Input

--- a/src/ducks/Watchlists/Actions/Edit/EditForm/index.module.scss
+++ b/src/ducks/Watchlists/Actions/Edit/EditForm/index.module.scss
@@ -21,19 +21,23 @@
 .btn,
 .input {
   height: 32px;
-  padding: 10px 16px;
-
   @include text('body-3');
 }
 
 .btn {
   justify-content: center;
+  padding: 10px 20px;
+}
+
+.input {
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 .textarea {
   border-radius: $border-radius;
   margin: 0;
-  padding: 10px 16px;
+  padding: 10px;
   color: var(--rhino);
   background: var(--white);
   border: 1px solid var(--porcelain);
@@ -84,7 +88,7 @@
 }
 
 .description__label {
-  margin: 8px 0 4px;
+  margin: 17px 8px 0 4px;
 }
 
 .mrhalf {
@@ -105,6 +109,7 @@
 
 .selector {
   position: relative;
+  padding: 0 10px;
 
   &:hover, &:focus {
     border: 1px solid var(--jungle-green);
@@ -113,6 +118,7 @@
 
 .searchInput {
   border: none;
+  padding: 0px;
   width: 100%;
   height: 99.9%;
 }


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Assets modal styles fixed.

## Notion's card

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

![image](https://user-images.githubusercontent.com/6568353/147576922-14539799-9824-4e2e-93e7-bc2644d273fa.png)
