### PR TITLE
empty state for non logged users fixed, username style fixed

### DIFF
--- a/src/pages/Explorer/Category/ExplorerCategory.svelte
+++ b/src/pages/Explorer/Category/ExplorerCategory.svelte
@@ -7,6 +7,7 @@
   import EmptyState from '../Components/EmptyState.svelte'
   import TypeSelector from '../Components/TypeSelector.svelte'
   import { queryExplorerItems } from '../api'
+  import { currentUser } from '../store'
   import { EntityType, RANGES, MenuItem, getExplorerItem } from '../const'
 
   export let activeMenu
@@ -27,6 +28,9 @@
   let loading = false
 
   $: activeMenu, reset()
+  $: showEmpty = !$currentUser && activeMenu !== MenuItem.MY_CREATIONS
+  $: voted = activeMenu === MenuItem.LIKES
+  $: currentUserDataOnly = activeMenu === MenuItem.MY_CREATIONS
   $: range, assets, selectedTypes, page, fetch()
   $: onLoadingChange(loading)
 
@@ -35,9 +39,13 @@
   })
 
   function fetch(bypassLoading = false) {
+    if (showEmpty) {
+      pages = 1
+      page = 1
+      items = []
+      return
+    }
     if (!bypassLoading) loading = true
-    const voted = activeMenu === MenuItem.LIKES
-    const currentUserDataOnly = activeMenu === MenuItem.MY_CREATIONS
     queryExplorerItems({
       types: Array.from(selectedTypes),
       voted,
@@ -136,6 +144,6 @@
   </svelte:fragment>
 </Category>
 
-{#if !loading && items.length === 0}
+{#if showEmpty || (!loading && items.length === 0)}
   <EmptyState {activeMenu} />
 {/if}

--- a/src/pages/Explorer/Category/UserCreation.svelte
+++ b/src/pages/Explorer/Category/UserCreation.svelte
@@ -54,7 +54,7 @@
   <div class="bottom row justify v-center c-waterloo mrg-s mrg--t" class:caption={small}>
     <Tooltip openDelay={110}>
       <svelte:fragment slot="trigger">
-        <Profile {user} class="author" />
+        <Profile {user} class="author fluid" />
       </svelte:fragment>
 
       <svelte:fragment slot="tooltip">


### PR DESCRIPTION
## Changes
- empty state for non logged users fixed
- username style fixed
<!--- Describe your changes -->

## Notion's card
https://discord.com/channels/334289660698427392/413675697815683072/969859387596345385
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

