### PR TITLE
Updated Alert's modal, explore page styles

### DIFF
--- a/src/components/ConfirmDialog/ConfirmDialog.js
+++ b/src/components/ConfirmDialog/ConfirmDialog.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react'
+import cx from 'classnames'
 import Dialog from '@santiment-network/ui/Dialog'
 import styles from './ConfirmDialog.module.scss'
 
@@ -50,7 +51,7 @@ class ConfirmDialog extends PureComponent {
   render() {
     const { title, description, trigger, classes, confirmLabel, isLoading } = this.props
 
-    const mergedClasses = { ...styles, ...classes }
+    const { dialog, dialogTitle, ...restClasses } = classes
 
     return (
       <Dialog
@@ -58,17 +59,29 @@ class ConfirmDialog extends PureComponent {
         onClose={this.onClose}
         onOpen={this.openDialog}
         trigger={trigger}
-        classes={mergedClasses}
+        classes={{
+          dialog: cx(styles.dialog, 'box', dialog),
+          title: cx('h4 txt-m c-black mrg--b mrg-s', dialogTitle),
+          ...restClasses,
+        }}
       >
-        <Dialog.ScrollContent withPadding>
-          {title && <div className={styles.title}>{title}</div>}
-          {description && <div className={styles.description}>{description}</div>}
+        <Dialog.ScrollContent withPadding className={styles.content}>
+          {title && <div className='row hv-center h4 txt-m mrg--b mrg-s c-black'>{title}</div>}
+          {description && <div className='column hv-center body-2 c-waterloo'>{description}</div>}
         </Dialog.ScrollContent>
-        <Dialog.Actions className={styles.actions}>
-          <Dialog.Approve onClick={this.onDeleteClick} isLoading={isLoading}>
+        <Dialog.Actions className={cx(styles.actions, 'row hv-center mrg--b')}>
+          <Dialog.Approve
+            className={cx(styles.button, 'btn-1 btn--green c-white')}
+            onClick={this.onDeleteClick}
+            isLoading={isLoading}
+          >
             {confirmLabel}
           </Dialog.Approve>
-          <Dialog.Cancel onClick={this.onClose} className={styles.cancel} isLoading={isLoading}>
+          <Dialog.Cancel
+            onClick={this.onClose}
+            className={cx(styles.button, 'btn-2')}
+            isLoading={isLoading}
+          >
             Cancel
           </Dialog.Cancel>
         </Dialog.Actions>

--- a/src/components/ConfirmDialog/ConfirmDialog.module.scss
+++ b/src/components/ConfirmDialog/ConfirmDialog.module.scss
@@ -1,37 +1,24 @@
 @import '~@santiment-network/ui/mixins';
 
 .dialog {
-  width: 480px;
-  filter: drop-shadow(0px 2px 24px rgba(24, 27, 43, 0.04)) drop-shadow(1px 3px 7px rgba(47, 53, 77, 0.05));
-  text-align: center;
+  width: 480px !important;
 
   @include responsive('phone-xs', 'phone') {
     width: 100%;
   }
 }
 
+.content {
+  padding: 6px 40px 0 !important;
+  margin-bottom: 24px !important;
+}
+
 .actions {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  margin-bottom: 24px;
+  --margin: 40px;
+  gap: 16px;
+  padding: 0 !important;
 }
 
-.cancel {
-  margin-left: 16px;
-}
-
-.title {
-  @include text('h4');
-
-  color: var(--rhino);
-  margin-bottom: 8px;
-}
-
-.description {
-  @include text('body-2');
-
-  color: var(--waterloo);
-  margin-bottom: 18px;
+.button {
+  --h-padding: 30px !important;
 }

--- a/src/components/IndexTabs/IndexTab.js
+++ b/src/components/IndexTabs/IndexTab.js
@@ -10,9 +10,9 @@ const IndexTab = ({ tabs, initialTab = 0, renderTopActions = [], bottomActions =
 
   return (
     <>
-      <div className={styles.header}>
+      <div className='row justify mrg--b mrg-xxl'>
         {renderTopActions(activeTab)}
-        <div className={styles.tabs}>
+        <div className={cx(styles.tabs, 'row')}>
           {tabs.map((item) => {
             if (!item) {
               return null
@@ -23,7 +23,11 @@ const IndexTab = ({ tabs, initialTab = 0, renderTopActions = [], bottomActions =
             return (
               <div
                 key={id}
-                className={cx(styles.title, id === activeTab && styles.active)}
+                className={cx(
+                  styles.title,
+                  'btn mrg--l mrg-xxl  h4 txt-m',
+                  id === activeTab && styles.active,
+                )}
                 onClick={() => setTab(id)}
               >
                 {title}
@@ -31,7 +35,7 @@ const IndexTab = ({ tabs, initialTab = 0, renderTopActions = [], bottomActions =
             )
           })}
         </div>
-        <div className={styles.actions}>
+        <div className={cx(styles.actions, 'row v-center')}>
           {bottomActions
             .filter(({ showOnTabs, hide, component }) => {
               if (!component) {

--- a/src/components/IndexTabs/IndexTab.module.scss
+++ b/src/components/IndexTabs/IndexTab.module.scss
@@ -1,14 +1,8 @@
-@import "~@santiment-network/ui/mixins";
+@import '~@santiment-network/ui/mixins';
 
 .title {
-  cursor: pointer;
-  color: var(--casper);
-  margin-left: 32px;
-  user-select: none;
-
-  &:hover {
-    color: var(--jungle-green);
-  }
+  --color: var(--casper);
+  --color-hover: var(--fiord);
 
   &:first-child {
     margin-left: 0;
@@ -16,17 +10,8 @@
 }
 
 .active {
-  --color: var(--rhino);
-  color: var(--rhino);
-}
-
-.header {
-  display: flex;
-  margin-bottom: 32px;
-  color: var(--rhino);
-  justify-content: space-between;
-
-  @include text("h4", "m");
+  --color: var(--black);
+  --color-hover: var(--black);
 }
 
 :global(.phone-xs) .header,
@@ -36,7 +21,6 @@
 }
 
 .tabs {
-  display: flex;
   flex: 1 1 100%;
 }
 
@@ -48,8 +32,6 @@
 }
 
 .actions {
-  display: flex;
   justify-content: flex-end;
-  align-items: center;
   flex: 1 1 100%;
 }

--- a/src/components/SignalCard/card/SignalCard.module.scss
+++ b/src/components/SignalCard/card/SignalCard.module.scss
@@ -109,21 +109,16 @@
 }
 
 .popupItem {
-  display: flex;
-  align-items: center;
   gap: 8px;
   width: 128px;
   height: 32px;
   border-radius: 4px;
-  padding: 6px 8px;
+  --fill: var(--waterloo);
+  --fill-hover: var(--green);
+}
 
-  @include text("body-3");
-
-  &:hover {
-    background: var(--athens);
-    fill: var(--jungle-green-hover);
-    color: var(--jungle-green-hover);
-  }
+.publicShare {
+  --color-hover: var(--green);
 }
 
 .sharePanelBtn {
@@ -141,8 +136,8 @@
 }
 
 .expandButton {
-  background-color: transparent;
-  margin-right: 20px;
+  --color: var(--waterloo);
+  --color-hover: var(--green);
   padding-left: 0;
 
   @include responsive("phone", "phone-xs") {
@@ -181,13 +176,6 @@
 
 .shareSingle {
   padding: 0;
-}
-
-.popupButton {
-  cursor: pointer;
-  align-items: center;
-
-  @include text("body-3");
 }
 
 .awaitingBlock {

--- a/src/components/SignalCard/controls/CopySignal.js
+++ b/src/components/SignalCard/controls/CopySignal.js
@@ -1,8 +1,6 @@
 import React, { useState } from 'react'
 import cx from 'classnames'
 import { connect } from 'react-redux'
-import debounce from 'lodash.debounce'
-import Button from '@santiment-network/ui/Button'
 import Icon from '@santiment-network/ui/Icon'
 import isEqual from 'lodash.isequal'
 import { createTrigger } from '../../../ducks/Signals/common/actions'
@@ -11,7 +9,6 @@ import styles from './CopySignal.module.scss'
 
 const CopySignal = ({
   children,
-  as = 'a',
   isAuthor,
   isCreated,
   signal,
@@ -27,10 +24,13 @@ const CopySignal = ({
 
   if (isCreated && isCreation) {
     return (
-      <Button as={as} className={cx(styles.copyBtn, styles.copiedBtn)} {...btnParams}>
+      <button
+        className={cx(styles.copyBtn, 'btn body-3 row v-center', styles.copiedBtn)}
+        {...btnParams}
+      >
         {doneLabel}
-        <Icon className={styles.copyBtnIcon} type='success-round' />
-      </Button>
+        <Icon type='success-round' />
+      </button>
     )
   }
 
@@ -43,7 +43,7 @@ const CopySignal = ({
     return null
   }
 
-  const copySignal = debounce(() => {
+  function copySignal() {
     if (onCreate) {
       onCreate()
     } else {
@@ -56,19 +56,18 @@ const CopySignal = ({
     if (onClose) {
       onClose()
     }
-  })
+  }
 
   return (
     <>
       {children}
-      <Button
+      <button
         onClick={!isCreation ? copySignal : undefined}
-        as={as}
-        className={cx(styles.copyBtn, classes.copyBtn)}
+        className={cx(styles.copyBtn, 'btn body-3', classes.copyBtn)}
         {...btnParams}
       >
         {label}
-      </Button>
+      </button>
     </>
   )
 }

--- a/src/components/SignalCard/controls/CopySignal.module.scss
+++ b/src/components/SignalCard/controls/CopySignal.module.scss
@@ -1,16 +1,13 @@
-@import "~@santiment-network/ui/mixins";
+@import '~@santiment-network/ui/mixins';
 
 .copyBtn {
-  margin: 0 0 0 auto;
+  --color: var(--black);
+  --color-hover: var(--green);
 }
 
 .copiedBtn {
-  &:hover {
-    color: var(--jungle-green);
-  }
-}
-
-.copyBtnIcon {
-  fill: var(--jungle-green);
-  margin-left: 8px;
+  gap: 8px;
+  --color: var(--green);
+  --color-hover: var(--green);
+  --fill: var(--green);
 }

--- a/src/components/SignalCard/controls/MoreSignalActions.js
+++ b/src/components/SignalCard/controls/MoreSignalActions.js
@@ -66,11 +66,6 @@ const ShareSignal = ({
   )
 }
 
-const btnParams = { variant: 'flat' }
-const classes = {
-  copyBtn: styles.buttonWrapper__button,
-}
-
 const MoreSignalActions = ({
   signalId,
   signalTitle,
@@ -96,7 +91,7 @@ const MoreSignalActions = ({
             className={styles.shareBtn}
             signalId={signalId}
             signalTitle={signalTitle}
-            shareBtnClassName={styles.shareSingle}
+            shareBtnClassName={cx(styles.popupItem, styles.publicShare, 'row v-center btn body-3')}
             trigger={PublicSignalShareTrigger}
             isUserTheAuthor={isUserTheAuthor}
             userId={userId}
@@ -104,13 +99,7 @@ const MoreSignalActions = ({
         )}
         {!shouldDisableActions && (
           <DesktopOnly>
-            <CopySignal
-              signal={signal}
-              label='Copy to my alerts'
-              as='div'
-              classes={classes}
-              btnParams={btnParams}
-            />
+            <CopySignal signal={signal} label='Copy to my alerts' />
           </DesktopOnly>
         )}
       </div>
@@ -122,9 +111,15 @@ const MoreSignalActions = ({
   return (
     <Tooltip
       trigger={
-        <Button className={cx(styles.expandButton, isFrozen && styles.frozenExpandButton)}>
+        <button
+          className={cx(
+            styles.expandButton,
+            'btn mrg--r mrg-xl',
+            isFrozen && styles.frozenExpandButton,
+          )}
+        >
           <Icon type='dots' />
-        </Button>
+        </button>
       }
       position='bottom'
       align='start'
@@ -133,7 +128,7 @@ const MoreSignalActions = ({
         {editable && (
           <Link
             to={`/alerts/${signalId}${window.location.search}`}
-            className={cx(styles.popupItem, styles.popupButton)}
+            className={cx(styles.popupItem, 'row v-center btn-ghost body-3')}
           >
             <Icon type='edit' />
             Edit
@@ -159,10 +154,10 @@ const MoreSignalActions = ({
             id={signalId}
             signalTitle={signalTitle}
             trigger={() => (
-              <div className={cx(styles.popupItem, styles.popupButton)}>
+              <button className={cx(styles.popupItem, 'row v-center btn-ghost body-3')}>
                 <Icon type='remove' />
                 Delete
-              </div>
+              </button>
             )}
           />
         )}
@@ -172,17 +167,17 @@ const MoreSignalActions = ({
 }
 
 const PublicSignalShareTrigger = ({ ...props }) => (
-  <Button as='a' className={styles.share} {...props}>
-    <Icon className={styles.shareIcon} type='share' />
+  <button {...props}>
+    <Icon type='share' />
     Share alert
-  </Button>
+  </button>
 )
 
 const SignalShareTrigger = ({ ...props }) => (
-  <Button as='a' {...props} className={cx(styles.popupItem, styles.popupButton)}>
+  <button {...props} className={cx(styles.popupItem, 'row v-center btn-ghost body-3')}>
     <Icon type='share' />
     Share
-  </Button>
+  </button>
 )
 
 export default MoreSignalActions

--- a/src/components/SignalCard/controls/RemoveSignalButton.js
+++ b/src/components/SignalCard/controls/RemoveSignalButton.js
@@ -7,9 +7,10 @@ import ConfirmDialog from '../../ConfirmDialog/ConfirmDialog'
 import { removeTrigger } from '../../../ducks/Signals/common/actions'
 import styles from './SignalControls.module.scss'
 
-const RemoveDescription = (title) => (
+const formatDescription = (title) => (
   <>
-    Are you sure you want to delete <span>{title}</span> ?
+    <div className={styles.description}>Are you sure you want to delete {title}?</div>
+    <div>This action cannot be undone.</div>
   </>
 )
 
@@ -29,8 +30,8 @@ const RemoveSignalButton = ({
   withConfirm ? (
     <ConfirmDialog
       id={id}
-      title='Delete alert'
-      description={RemoveDescription(signalTitle)}
+      title='Do you want to delete this Alert?'
+      description={formatDescription(signalTitle)}
       onApprove={removeSignal}
       redirect={redirect}
       classes={styles}

--- a/src/components/SignalCard/controls/SignalControls.module.scss
+++ b/src/components/SignalCard/controls/SignalControls.module.scss
@@ -33,11 +33,7 @@
 }
 
 .description {
-  margin-bottom: 20px;
-
-  @include responsive("phone", "phone-xs") {
-    margin-bottom: 0;
-  }
+  text-align: center;
 }
 
 .btn {

--- a/src/ducks/Alert/components/AlertPreview/AlertPreview.js
+++ b/src/ducks/Alert/components/AlertPreview/AlertPreview.js
@@ -93,18 +93,15 @@ const AlertPreview = ({ setIsPreview, signal, handleCloseDialog, shouldDisableAc
           {chart}
         </div>
         <div className={cx(styles.divider, 'mrg--b mrg-xl')} />
-        <div className='row'>
+        <div className={cx(styles.actions, 'row')}>
           <CopySignal
             signal={signal}
             label='Copy to my alerts'
             onClose={handleCloseDialog}
             classes={{
-              copyBtn: cx(styles.copyBtn, shouldDisableActions && 'c-waterloo'),
+              copyBtn: cx('btn-1 btn--green', styles.copyBtn, shouldDisableActions && 'c-waterloo'),
             }}
-            as='div'
             btnParams={{
-              variant: 'fill',
-              accent: 'positive',
               disabled: shouldDisableActions,
             }}
           />

--- a/src/ducks/Alert/components/AlertPreview/AlertPreview.module.scss
+++ b/src/ducks/Alert/components/AlertPreview/AlertPreview.module.scss
@@ -10,7 +10,11 @@
 }
 
 .copyBtn {
-  margin: 0 8px 0 0 !important;
+  --color-hover: #fff;
+}
+
+.actions {
+  gap: 8px;
 }
 
 .chartWrapper {

--- a/src/ducks/Alert/components/AlertTypeSelector/AlertTypeSelector.js
+++ b/src/ducks/Alert/components/AlertTypeSelector/AlertTypeSelector.js
@@ -40,7 +40,6 @@ const AlertTypeSelector = ({ selectorSettings }) => {
               key={type.title}
               {...type}
               onClick={() => handleSelectType({ type, isSelected })}
-              isSelected={isSelected}
             />
           )
         })}

--- a/src/ducks/Alert/components/AlertTypeSelector/Type/Type.js
+++ b/src/ducks/Alert/components/AlertTypeSelector/Type/Type.js
@@ -3,13 +3,13 @@ import cx from 'classnames'
 import Icon from '@santiment-network/ui/Icon'
 import styles from './Type.module.scss'
 
-const Type = ({ iconType, title, description, onClick, isSelected }) => (
-  <div className={cx(styles.wrapper, isSelected && styles.selected)} onClick={onClick}>
-    <div className={styles.title}>
+const Type = ({ iconType, title, description, onClick }) => (
+  <div className={cx(styles.wrapper, 'column')} onClick={onClick}>
+    <div className={cx(styles.title, 'row v-center body-1 c-black')}>
       <Icon type={iconType} className={styles.icon} />
       {title}
     </div>
-    <div className={styles.description}>{description}</div>
+    <div className={cx(styles.description, 'body-3')}>{description}</div>
   </div>
 )
 

--- a/src/ducks/Alert/components/AlertTypeSelector/Type/Type.module.scss
+++ b/src/ducks/Alert/components/AlertTypeSelector/Type/Type.module.scss
@@ -1,14 +1,7 @@
 @import "~@santiment-network/ui/mixins";
 
-.selected {
-  --type-border: var(--mystic);
-  --type-background: var(--whale);
-}
-
 .wrapper {
   width: 277px;
-  display: flex;
-  flex-direction: column;
   gap: 12px;
   padding: 20px 32px 32px;
   border: 1px solid var(--type-border, var(--porcelain));
@@ -17,24 +10,17 @@
   cursor: pointer;
 
   &:hover {
-    --type-border: var(--jungle-green-hover);
-    --type-title: var(--jungle-green-hover);
+    --type-border: var(--mystic);
+    --type-background: var(--whale);
   }
 }
 
 .title {
-  display: flex;
-  align-items: center;
   gap: 12px;
-  color: var(--type-title, var(--rhino));
-
-  @include text("body-1");
 }
 
 .description {
   color: var(--fiord);
-
-  @include text("body-3");
 }
 
 .icon {

--- a/src/ducks/Alert/constants.js
+++ b/src/ducks/Alert/constants.js
@@ -49,7 +49,7 @@ export const ALERT_TYPES = [
   {
     title: 'Watchlist',
     description: 'Create an alert for the specific watchlist of yours',
-    iconType: 'view-option',
+    iconType: 'watchlist',
     settings: {
       type: 'metric_signal',
       metric: '',

--- a/src/pages/Alerts/MyAlertsTab/MyAlertsTab.js
+++ b/src/pages/Alerts/MyAlertsTab/MyAlertsTab.js
@@ -6,7 +6,7 @@ import styles from './MyAlertsTab.module.scss'
 
 const MyAlertsTab = ({ alertsRestrictions: { currentAmount, maxAmount } }) => (
   <div className='row hv-center'>
-    <div className={cx(styles.tab, 'btn c-casper')}>My Alerts</div>
+    <div className={cx(styles.tab, 'btn c-casper h4 txt-m')}>My Alerts</div>
     {maxAmount <= 20 && (
       <Tooltip
         trigger={

--- a/src/pages/Alerts/MyAlertsTab/MyAlertsTab.module.scss
+++ b/src/pages/Alerts/MyAlertsTab/MyAlertsTab.module.scss
@@ -1,14 +1,12 @@
 .tab {
   --color: inherit;
-  --color-hover: var(--green);
 }
 
 .badge {
   --bg-hover: var(--green-light-1);
   --color-hover: var(--green);
 
-  height: 24px;
-  padding: 2px 10px;
+  padding: 6px 12px;
   margin-left: 10px;
   background-color: var(--athens);
   border-radius: 48px;


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Fixed explore alerts page styles, updated tooltips and delete modal styles, fixed icons and copy to my alerts flow

## Notion's card

<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/Alert-fixes-General-updates-e0cdeba68e714a06a971217b1c83de36

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [ ] If I make changes to another person's module, I've asked how to use it or request a review
- [ ] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [ ] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [ ] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

