### PR TITLE
font color fixed, sizing check updated

### DIFF
--- a/src/ducks/Watchlists/Widgets/VolumeChart/CustomizedTreeMapContent.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/CustomizedTreeMapContent.js
@@ -25,9 +25,10 @@ const CustomizedTreeMapContent = props => {
   const fontSize = getFontSize(index, children.length)
 
   const tickerLength = getWordLength(fontSize, ticker)
+  const showTicker = tickerLength + 8 < width
 
-  const showTicker = tickerLength < width
-  const showChange = showTicker && fontSize * 2 + 5 < height
+  const valueLength = getWordLength(fontSize, value)
+  const showChange = showTicker && valueLength + 2 < width && fontSize * 2 + 5 < height
 
   return (
     <g>
@@ -47,7 +48,7 @@ const CustomizedTreeMapContent = props => {
           x={x + width / 2}
           y={y + height / 2 - (showChange ? 2 : -2)}
           textAnchor='middle'
-          fill='var(--fiord)'
+          fill='var(--rhino)'
           fontSize={fontSize}
           fontWeight={500}
         >
@@ -59,7 +60,7 @@ const CustomizedTreeMapContent = props => {
           x={x + width / 2}
           y={y + height / 2 + fontSize - 1}
           textAnchor='middle'
-          fill='var(--fiord)'
+          fill='var(--rhino)'
           fontSize={fontSize}
           fontWeight={500}
         >

--- a/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.js
@@ -39,15 +39,21 @@ const renderCustomizedLabel = props => {
   const fontSize = width < 20 ? 7 : 14
   const position = +value >= 0 ? -1 * (fontSize / 2) : fontSize
 
+  const xValue = x + width / 2
+  const yValue = y + position
+  const translateY = +value >= 0 ? -10 : 8
+
   return (
-    <g>
+    <g style={{transform: `translateY(${translateY}px)`}}>
       <text
-        x={x + width / 2}
-        y={y + position}
+        x={xValue}
+        y={yValue}
         fill={fill}
         textAnchor='middle'
         fontSize={fontSize}
         fontWeight={500}
+        dominant-baseline="central"
+        transform={`rotate(270, ${xValue}, ${yValue})`}
       >
         {value && getBarValue(+value)}
       </text>


### PR DESCRIPTION
## Changes
- font color fixed
- sizing check updated
- chart y labels rotated

<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/Fix-color-for-infographics-text-62acadfb7a8c475fb2cb63623b725d45

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
![image](https://user-images.githubusercontent.com/6568353/161014132-496ef246-84cb-4a12-91ad-22fdc4222ce6.png)

![image](https://user-images.githubusercontent.com/6568353/161014216-01c338ee-8160-44e8-baa3-668aa02bac6c.png)

![image](https://user-images.githubusercontent.com/6568353/161024583-56dc01b9-1fb7-47e5-a17b-d18e767d278d.png)

