### PR TITLE
explorer bugs fixed (part 1)

### DIFF
--- a/src/pages/Explorer/Category/UserCreation.svelte
+++ b/src/pages/Explorer/Category/UserCreation.svelte
@@ -55,7 +55,7 @@
 <div class="bottom row justify v-center c-waterloo mrg-s mrg--t" class:caption={small}>
   <Tooltip openDelay={110}>
     <svelte:fragment slot="trigger">
-      <Profile {user} class="author fluid" />
+      <Profile {user} class="author" />
     </svelte:fragment>
 
     <svelte:fragment slot="tooltip">

--- a/src/pages/Explorer/Components/AssetIcons.svelte
+++ b/src/pages/Explorer/Components/AssetIcons.svelte
@@ -17,7 +17,7 @@
 
 <style>
   .icon {
-    background-color: var(--porcelain);
+    background: var(--porcelain);
   }
 
   .assets > :global(*) {

--- a/src/pages/Explorer/Components/AssetIcons.svelte
+++ b/src/pages/Explorer/Components/AssetIcons.svelte
@@ -7,7 +7,7 @@
 <div class="assets row mrg-l mrg--r">
   {#each assets.slice(0, 3) as { slug }, i}
     <span style="z-index:{5 - i}">
-      <ProjectIcon {slug} size={24} />
+      <ProjectIcon {slug} size={24} class="$style.icon" />
     </span>
   {/each}
   {#if assets.length > 3}
@@ -16,6 +16,10 @@
 </div>
 
 <style>
+  .icon {
+    background-color: var(--porcelain);
+  }
+
   .assets > :global(*) {
     margin-left: -8px;
   }

--- a/src/pages/Explorer/Components/AssetSelector.svelte
+++ b/src/pages/Explorer/Components/AssetSelector.svelte
@@ -109,8 +109,9 @@
         {/if}
       </div>
     </div>
-
-    <button class="deselect btn caption fluid" on:click={deselect}>Deselect all</button>
+    {#if selections.size > 0}
+      <button class="deselect btn caption fluid" on:click={deselect}>Deselect all</button>
+    {/if}
   </div>
 </Tooltip>
 

--- a/src/pages/Explorer/api.js
+++ b/src/pages/Explorer/api.js
@@ -57,7 +57,7 @@ export const queryExplorerItems = ({
         }
       }
     `
-  return query(QUERY, { cacheTime: 20 }).then(accessor)
+  return query(QUERY).then(accessor)
 }
 
 export function queryReports() {


### PR DESCRIPTION
## Changes
- Show usernames’ tooltip, only when user hover exactly on username or avatar part 
- Add rounded circle frame with background(Porcelain), so in case of having squared or transparent logo from backend - it will be fixed by our frame 
- Deselect should appear only when user have selected smth 
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/Explorer-bugs-ad72eb628eac4dd590c0e0f299ee4a77
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

