### PR TITLE
getMetricSignalKey added to fix compare interval values

### DIFF
--- a/src/ducks/Alert/AlertModalFormMaster.js
+++ b/src/ducks/Alert/AlertModalFormMaster.js
@@ -11,7 +11,7 @@ import AlertModalForm from './AlertModalForm'
 import { createTrigger, updateTrigger } from '../Signals/common/actions'
 import { useUser } from '../../stores/user'
 import { useSignal } from './hooks/useSignal'
-import { validateFormSteps } from './utils'
+import { getMetricSignalKey, validateFormSteps } from './utils'
 import { GET_METRIC_MIN_INTERVAL } from './hooks/queries'
 import styles from './AlertModalFormMaster.module.scss'
 
@@ -95,9 +95,7 @@ const AlertModalFormMaster = ({
     }
 
     const { data } = await refetch({ metric: triggerValues.settings.metric })
-    const minInterval = data.metric.metadata.minInterval
-    triggerValues.settings.type =
-      minInterval <= '5m' ? 'metric_signal' : 'daily_metric_signal'
+    triggerValues.settings.type = getMetricSignalKey(data.metric.metadata.minInterval)
 
     if (id && !isSharedTrigger) {
       updateAlert({

--- a/src/ducks/Alert/utils.js
+++ b/src/ducks/Alert/utils.js
@@ -1,6 +1,6 @@
-import { parseIntervalString } from '../../utils/dates'
 import { getMetric } from '../Studio/Sidebar/utils'
 import { capitalizeStr } from '../../utils/utils'
+import { parseIntervalString } from '../../utils/dates'
 
 function formatFrequencyStr (cooldown) {
   const { amount: cooldownCount, format: cooldownPeriod } = parseIntervalString(
@@ -382,4 +382,29 @@ export function validateFormSteps ({
       }
     }
   }
+}
+function calcSeconds (amount, format) {
+  let factor
+  switch (format) {
+    case 'm':
+      factor = 60
+      break
+    case 'h':
+      factor = 60 * 60
+      break
+    case 'd':
+      factor = 60 * 60 * 24
+      break
+    default:
+      factor = 1
+  }
+  return +amount * factor
+}
+
+export function getMetricSignalKey (minInterval) {
+  const condition = parseIntervalString('5m')
+  const base = calcSeconds(condition.amount, condition.format)
+  const { amount, format } = parseIntervalString(minInterval)
+  const value = calcSeconds(amount, format)
+  return value <= base ? 'metric_signal' : 'daily_metric_signal'
 }


### PR DESCRIPTION
## Changes
- getMetricSignalKey added to fix compare interval values

## Notion's card

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

