### PR TITLE
digest settings removed

### DIFF
--- a/src/pages/Account/AccountPage.module.scss
+++ b/src/pages/Account/AccountPage.module.scss
@@ -330,17 +330,6 @@
   }
 }
 
-.digest {
-  width: 100%;
-  display: flex;
-  align-items: center;
-
-  @include responsive('phone', 'phone-xs') {
-    display: flex;
-    flex-direction: column;
-  }
-}
-
 .neuro {
   width: 100%;
   display: flex;
@@ -349,14 +338,6 @@
   @include responsive('phone', 'phone-xs') {
     display: flex;
     flex-direction: column;
-  }
-}
-
-.digestSelector {
-  margin-left: auto;
-
-  @include responsive('phone', 'phone-xs') {
-    margin: 10px 0 0 0;
   }
 }
 

--- a/src/pages/Account/SettingsNotifications.js
+++ b/src/pages/Account/SettingsNotifications.js
@@ -3,13 +3,9 @@ import { connect } from 'react-redux'
 import { compose } from 'recompose'
 import { graphql } from 'react-apollo'
 import { Link } from 'react-router-dom'
-import Label from '@santiment-network/ui/Label'
-import Selector from '@santiment-network/ui/Selector/Selector'
 import { NEWSLETTER_SUBSCRIPTION_MUTATION } from './gql'
 import Settings from './Settings'
 import * as actions from '../../actions/types'
-import { store } from '../../redux'
-import { showNotification } from '../../actions/rootActions'
 import SettingsTelegramNotifications from './SettingsTelegramNotifications'
 import SettingsEmailNotifications from './SettingsEmailNotifications'
 import SettingsSonarWebPushNotifications from './SettingsSonarWebPushNotifications'
@@ -22,14 +18,6 @@ import { CHANNEL_TYPES } from '../../ducks/Signals/utils/constants'
 import { useUserSettings } from '../../stores/user/settings'
 import SignalLimits from './limits/SignalLimits'
 import styles from './AccountPage.module.scss'
-
-const onDigestChangeSuccess = () =>
-  store.dispatch(showNotification('Digest type has been successfully changed'))
-
-const onDigestChangeError = () =>
-  store.dispatch(
-    showNotification({ title: 'Failed to change digest type', type: 'error' })
-  )
 
 const channelByTypeLength = (signals, type) => {
   return filterByChannels(signals, type).length
@@ -53,10 +41,10 @@ const SignalsDescription = (
   )
 }
 
-const SettingsNotifications = ({ changeDigestType, mutateDigestType }) => {
+const SettingsNotifications = () => {
   const { settings } = useUserSettings()
 
-  const { newsletterSubscription: digestType, alertsPerDayLimit } = settings
+  const { alertsPerDayLimit } = settings
 
   const { data: signals } = useSignals()
 
@@ -105,33 +93,6 @@ const SettingsNotifications = ({ changeDigestType, mutateDigestType }) => {
 
       <Settings.Row>
         <SignalLimits alertsPerDayLimit={alertsPerDayLimit} classes={styles} />
-      </Settings.Row>
-
-      <Settings.Row>
-        <div className={styles.digest}>
-          <div className={styles.setting__left}>
-            <Label>Digest</Label>
-            <Label className={styles.setting__description} accent='waterloo'>
-              Receive the best insights and alerts on Sanbase
-              <br />
-              peersonalized based on your interests.
-            </Label>
-          </div>
-          <Selector
-            className={styles.digestSelector}
-            options={['WEEKLY', 'OFF']}
-            nameOptions={['Weekly', 'Off']}
-            onSelectOption={subscription =>
-              mutateDigestType({ variables: { subscription } })
-                .then(() => {
-                  changeDigestType(subscription)
-                  onDigestChangeSuccess()
-                })
-                .catch(onDigestChangeError)
-            }
-            defaultSelected={digestType}
-          />
-        </div>
       </Settings.Row>
     </Settings>
   )

--- a/src/pages/Account/SettingsNotifications.js
+++ b/src/pages/Account/SettingsNotifications.js
@@ -1,11 +1,6 @@
 import React from 'react'
-import { connect } from 'react-redux'
-import { compose } from 'recompose'
-import { graphql } from 'react-apollo'
 import { Link } from 'react-router-dom'
-import { NEWSLETTER_SUBSCRIPTION_MUTATION } from './gql'
 import Settings from './Settings'
-import * as actions from '../../actions/types'
 import SettingsTelegramNotifications from './SettingsTelegramNotifications'
 import SettingsEmailNotifications from './SettingsEmailNotifications'
 import SettingsSonarWebPushNotifications from './SettingsSonarWebPushNotifications'
@@ -98,17 +93,4 @@ const SettingsNotifications = () => {
   )
 }
 
-const mapDispatchToProps = dispatch => ({
-  changeDigestType: type =>
-    dispatch({
-      type: actions.USER_DIGEST_CHANGE,
-      payload: type
-    })
-})
-
-const enhance = compose(
-  connect(null, mapDispatchToProps),
-  graphql(NEWSLETTER_SUBSCRIPTION_MUTATION, { name: 'mutateDigestType' })
-)
-
-export default enhance(SettingsNotifications)
+export default SettingsNotifications


### PR DESCRIPTION
## Changes
- digest settings removed

## Notion's card
https://discord.com/channels/334289660698427392/646705213893378068/956615224486682705

## Checklist

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
![image](https://user-images.githubusercontent.com/6568353/160073910-2a7f11a9-de32-4233-ac32-a2c0a2d26c5c.png)

