### PR TITLE
explorer assets icons bug fixed

### DIFF
--- a/src/pages/Explorer/Layouts/LayoutItem.svelte
+++ b/src/pages/Explorer/Layouts/LayoutItem.svelte
@@ -16,7 +16,7 @@
 <UserCreation {item} {small} {type} {showActions} url={getItemUrl(item, type)}>
   {#if !small}
     {#if hasIcons}
-      <AssetIcons {assets} />
+      <AssetIcons assets={assets.filter((asset) => asset.slug)} />
     {:else}
       <AssetTags tags={assets} />
     {/if}


### PR DESCRIPTION
## Changes
- filter assets and pick only those have 'slug' property
<!--- Describe your changes -->

## Notion's card
https://discord.com/channels/334289660698427392/413675697815683072/978166133347721276
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

