### PR TITLE
Updated styles for restriction message

### DIFF
--- a/src/ducks/Alert/AlertModal.js
+++ b/src/ducks/Alert/AlertModal.js
@@ -27,6 +27,7 @@ const AlertModal = ({
   const match = useRouteMatch('/alerts/:id')
   const history = useHistory()
   const { isLoggedIn } = useUser()
+  const [isRestrictedMessageClosed, setIsRestrictedMessageClosed] = useState(false)
   const [isModalOpen, setIsModalOpen] = useState(defaultOpen)
   const [isClosing, setIsClosing] = useState(false)
   const [isEdited, setIsEdited] = useState(false)
@@ -75,13 +76,19 @@ const AlertModal = ({
         }
         classes={{
           dialog: cx(styles.dialog, isClosing && styles.hidden, isPreview && styles.preview),
+          title: styles.dialogTitle,
         }}
       >
         <>
           {!isPreview && (
-            <AlertRestrictionMessage shouldHideRestrictionMessage={shouldHideRestrictionMessage} />
+            <AlertRestrictionMessage
+              shouldHideRestrictionMessage={shouldHideRestrictionMessage}
+              isRestrictedMessageClosed={isRestrictedMessageClosed}
+              setIsRestrictedMessageClosed={setIsRestrictedMessageClosed}
+            />
           )}
           <AlertModalFormMaster
+            isRestrictedMessageClosed={isRestrictedMessageClosed}
             isRecommendedSignal={isRecommendedSignal}
             shouldDisableActions={shouldDisableActions}
             shouldHideRestrictionMessage={shouldHideRestrictionMessage}

--- a/src/ducks/Alert/AlertModal.module.scss
+++ b/src/ducks/Alert/AlertModal.module.scss
@@ -7,6 +7,10 @@
   overflow: hidden;
 }
 
+.dialogTitle {
+  padding: 14px 24px !important;
+}
+
 .hidden {
   visibility: hidden;
 }

--- a/src/ducks/Alert/AlertModalForm.js
+++ b/src/ducks/Alert/AlertModalForm.js
@@ -18,6 +18,7 @@ const AlertModalForm = ({
   isModalOpen,
   isSharedTrigger,
   isRecommendedSignal,
+  isRestrictedMessageClosed,
 }) => {
   const {
     setSelectedType,
@@ -137,6 +138,7 @@ const AlertModalForm = ({
     return (
       <Form className={styles.wrapper}>
         <AlertModalSidebar
+          isRestrictedMessageClosed={isRestrictedMessageClosed}
           isRecommendedSignal={isRecommendedSignal}
           isEdited={isEdited}
           isSharedTrigger={isSharedTrigger}

--- a/src/ducks/Alert/AlertModalFormMaster.js
+++ b/src/ducks/Alert/AlertModalFormMaster.js
@@ -50,6 +50,7 @@ const AlertModalFormMaster = ({
   shouldHideRestrictionMessage,
   shouldDisableActions,
   isRecommendedSignal,
+  isRestrictedMessageClosed,
 }) => {
   const [formPreviousValues, setFormPreviousValues] = useState(initialValues)
   const [selectedType, setSelectedType] = useState(defaultType)
@@ -199,13 +200,19 @@ const AlertModalFormMaster = ({
   }
 
   if (selectedStep === undefined) {
-    return <AlertTypeSelector selectorSettings={selectorSettings} />
+    return (
+      <AlertTypeSelector
+        selectorSettings={selectorSettings}
+        isRestrictedMessageClosed={isRestrictedMessageClosed}
+      />
+    )
   }
 
   return (
     <Formik initialValues={initialState} onSubmit={handleSubmit} enableReinitialize={true}>
       {(formik) => (
         <AlertModalForm
+          isRestrictedMessageClosed={isRestrictedMessageClosed}
           isRecommendedSignal={isRecommendedSignal}
           signal={signalData || (data && data.trigger && data.trigger.trigger)}
           isModalOpen={isModalOpen}

--- a/src/ducks/Alert/components/AlertModalSidebar/AlertModalSidebar.js
+++ b/src/ducks/Alert/components/AlertModalSidebar/AlertModalSidebar.js
@@ -4,6 +4,7 @@ import { useFormikContext } from 'formik'
 import Button from '@santiment-network/ui/Button'
 import Icon from '@santiment-network/ui/Icon'
 import AlertStepsSelector from '../AlertStepsSelector/AlertStepsSelector'
+import AlertRestrictionMessageTooltip from '../AlertRestrictionMessage/AlertRestrictionMessageTooltip'
 import styles from './AlertModalSidebar.module.scss'
 
 const AlertModalSidebar = ({
@@ -14,6 +15,7 @@ const AlertModalSidebar = ({
   isSharedTrigger,
   isEdited,
   isRecommendedSignal,
+  isRestrictedMessageClosed,
 }) => {
   const { submitForm, isSubmitting } = useFormikContext()
 
@@ -52,10 +54,15 @@ const AlertModalSidebar = ({
       <div>
         <div className={cx(styles.titleWrapper, 'row justify v-center')}>
           <div className='h4 c-black'>{selectedType.title}</div>
-          {!hasSignal && (
+          {!hasSignal ? (
             <button className={cx(styles.backButton, 'btn body-3')} onClick={handleReturnBack}>
               <Icon type='arrow-left' className={cx(styles.backIcon, 'mrg--r mrg-s')} /> Alert types
             </button>
+          ) : (
+            <AlertRestrictionMessageTooltip
+              shouldHideRestrictionMessage={shouldHideRestrictionMessage}
+              isRestrictedMessageClosed={isRestrictedMessageClosed}
+            />
           )}
         </div>
         <div className={styles.divider} />

--- a/src/ducks/Alert/components/AlertRestrictionMessage/AlertRestrictionMessage.js
+++ b/src/ducks/Alert/components/AlertRestrictionMessage/AlertRestrictionMessage.js
@@ -4,21 +4,32 @@ import cx from 'classnames'
 import Icon from '@santiment-network/ui/Icon'
 import styles from './AlertRestrictionMessage.module.scss'
 
-const AlertRestrictionMessage = ({ shouldHideRestrictionMessage }) => {
-  if (shouldHideRestrictionMessage) {
+const AlertRestrictionMessage = ({
+  shouldHideRestrictionMessage,
+  isRestrictedMessageClosed,
+  setIsRestrictedMessageClosed,
+}) => {
+  if (shouldHideRestrictionMessage || isRestrictedMessageClosed) {
     return null
   }
 
   return (
-    <div className={cx(styles.wrapper, 'row v-center')}>
-      <Icon type='alert' className={styles.icon} />
-      <div className='body-2'>
-        <span className='txt-m'>Duration restriction!</span> Your Alert will be valid for 30 days.
-        To extend Alert please{' '}
-        <Link to='/pricing' className={cx(styles.link, 'txt-m')}>
-          Update your Plan.
-        </Link>
+    <div className={cx(styles.wrapper, 'row justify v-center')}>
+      <div className='row v-center'>
+        <Icon type='alert' className={styles.icon} />
+        <div className='body-3'>
+          <span className='txt-m'>Duration restriction!</span> Your Alert will be valid for 30 days.
+          To extend Alert please{' '}
+          <Link to='/pricing' className={cx(styles.link, 'txt-m')}>
+            Update your Plan.
+          </Link>
+        </div>
       </div>
+      <Icon
+        type='close-medium'
+        className='btn c-waterloo'
+        onClick={() => setIsRestrictedMessageClosed(true)}
+      />
     </div>
   )
 }

--- a/src/ducks/Alert/components/AlertRestrictionMessage/AlertRestrictionMessage.module.scss
+++ b/src/ducks/Alert/components/AlertRestrictionMessage/AlertRestrictionMessage.module.scss
@@ -1,6 +1,6 @@
 .wrapper {
-  min-height: 56px;
-  padding-left: 48px;
+  min-height: 52px;
+  padding: 0 24px;
   background-color: var(--orange-light-1);
 }
 
@@ -20,4 +20,21 @@
   &:hover {
     color: var(--orange-hover);
   }
+}
+
+.btn {
+  --bg-hover: var(--orange-light-1);
+  --fill: var(--orange);
+  --fill-hover: var(--orange);
+  padding: 9px 8px;
+}
+
+.tooltip {
+  z-index: 11111;
+  padding: 18px 24px;
+  width: 272px;
+}
+
+.tooltipLink {
+  display: inline-block;
 }

--- a/src/ducks/Alert/components/AlertRestrictionMessage/AlertRestrictionMessageTooltip.js
+++ b/src/ducks/Alert/components/AlertRestrictionMessage/AlertRestrictionMessageTooltip.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import cx from 'classnames'
+import Icon from '@santiment-network/ui/Icon'
+import Tooltip from '@santiment-network/ui/Tooltip'
+import styles from './AlertRestrictionMessage.module.scss'
+
+const AlertRestrictionMessageTooltip = ({
+  shouldHideRestrictionMessage,
+  isRestrictedMessageClosed,
+}) => {
+  if (shouldHideRestrictionMessage || !isRestrictedMessageClosed) {
+    return null
+  }
+
+  return (
+    <Tooltip
+      trigger={
+        <div className={cx('btn row hv-center', styles.btn)}>
+          <Icon type='alert' />
+        </div>
+      }
+      position='bottom'
+      className={cx(styles.tooltip, 'border box')}
+    >
+      <div className='relative row body-3'>
+        <span>
+          <span className='txt-m'>Alert with Duration Restriction.</span> Your Alert will be valid
+          for 30 days from the day it’s created. To extend Alert please{' '}
+          <Link to='/pricing' className={cx(styles.link, styles.tooltipLink, 'txt-m')}>
+            Update your Plan!
+          </Link>
+        </span>
+      </div>
+    </Tooltip>
+  )
+}
+
+export default AlertRestrictionMessageTooltip

--- a/src/ducks/Alert/components/AlertTypeSelector/AlertTypeSelector.js
+++ b/src/ducks/Alert/components/AlertTypeSelector/AlertTypeSelector.js
@@ -1,9 +1,11 @@
 import React from 'react'
+import cx from 'classnames'
 import Type from './Type/Type'
+import AlertRestrictionMessageTooltip from '../AlertRestrictionMessage/AlertRestrictionMessageTooltip'
 import { ALERT_TYPES } from '../../constants'
 import styles from './AlertTypeSelector.module.scss'
 
-const AlertTypeSelector = ({ selectorSettings }) => {
+const AlertTypeSelector = ({ selectorSettings, isRestrictedMessageClosed }) => {
   const {
     selectedType,
     setSelectedType,
@@ -13,6 +15,7 @@ const AlertTypeSelector = ({ selectorSettings }) => {
     initialState,
     setInitialState,
     formPreviousValues,
+    shouldHideRestrictionMessage,
   } = selectorSettings
 
   function handleSelectType({ type, isSelected }) {
@@ -31,7 +34,13 @@ const AlertTypeSelector = ({ selectorSettings }) => {
 
   return (
     <div className={styles.wrapper}>
-      <div className={styles.title}>Choose type of alert bellow:</div>
+      <div className={cx(styles.title, 'row v-center justify')}>
+        Choose type of alert bellow:
+        <AlertRestrictionMessageTooltip
+          isRestrictedMessageClosed={isRestrictedMessageClosed}
+          shouldHideRestrictionMessage={shouldHideRestrictionMessage}
+        />
+      </div>
       <div className={styles.typesWrapper}>
         {ALERT_TYPES.map((type) => {
           const isSelected = selectedType && selectedType.title === type.title

--- a/src/pages/Alerts/AlertRestrictionMessage/AlertRestrictionMessage.js
+++ b/src/pages/Alerts/AlertRestrictionMessage/AlertRestrictionMessage.js
@@ -4,20 +4,32 @@ import cx from 'classnames'
 import Icon from '@santiment-network/ui/Icon'
 import styles from '../../../ducks/Alert/components/AlertRestrictionMessage/AlertRestrictionMessage.module.scss'
 
-const AlertRestrictionMessage = ({ shouldHideRestrictionMessage }) => {
-  if (shouldHideRestrictionMessage) {
+const AlertRestrictionMessage = ({
+  shouldHideRestrictionMessage,
+  isRestrictedMessageClosed,
+  setIsRestrictedMessageClosed,
+}) => {
+  if (shouldHideRestrictionMessage || isRestrictedMessageClosed) {
     return null
   }
 
   return (
-    <div className={cx(styles.wrapper, styles.wrapperPage, 'mrg-xl mrg--b row v-center')}>
-      <Icon type='alert' className={styles.icon} />
-      <div className='body-2'>
-        You have reached the maximum amount of alerts available to you. To unlock more alerts please{' '}
-        <Link to='/pricing' className={cx(styles.link, 'txt-m')}>
-          Update your Plan.
-        </Link>
+    <div className={cx(styles.wrapper, styles.wrapperPage, 'mrg-xl mrg--b row v-center justify')}>
+      <div className='row v-center'>
+        <Icon type='alert' className={styles.icon} />
+        <div className='body-3'>
+          You have reached the maximum amount of alerts available to you. To unlock more alerts
+          please{' '}
+          <Link to='/pricing' className={cx(styles.link, 'txt-m')}>
+            Update your Plan.
+          </Link>
+        </div>
       </div>
+      <Icon
+        type='close-medium'
+        className='btn c-waterloo'
+        onClick={() => setIsRestrictedMessageClosed(true)}
+      />
     </div>
   )
 }

--- a/src/pages/Alerts/Alerts.js
+++ b/src/pages/Alerts/Alerts.js
@@ -34,6 +34,7 @@ function getAlertsRestrictions({ signals, isPro, isProPlus }) {
 
 const Alerts = ({ isDesktop, match }) => {
   const [filter, setFilter] = useState(filters.ALL)
+  const [isRestrictedMessageClosed, setIsRestrictedMessageClosed] = useState(false)
   const { user, loading: isUserLoading } = useUser()
   const { tab } = parse(useLocation().search, { parseNumbers: true })
   const { data: signals = [], loading } = useSignals({
@@ -126,6 +127,8 @@ const Alerts = ({ isDesktop, match }) => {
                   <>
                     <AlertRestrictionMessage
                       shouldHideRestrictionMessage={shouldHideRestrictionMessage}
+                      isRestrictedMessageClosed={isRestrictedMessageClosed}
+                      setIsRestrictedMessageClosed={setIsRestrictedMessageClosed}
                     />
                     <LoadableAlertsList
                       userId={user ? user.id : ''}

--- a/src/pages/Alerts/MyAlertsTab/MyAlertsTab.js
+++ b/src/pages/Alerts/MyAlertsTab/MyAlertsTab.js
@@ -23,7 +23,7 @@ const MyAlertsTab = ({ alertsRestrictions: { currentAmount, maxAmount } }) => (
             available. To unlock more alerts please
           </span>
           <Link to='/pricing' className={cx(styles.link, 'txt-m')}>
-            Update your Plan.
+            Update your Plan!
           </Link>
         </div>
       </Tooltip>


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Updated restriction message styles, added tooltip

## Notion's card

<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/Alert-restrictions-Ui-fixes-6e01fbf6c03548b099c116e99fcda8f3

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
![Снимок экрана 2022-04-13 в 11 22 08](https://user-images.githubusercontent.com/46782114/163133024-a235991b-508d-41c3-88b7-079f6fc8232a.png)
![Снимок экрана 2022-04-13 в 11 22 15](https://user-images.githubusercontent.com/46782114/163133033-73009434-e15f-49e6-8844-419a4c09da97.png)
![Снимок экрана 2022-04-13 в 11 22 39](https://user-images.githubusercontent.com/46782114/163133036-71536bfb-82f0-459e-9f7c-c2a548758451.png)

