### PR TITLE
explorer empty tabs bug fixed

### DIFF
--- a/src/components/Navbar/Navbar.svelte
+++ b/src/components/Navbar/Navbar.svelte
@@ -35,11 +35,13 @@
     isCompact
     isColumn
     class="mrg-xxl mrg--r"
-    tooltipClassName="$style.dropdown" />
+    tooltipClassName="$style.dropdown"
+  />
 
   <a href="https://santiment.net/discord" class="discord btn-1 btn--s row v-center nowrap">
     <Svg id="discord" w="16" h="12" class="mrg-s mrg--r" />
-    Join us!</a>
+    Join us!</a
+  >
 
   <div class="search fluid mrg-a mrg--l" bind:this={searchNode} />
 

--- a/src/components/SideNav/index.svelte
+++ b/src/components/SideNav/index.svelte
@@ -28,7 +28,8 @@
 <aside
   class:collapsed={isCollapsed}
   on:mouseenter={() => (isPeeked = true)}
-  on:mouseleave={() => (isPeeked = false)}>
+  on:mouseleave={() => (isPeeked = false)}
+>
   <div class="content">
     <MinimizedCategories {pathname} {isCollapsed} />
     <div class="container txt-m" class:no-scrollbar={isCollapsed}>

--- a/src/pages/Explorer/Category/ExplorerCategory.svelte
+++ b/src/pages/Explorer/Category/ExplorerCategory.svelte
@@ -28,7 +28,7 @@
   let loading = false
 
   $: activeMenu, reset()
-  $: showEmpty = !$currentUser && activeMenu !== MenuItem.MY_CREATIONS
+  $: showEmpty = !$currentUser && activeMenu !== MenuItem.NEW
   $: voted = activeMenu === MenuItem.LIKES
   $: currentUserDataOnly = activeMenu === MenuItem.MY_CREATIONS
   $: range, assets, selectedTypes, page, fetch()

--- a/src/pages/Explorer/const.js
+++ b/src/pages/Explorer/const.js
@@ -30,7 +30,7 @@ export const EntityType = {
     key: EntityKeys.PROJECT_WATCHLIST,
     voteKey: 'watchlistId',
     deleteKey: 'WATCHLIST',
-    label: 'Projects',
+    label: 'Watchlists',
     singular: 'watchlist',
     icon: 'watchlist',
     color: 'var(--orange)',

--- a/src/pages/Explorer/index.svelte
+++ b/src/pages/Explorer/index.svelte
@@ -26,7 +26,8 @@
       class="btn-2 row v-center"
       class:active={activeMenu === MenuItem.NEW}
       class:loading={activeMenu === MenuItem.NEW && loading}
-      on:click={() => changeMenu(MenuItem.NEW)}>
+      on:click={() => changeMenu(MenuItem.NEW)}
+    >
       <Svg id="time" w="16" class="mrg-s mrg--r" />
       New
     </div>
@@ -34,7 +35,8 @@
       class="btn-2 row v-center mrg-s mrg--l"
       class:active={activeMenu === MenuItem.LIKES}
       class:loading={activeMenu === MenuItem.LIKES && loading}
-      on:click={() => changeMenu(MenuItem.LIKES)}>
+      on:click={() => changeMenu(MenuItem.LIKES)}
+    >
       <Svg id="rocket" w="16" class="mrg-s mrg--r" />
       Likes
     </div>
@@ -43,7 +45,8 @@
       class="btn-2 row v-center mrg-a mrg--l"
       class:active={activeMenu === MenuItem.MY_CREATIONS}
       class:loading={activeMenu === MenuItem.MY_CREATIONS && loading}
-      on:click={() => changeMenu(MenuItem.MY_CREATIONS)}>
+      on:click={() => changeMenu(MenuItem.MY_CREATIONS)}
+    >
       <Svg id="user" w="16" class="mrg-s mrg--r" />
       My creations
     </div>


### PR DESCRIPTION
## Changes
- explorer empty tabs bug fixed
- projects renamed to watchlists
<!--- Describe your changes -->

## Notion's card
https://discord.com/channels/334289660698427392/413675697815683072/970258229567311872
https://discord.com/channels/334289660698427392/413675697815683072/969966045030907925
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
![image](https://user-images.githubusercontent.com/6568353/166198083-0438f245-beca-46a3-b40c-e31467c3ee61.png)
![image](https://user-images.githubusercontent.com/6568353/166198121-4e88b643-c525-4e94-8790-00157fee0a32.png)

