### PR TITLE
enhance/short-url-parse

### DIFF
--- a/src/components/Share/utils.js
+++ b/src/components/Share/utils.js
@@ -53,6 +53,7 @@ export function redirectSharedLink () {
       switch (pathname[hashEndIndex]) {
         case '/':
         case '?':
+        case '&': // NOTE(vanguard): remove when external link generator is fixed [21 Jan, 22]
           break loop
         default:
           continue


### PR DESCRIPTION
## Changes
Stopping short-url parse loop when encountering  `&`. (e.g. `/s/KU8TLcOJ&fpr=maksim51?utm_source=twitter`)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

