### PR TITLE
fix/studio-combined-metric-project-lock-share

### DIFF
--- a/src/pages/Studio/sharing/parse.js
+++ b/src/pages/Studio/sharing/parse.js
@@ -130,10 +130,21 @@ function parseMetrics (metrics, comparables = [], KnownMetric) {
     .filter(Boolean)
 }
 
+function parseProjectCombinedMetrics (metric) {
+  return getProjectMetricByKey(metric.key, undefined, {
+    getMetricByKey: () => metric,
+    parseSlug: false
+  })
+}
+
 function parseCombinedMetrics (metrics, KnownMetric) {
   return (metrics || []).map(({ k, exp, l, bm }) => {
-    const metric = newExpessionMetric(bm.map(getMetric), exp, l)
+    let metric = newExpessionMetric(bm.map(getMetric), exp, l)
     metric.key = k
+
+    if (checkIsProjectMetricKey(k)) {
+      metric = parseProjectCombinedMetrics(metric)
+    }
 
     KnownMetric[k] = metric
     return metric

--- a/src/pages/Studio/sharing/share.js
+++ b/src/pages/Studio/sharing/share.js
@@ -67,10 +67,10 @@ function shareSignalMetrics (signalMetrics) {
 function shareCombinedMetrics (metrics) {
   return metrics
     .filter(({ expression }) => expression)
-    .map(({ key, expression, label, baseMetrics }) => ({
+    .map(({ key, expression, label, baseMetrics, base }) => ({
       k: key,
       exp: expression,
-      l: label,
+      l: base ? base.label : label,
       bm: shareMetrics(baseMetrics)
     }))
 }


### PR DESCRIPTION
## Changes
Correctly sharing and parsing shared combined metric with a project lock

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)


