### PR TITLE
Fixed creating alerts from other pages

### DIFF
--- a/src/ducks/HistoricalBalance/Address/CreateAlert.js
+++ b/src/ducks/HistoricalBalance/Address/CreateAlert.js
@@ -1,41 +1,48 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import AlertModal from '../../Alert/AlertModal'
-import { mapToOptions } from '../../Signals/utils/utils'
-import { ETH_WALLET_METRIC, PRICE_ABS_CHANGE_BELOW } from '../../Signals/utils/constants'
+import { ALERT_TYPES } from '../../Alert/constants'
+import { getAddressInfrastructure } from '../../../utils/address'
 
-const PARAMS = {
-  variant: 'ghost',
-  border: true,
-}
-
-const METRIC = {
-  value: ETH_WALLET_METRIC,
-}
-const TYPE = {
-  value: PRICE_ABS_CHANGE_BELOW,
-}
-
-const DEFAULTS = {
-  metric: METRIC,
-  type: TYPE,
+const DEFAULT_SIGNAL = {
+  cooldown: '1d',
+  description: '',
+  iconUrl: '',
+  isActive: true,
+  isPublic: false,
+  isRepeating: true,
+  tags: [],
+  title: '',
+  settings: {
+    type: 'wallet_movement',
+    target: { address: '' },
+    selector: { infrastructure: '', slug: '' },
+    channel: [],
+    time_window: '',
+    operation: {},
+  },
 }
 
 const CreateAlert = ({ assets, address, trigger }) => {
-  const ethAddress = useMemo(() => mapToOptions(address), [address])
-  const target = useMemo(() => ({ value: assets.length ? mapToOptions(assets[0]) : [] }), [assets])
+  const infrastructure = getAddressInfrastructure(address)
+  const slug = assets.length !== 0 ? assets[0].slug : ''
 
   return (
     <AlertModal
-      trigger={trigger}
-      enabled={address && assets.length}
-      canRedirect={false}
-      metaFormSettings={{
-        ethAddress,
-        target,
-        ...DEFAULTS,
+      defaultType={ALERT_TYPES[2]}
+      signalData={{
+        ...DEFAULT_SIGNAL,
+        settings: {
+          ...DEFAULT_SIGNAL.settings,
+          target: { ...DEFAULT_SIGNAL.settings.target, address },
+          selector: {
+            ...DEFAULT_SIGNAL.settings.selector,
+            slug,
+            infrastructure,
+          },
+        },
       }}
-      buttonParams={PARAMS}
-      noLoginPopupContainer
+      trigger={trigger}
+      disabled={!address || !slug}
     />
   )
 }

--- a/src/ducks/SANCharts/ChartSignalCreationDialog.js
+++ b/src/ducks/SANCharts/ChartSignalCreationDialog.js
@@ -2,10 +2,42 @@ import React from 'react'
 import Button from '@santiment-network/ui/Button'
 import Icon from '@santiment-network/ui/Icon'
 import AlertModal from '../Alert/AlertModal'
+import { ALERT_TYPES } from '../Alert/constants'
 import styles from './ChartSignalCreationDialog.module.scss'
 
-const ChartSignalCreationDialog = ({ trigger = DefaultSignalCreationTrigger }) => (
-  <AlertModal trigger={trigger} />
+const DEFAULT_SIGNAL = {
+  cooldown: '1d',
+  description: '',
+  iconUrl: '',
+  isActive: true,
+  isPublic: false,
+  isRepeating: true,
+  tags: [],
+  title: '',
+  settings: {
+    type: 'metric_signal',
+    metric: '',
+    target: { slug: '' },
+    channel: [],
+    time_window: '',
+    operation: {},
+  },
+}
+
+const ChartSignalCreationDialog = ({ trigger = DefaultSignalCreationTrigger, slug }) => (
+  <AlertModal
+    defaultType={ALERT_TYPES[0]}
+    signalData={{
+      ...DEFAULT_SIGNAL,
+      settings: {
+        ...DEFAULT_SIGNAL.settings,
+        target: {
+          slug,
+        },
+      },
+    }}
+    trigger={trigger}
+  />
 )
 
 const DefaultSignalCreationTrigger = (


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Fixed alerts creating from charts and historical balance

## Notion's card

<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/Alert-fixes-General-updates-e0cdeba68e714a06a971217b1c83de36
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

