### PR TITLE
Fixed exchange balance metric on alerts modal

### DIFF
--- a/src/ducks/Alert/components/AlertModalContent/StepsContent/MetricAndConditions/ConditionsSelector/OperationSelector/OperationInput/OperationInput.js
+++ b/src/ducks/Alert/components/AlertModalContent/StepsContent/MetricAndConditions/ConditionsSelector/OperationSelector/OperationInput/OperationInput.js
@@ -3,13 +3,25 @@ import cx from 'classnames'
 import Input from '@santiment-network/ui/Input'
 import styles from './OperationInput.module.scss'
 
-function getValue(e) {
+function getValue(e, isPositiveMetric) {
+  if (!isPositiveMetric) {
+    return e.target.value === '' ? '' : Number(e.target.value)
+  }
+
   const currentValue = e.target.value < 0 ? '' : Number(e.target.value)
 
   return e.target.value === '' ? '' : currentValue
 }
 
-const OperationInput = ({ count, hasIcon, iconType, setCount, operation, className }) => {
+const OperationInput = ({
+  count,
+  hasIcon,
+  iconType,
+  setCount,
+  operation,
+  className,
+  isPositiveMetric,
+}) => {
   let prefix = '$'
 
   if (iconType === 'percent') {
@@ -18,7 +30,7 @@ const OperationInput = ({ count, hasIcon, iconType, setCount, operation, classNa
 
   if (Array.isArray(count)) {
     function handleChangeCount(e) {
-      const value = getValue(e)
+      const value = getValue(e, isPositiveMetric)
 
       if (value > count[1] && operation !== 'some_of') {
         setCount([value, value])
@@ -28,9 +40,15 @@ const OperationInput = ({ count, hasIcon, iconType, setCount, operation, classNa
     }
 
     function handleChangeSecondCount(e) {
-      const value = getValue(e)
+      const value = getValue(e, isPositiveMetric)
 
       setCount([count[0], value])
+    }
+
+    let secondInputMinValue = operation === 'some_of' ? 0 : count[0]
+
+    if (!isPositiveMetric && operation === 'some_of') {
+      secondInputMinValue = count[0]
     }
 
     return (
@@ -48,7 +66,7 @@ const OperationInput = ({ count, hasIcon, iconType, setCount, operation, classNa
           {hasIcon && <span className={styles.prefix}>{prefix}</span>}
           <Input
             type='number'
-            min={operation === 'some_of' ? 0 : count[0]}
+            min={secondInputMinValue}
             value={count[1]}
             onChange={handleChangeSecondCount}
             className={hasIcon && styles.inputWithPrefix}
@@ -59,7 +77,7 @@ const OperationInput = ({ count, hasIcon, iconType, setCount, operation, classNa
   }
 
   function handleChangeInput(e) {
-    const value = getValue(e)
+    const value = getValue(e, isPositiveMetric)
 
     setCount(value)
   }

--- a/src/ducks/Alert/components/AlertModalContent/StepsContent/MetricAndConditions/ConditionsSelector/OperationSelector/OperationSelector.js
+++ b/src/ducks/Alert/components/AlertModalContent/StepsContent/MetricAndConditions/ConditionsSelector/OperationSelector/OperationSelector.js
@@ -46,6 +46,7 @@ const OperationSelector = ({ metric, isWallet }) => {
   }, [operation, count])
 
   const hasPriceIcon = metric.category === 'Financial' || metric.key === 'price_usd'
+  const isPositiveMetric = metric.key !== 'exchange_balance'
   const isPercentIcon = PERCENT_OPERATIONS.includes(operation.value)
   const isMultipleValues = MULTIPLE_VALUES_OPERATIONS.includes(operation.value)
 
@@ -68,6 +69,7 @@ const OperationSelector = ({ metric, isWallet }) => {
         hasIcon={hasPriceIcon || isPercentIcon}
         iconType={isPercentIcon && 'percent'}
         className={styles.inputs}
+        isPositiveMetric={isPositiveMetric}
       />
     </div>
   )

--- a/src/ducks/Alert/utils.js
+++ b/src/ducks/Alert/utils.js
@@ -118,9 +118,9 @@ export function getConditionsStr({ operation, count, timeWindow, hasPriceIcon = 
       break
   }
 
-  return `${hasPriceIcon ? condition : condition.replace('$', '')} compared to ${formatFrequencyStr(
-    timeWindow,
-  )} earlier`
+  return `${
+    hasPriceIcon ? condition : condition.replaceAll('$', '')
+  } compared to ${formatFrequencyStr(timeWindow)} earlier`
 }
 
 export function getTitleStr({ watchlist, slug, metric, operation, timeWindow, onlyCondition }) {


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Fixed exchange balance metric

## Notion's card

<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/Unable-to-put-negative-values-in-Alert-72d4b21deb754c049b3356f6c595e0ce

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

