### PR TITLE
explorer sticky effect for main tag fixed

### DIFF
--- a/src/pages/Explorer/index.js
+++ b/src/pages/Explorer/index.js
@@ -11,7 +11,7 @@ const PAGE_STYLE = {
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'flex-start',
-  margin: '24px 0 100px 240px',
+  margin: '14px 0 100px 240px',
 }
 
 export const Page = toReact(SveltePage, PAGE_STYLE, 'div')

--- a/src/pages/Explorer/index.svelte
+++ b/src/pages/Explorer/index.svelte
@@ -58,10 +58,12 @@
 <Aside class="$style.aside" />
 
 <style>
+  main,
   .aside {
     position: sticky;
     align-self: flex-end;
     bottom: 0;
+    padding-top: 10px;
   }
 
   :global(.tablet) .aside {
@@ -71,6 +73,7 @@
 
   main {
     width: 640px;
+    min-height: 100vh;
   }
 
   .aside {


### PR DESCRIPTION
## Changes
- explorer sticky effect for main tag fixed
<!--- Describe your changes -->

## Notion's card

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

