### PR TITLE
tooltipClass prop name fixed

### DIFF
--- a/src/components/Navbar/Navbar.svelte
+++ b/src/components/Navbar/Navbar.svelte
@@ -36,7 +36,7 @@
     isCompact
     isColumn
     class="mrg-xxl mrg--r"
-    tooltipClassName="$style.dropdown"
+    tooltipClass="$style.dropdown"
   />
 
   <a


### PR DESCRIPTION
## Changes
- tooltipClass prop name fixed
<!--- Describe your changes -->

## Notion's card

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

