### PR TITLE
fix/paths-dialogs-hook

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -204,7 +204,7 @@ export const App = ({
 
     const svelte = new Dialogs({ target: document.body })
     return () => svelte.$destroy()
-  }, [])
+  }, [pathname])
 
   useEffect(() => {
     if (isListPath(pathname)) {


### PR DESCRIPTION
## Changes

Making `Dialogs` hook reactive by adding `pathname` as a dependency \

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)


