### PR TITLE
screener reported bugs fixed

### DIFF
--- a/src/ducks/Watchlists/Actions/SaveAs/index.js
+++ b/src/ducks/Watchlists/Actions/SaveAs/index.js
@@ -42,6 +42,7 @@ const SaveAs = ({ watchlist, trigger, type, prefix = 'Duplicate' }) => {
       toggleOpen={toggleOpen}
       onFormSubmit={onSubmit}
       title={`${prefix} ${title}`}
+      buttonLabel={prefix}
       settings={{ name, description }}
       watchlist={watchlist}
     />

--- a/src/ducks/Watchlists/Widgets/Table/AssetsTable.module.scss
+++ b/src/ducks/Watchlists/Widgets/Table/AssetsTable.module.scss
@@ -14,3 +14,7 @@
 .compareIcon {
   fill: var(--waterloo);
 }
+
+.compareIconDisabled {
+  fill: var(--mystic);
+}

--- a/src/ducks/Watchlists/Widgets/Table/Columns/Toggler/Configs/EditForm.js
+++ b/src/ducks/Watchlists/Widgets/Table/Columns/Toggler/Configs/EditForm.js
@@ -9,7 +9,7 @@ import styles from './EditForm.module.scss'
 const MIN_LENGTH = 3
 const SHORT_NAME_ERROR = `The name should be at least ${MIN_LENGTH} characters`
 const BAD_SYMBOLS_ERROR = "Use only letters, numbers, whitespace and _-.'/,"
-const NAME_EXISTS_ERROR = 'You has already use this name'
+const NAME_EXISTS_ERROR = 'You have already used this name'
 const ALLOWED_SYMBOLS_REGEXP = /^([.\-/_' ,\w]*)$/
 
 const EMPTY_ARRAY = []
@@ -102,7 +102,8 @@ const EditForm = ({
           placeholder='For example, Social movements'
           maxLength='25'
           defaultValue={formState.name}
-          onChange={onInputChange}
+          onChange={e => formState.error && onInputChange(e)}
+          onBlur={onInputChange}
           isError={formState.error}
           errorText={formState.error}
           autoComplete='off'
@@ -117,12 +118,7 @@ const EditForm = ({
             className={styles.btn}
             accent='positive'
             isLoading={isLoading}
-            disabled={
-              isLoading ||
-              formState.error ||
-              !formState.name ||
-              formState.name.length < MIN_LENGTH
-            }
+            disabled={isLoading}
           >
             {buttonLabel}
           </Dialog.Approve>

--- a/src/ducks/Watchlists/Widgets/Table/CompareInfo/Actions/index.js
+++ b/src/ducks/Watchlists/Widgets/Table/CompareInfo/Actions/index.js
@@ -48,14 +48,14 @@ const Actions = ({ selected, watchlist, onAdd, onRemove, assets }) => {
   return (
     <>
       <div className={styles.actions}>
-        {watchlist && watchlist.type !== "BLOCKCHAIN_ADDRESS" &&
+        {watchlist && watchlist.type !== 'BLOCKCHAIN_ADDRESS' && (
           <Copy
             selectedText={selectedText}
             watchlist={watchlist}
             assets={assets}
             selected={selected}
           />
-        }
+        )}
         <SaveAs selectedText={selectedText} watchlist={watchlist} />
         <Delete
           selected={selected}

--- a/src/ducks/Watchlists/Widgets/Table/CompareInfo/CompareAction.js
+++ b/src/ducks/Watchlists/Widgets/Table/CompareInfo/CompareAction.js
@@ -15,7 +15,9 @@ const CompareTooltip = ({ disabledComparision }) => {
         <div>
           <Button
             classes={{
-              btnIcon: !disabledComparision && styles.compareIcon
+              btnIcon: disabledComparision
+                ? styles.compareIconDisabled
+                : styles.compareIcon
             }}
             icon='compare'
             border

--- a/src/ducks/Watchlists/Widgets/TopPanel/BaseActions/Items.js
+++ b/src/ducks/Watchlists/Widgets/TopPanel/BaseActions/Items.js
@@ -87,7 +87,7 @@ export const Delete = ({ id, name, title }) => (
     id={id}
     name={name}
     trigger={
-      <Item icon='remove' accent='negative' className={styles.delete}>
+      <Item icon='remove' className={styles.delete}>
         Delete
       </Item>
     }

--- a/src/ducks/Watchlists/Widgets/TopPanel/BaseActions/Items.module.scss
+++ b/src/ducks/Watchlists/Widgets/TopPanel/BaseActions/Items.module.scss
@@ -11,7 +11,7 @@
   fill: var(--casper);
 
   &:hover {
-    fill: var(--jungle-green-light-3);
+    fill: var(--jungle-green);
   }
 }
 
@@ -70,9 +70,6 @@
 }
 
 .delete {
-  fill: var(--persimmon);
-  color: var(--persimmon);
-
   &:hover {
     fill: var(--persimmon-hover);
     color: var(--persimmon-hover);

--- a/src/ducks/Watchlists/Widgets/TopPanel/BaseActions/index.js
+++ b/src/ducks/Watchlists/Widgets/TopPanel/BaseActions/index.js
@@ -1,5 +1,6 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 import Panel from '@santiment-network/ui/Panel/Panel'
 import ContextMenu from '@santiment-network/ui/ContextMenu'
 import { notifyUpdate } from '../notifications'
@@ -29,6 +30,27 @@ const Actions = ({
   const [lists] = useUserWatchlists(type)
   const [updateWatchlist, { loading }] = useUpdateWatchlist(type)
   const [isMenuOpened, setIsMenuOpened] = useState(false)
+  const [showPanel, setShowPanel] = useState(true)
+
+  useEffect(() => {
+    const panelVisibilityChange = ({ detail }) => {
+      if (detail === 'show') {
+        setIsMenuOpened(false)
+      }
+      setShowPanel(detail === 'show')
+    }
+    window.addEventListener(
+      'panelVisibilityChange',
+      panelVisibilityChange,
+      false
+    )
+    return () =>
+      window.removeEventListener(
+        'panelVisibilityChange',
+        panelVisibilityChange,
+        false
+      )
+  }, [])
 
   if (!watchlist.id || isAuthorLoading) {
     return null
@@ -76,7 +98,10 @@ const Actions = ({
         passOpenStateAs='isActive'
         onClose={() => setIsMenuOpened(false)}
       >
-        <Panel variant='modal' className={styles.wrapper}>
+        <Panel
+          variant='modal'
+          className={cx(styles.wrapper, !showPanel && styles.hidePanel)}
+        >
           <Edit
             type={type}
             title={title}

--- a/src/ducks/Watchlists/Widgets/TopPanel/BaseActions/index.module.scss
+++ b/src/ducks/Watchlists/Widgets/TopPanel/BaseActions/index.module.scss
@@ -14,3 +14,7 @@
     width: 100%;
   }
 }
+
+.hidePanel {
+  display: none;
+}


### PR DESCRIPTION
## Changes

- Message edited to `You have already used this name`
- Modal approve button text fixed and always enabled
- The error message appear only when you went out from the input
- When you open any of the modal after pressing inside the dropdown, hide the dropdown
- Button and hover colors updated

## Notion's card

https://www.notion.so/santiment/Bugs-Modals-Scr-Watch-Addr-watch-f5de51276ea245f98ffa69f784e2f640

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
![image](https://user-images.githubusercontent.com/6568353/151130352-acdc8dd2-57cd-4791-94c7-80b7b57850c5.png)
![image](https://user-images.githubusercontent.com/6568353/151130323-29d668bd-de12-48cf-9415-27bf25dcc33c.png)
![image](https://user-images.githubusercontent.com/6568353/151130377-8a9cb4d6-3c78-4894-91c8-8a60c0194982.png)
![image](https://user-images.githubusercontent.com/6568353/151130509-f300c376-5ea1-4849-ad91-e47ac39081c8.png)
![image](https://user-images.githubusercontent.com/6568353/151130543-6af8b5ef-b3b4-498d-9a95-b663fd1fcd8d.png)

