### PR TITLE
Bags done

### DIFF
--- a/src/ducks/Watchlists/Widgets/Table/Columns/Toggler/index.module.scss
+++ b/src/ducks/Watchlists/Widgets/Table/Columns/Toggler/index.module.scss
@@ -1,7 +1,6 @@
 @import "~@santiment-network/ui/mixins";
 
 .container {
-  margin-right: 16px;
   display: flex;
   align-items: center;
 }

--- a/src/ducks/Watchlists/Widgets/Table/TableTop/index.js
+++ b/src/ducks/Watchlists/Widgets/Table/TableTop/index.js
@@ -1,10 +1,9 @@
 import React, { useState } from 'react'
 import Icon from '@santiment-network/ui/Icon'
 import Button from '@santiment-network/ui/Button'
-import { PROJECT, SCREENER } from '../../../detector'
+import { PROJECT } from '../../../detector'
 import ColumnsToggler from '../Columns/Toggler'
 import CompareInfo from '../CompareInfo/CompareInfo'
-import SaveAs from '../../../../WatchlistTable/SaveAs'
 import CompareAction from '../CompareInfo/CompareAction'
 import EditAssets from '../../../Actions/Edit/EditAssets'
 import Refresh from '../../../../../components/Refresh/Refresh'
@@ -87,12 +86,6 @@ const TableTop = ({
           watchlist={watchlist}
           downloadData={fetchAllColumns}
         />
-        {type === SCREENER && (
-          <>
-            <div className={styles.divider} />
-            <SaveAs watchlist={watchlist} type={PROJECT} />
-          </>
-        )}
       </div>
     </div>
   )

--- a/src/ducks/Watchlists/Widgets/Table/TableTop/index.module.scss
+++ b/src/ducks/Watchlists/Widgets/Table/TableTop/index.module.scss
@@ -1,7 +1,7 @@
 @import '~@santiment-network/ui/mixins';
 
 .wrapper {
-  padding: 8px 40px 10px 32px;
+  padding: 8px 40px 10px 40px;
   margin-top: 2px;
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Changes
- Padding (40px) between icon 'download' and sets for Watchlist-Screener updated
- Padding from both sides 40px for Watchlist-Screener 
- The icon 'save as watchlist' on Screener removed

## Notion's card

https://www.notion.so/santiment/Modals-updates-for-Watchlist-Screener-aa5b4b8c04fe457697d5ca4665427079

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

![image](https://user-images.githubusercontent.com/6568353/149091419-a04c5859-047c-45ce-95f1-f22109bba940.png)
