### PR TITLE
recents word edited, no-unreachable error disabled

### DIFF
--- a/src/components/ForceActionRedirector.js
+++ b/src/components/ForceActionRedirector.js
@@ -33,6 +33,7 @@ const ForceActionRedirector = ({ pathname }) => {
     // Disabled
     return
     //
+    /* eslint-disable no-unreachable */
     if (!socket || isProPlus || !shouldCheckPage(pathname)) {
       if (showTabLimitModal) {
         track.event('tab_limit_modal_closed')

--- a/src/components/SideNav/Recent.svelte
+++ b/src/components/SideNav/Recent.svelte
@@ -59,4 +59,4 @@
   }
 </script>
 
-<Section title="Recent" icon="time" links={recents} {pathname} />
+<Section title="Recents" icon="time" links={recents} {pathname} />


### PR DESCRIPTION
## Changes
- `Recent` renamed to `Recents`
- `no-unreachable` disabled
<!--- Describe your changes -->

## Notion's card
![image](https://user-images.githubusercontent.com/6568353/169051423-e357b782-8fea-4560-b733-fbcc50446823.png)

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
![image](https://user-images.githubusercontent.com/6568353/169051565-fbc423c8-3cf8-47f5-8ca7-b82568e4c4b9.png)

