### PR TITLE
fix/pricing-yearly-free-label

### DIFF
--- a/src/pages/Pricing/Plans/Plans.js
+++ b/src/pages/Pricing/Plans/Plans.js
@@ -37,7 +37,6 @@ const Billing = ({ selected, onClick }) => {
         onClick={() => onClick('year')}
       >
         Yearly
-        <span className={styles.billing__save}>(2 months free)</span>
       </span>
     </>
   )


### PR DESCRIPTION
## Changes
`2 months free` yearly label removed

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
![CleanShot 2022-03-21 at 15 44 55@2x](https://user-images.githubusercontent.com/25135650/159263476-976a7821-e8e6-4c14-8cc7-f5eb339cdb49.jpg)


