### PR TITLE
navbar discord icon click event tracker added

### DIFF
--- a/src/components/Navbar/Navbar.svelte
+++ b/src/components/Navbar/Navbar.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte'
   import { customerData$ } from 'webkit/stores/user'
   import { subscription$ } from 'webkit/stores/subscription'
+  import { track } from 'webkit/analytics'
   import Svg from 'webkit/ui/Svg/svelte'
   import Product from 'webkit/ui/Product.svelte'
   import Products from 'webkit/ui/Products/svelte'
@@ -38,7 +39,11 @@
     tooltipClassName="$style.dropdown"
   />
 
-  <a href="https://santiment.net/discord" class="discord btn-1 btn--s row v-center nowrap">
+  <a
+    href="https://santiment.net/discord"
+    class="discord btn-1 btn--s row v-center nowrap"
+    on:click={() => track.event('navbar_discord_join_us_clicked')}
+  >
     <Svg id="discord" w="16" h="12" class="mrg-s mrg--r" />
     Join us!</a
   >


### PR DESCRIPTION
## Changes
- `track.event` added to `on:click` event
<!--- Describe your changes -->

## Notion's card
https://discord.com/channels/334289660698427392/413675697815683072/978969519173287936
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

