### PR TITLE
fix/studio-holdings-on-top-exchanges-widget

### DIFF
--- a/src/pages/Studio/Widget/utils.js
+++ b/src/pages/Studio/Widget/utils.js
@@ -9,8 +9,7 @@ export const newExternalWidget = (Widget, props) =>
     ...props
   })
 
-export const withExternal = Component => props => {
-  const { target } = props
+export const withExternal = Component => ({target, ...props}) => {
   if (target) {
     target.classList.remove('widget')
     target.classList.remove('border')


### PR DESCRIPTION
## Changes
Excluding 'target' from pass down props for external widgets.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)
