### PR TITLE
user info added to profile dropdown

### DIFF
--- a/src/components/Navbar/NavbarProfileDropdown.js
+++ b/src/components/Navbar/NavbarProfileDropdown.js
@@ -24,8 +24,11 @@ import { VersionLabel } from '../Version/Version'
 import { APP_STATES } from '../../ducks/Updates/reducers'
 import { isHalloweenDay } from '../../utils/halloween'
 import ContactUs from '../ContactUs/ContactUs'
+import UserAvatar from '../../pages/Account/avatar/UserAvatar'
 import dropdownStyles from './NavbarDropdown.module.scss'
 import styles from './NavbarProfileDropdown.module.scss'
+
+const MAX_STR_LENGTH = 28
 
 const personalLinks = [
   { as: Link, to: '/alerts?tab=1', children: 'My alerts' },
@@ -123,15 +126,31 @@ export const NavbarProfileDropdown = ({
   const { isPro } = useUserSubscriptionStatus()
   const { isNightMode } = useTheme()
 
+  const trimString = str =>
+    str.length < MAX_STR_LENGTH ? str : str.substring(0, MAX_STR_LENGTH) + '...'
+
   return (
     <div className={cx(styles.wrapper, !user && styles.login)}>
       {user && (
         <div className={styles.profile}>
-          <div className={styles.nameWrapper}>
-            <Link className={styles.name} to={`/profile/${user.id}`}>
-              {user.username || user.email}
-            </Link>
-          </div>
+          <Link className={styles.userInfoWrapper} to={`/profile/${user.id}`}>
+            <UserAvatar
+              as='div'
+              userId={user.id}
+              externalAvatarUrl={user.avatarUrl}
+              classes={styles}
+            />
+            <div className={styles.infoWrapper}>
+              <div className={styles.name}>
+                {user.name ? trimString(user.name) : 'No full name'}
+              </div>
+              <div className={styles.username}>
+                {user.username
+                  ? trimString(`@${user.username}`)
+                  : 'No username'}
+              </div>
+            </div>
+          </Link>
           <SubscriptionsList />
           {isPro || (
             <UpgradeBtn

--- a/src/components/Navbar/NavbarProfileDropdown.module.scss
+++ b/src/components/Navbar/NavbarProfileDropdown.module.scss
@@ -50,22 +50,6 @@
   fill: var(--white);
 }
 
-.nameWrapper {
-  display: flex;
-}
-
-.name {
-  color: var(--rhino);
-
-  @include text('body-3');
-
-  width: 100%;
-  overflow: hidden;
-  display: inline-block;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .plan {
   @include text('caption');
 
@@ -124,4 +108,38 @@
 
 .newInsight {
   margin: 6px 0 8px 16px;
+}
+
+.name {
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--rhino);
+}
+
+.username {
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--waterloo);
+}
+
+.userInfoWrapper {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+
+  .infoWrapper {
+    margin-left: 8px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &:hover .username {
+    color: var(--jungle-green);
+  }
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
 }

--- a/src/pages/profile/info/EditProfile.js
+++ b/src/pages/profile/info/EditProfile.js
@@ -38,7 +38,8 @@ const EditProfile = ({ onClose, dispatchNewUsername, dispatchNewName }) => {
     changeFullname
   } = useFullnameChange(user.name)
 
-  async function saveButtonHandler () {
+  async function saveButtonHandler (e) {
+    e.preventDefault()
     if (
       savingFullname ||
       savingUsername ||
@@ -75,8 +76,10 @@ const EditProfile = ({ onClose, dispatchNewUsername, dispatchNewName }) => {
     }
   }
 
+  const loading = savingFullname || savingUsername
+
   return (
-    <div className={styles.modalContent}>
+    <form className={styles.modalContent} onSubmit={saveButtonHandler}>
       <label className={styles.label}>
         <DarkTooltip
           trigger={
@@ -102,7 +105,7 @@ const EditProfile = ({ onClose, dispatchNewUsername, dispatchNewName }) => {
         onBlur={e => checkFullname(e.target.value)}
         isError={!!fullnameError}
         errorText={fullnameError}
-        disabled={savingFullname}
+        disabled={loading}
       />
       <label className={styles.label}>
         <DarkTooltip
@@ -132,24 +135,22 @@ const EditProfile = ({ onClose, dispatchNewUsername, dispatchNewName }) => {
           isError={!!usernameError}
           errorText={usernameError}
           className={styles.usernameInput}
-          disabled={savingUsername}
+          disabled={loading}
         />
       </div>
       <Dialog.Actions className={styles.actions}>
         <Dialog.Approve
-          isLoading={savingFullname || savingUsername}
+          isLoading={loading}
           onClick={saveButtonHandler}
+          type='submit'
         >
           Save
         </Dialog.Approve>
-        <Dialog.Cancel
-          isLoading={savingFullname || savingUsername}
-          onClick={onClose}
-        >
+        <Dialog.Cancel disabled={loading} onClick={onClose} type='button'>
           Cancel
         </Dialog.Cancel>
       </Dialog.Actions>
-    </div>
+    </form>
   )
 }
 

--- a/src/pages/profile/info/ProfileInfo.js
+++ b/src/pages/profile/info/ProfileInfo.js
@@ -34,14 +34,14 @@ export const ShareProfile = () => (
 
 const DisplayProfileValue = ({ label, value, isCurrentUser }) => {
   const [isDialogVisible, setIsDialogVisible] = useState(false)
+
   if (!isCurrentUser) {
-    return <>{value ? `@${value}` : `No ${label}`}</>
+    return <>{value || `No ${label}`}</>
   }
 
   const Trigger = () => (
     <>
-      {value ? `@${value}` : `Add ${label}`}{' '}
-      <Icon className={styles.ml16} type='edit' />
+      {value || `Add ${label}`} <Icon className={styles.ml16} type='edit' />
     </>
   )
 
@@ -93,7 +93,7 @@ const InfoBlock = ({
           >
             <DisplayProfileValue
               label='username'
-              value={username}
+              value={username && `@${username}`}
               isCurrentUser={isCurrentUser}
             />
           </div>


### PR DESCRIPTION
## Changes
- Avatar and fullname based on new design added to profile dropdown menu
- User profile page display full name bug fixed

## Notion's card
https://www.notion.so/santiment/Add-full-name-username-and-avatar-to-profile-dropdown-6ded3117196b47d2ae4e754e58f8767f

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
![image](https://user-images.githubusercontent.com/6568353/152742866-10897e3c-066b-4223-87c2-e4f6e1b1a2fe.png)
![image](https://user-images.githubusercontent.com/6568353/152742910-86a51137-2105-4e44-b30b-ce7dd0fa38b2.png)
![image](https://user-images.githubusercontent.com/6568353/152743023-72ba77c8-0e02-4548-acb3-66dd5ca39852.png)

