### PR TITLE
fix/explorer-small-screens

### DIFF
--- a/src/pages/Explorer/index.svelte
+++ b/src/pages/Explorer/index.svelte
@@ -26,8 +26,7 @@
       class="btn-2 row v-center mrg-s mrg--r"
       class:active={activeMenu === MenuItem.SANTIMENT}
       class:loading={activeMenu === MenuItem.SANTIMENT && loading}
-      on:click={() => changeMenu(MenuItem.SANTIMENT)}
-    >
+      on:click={() => changeMenu(MenuItem.SANTIMENT)}>
       <Svg id="santiment" w="16" class="mrg-s mrg--r" />
       By Santiment
     </div>
@@ -35,8 +34,7 @@
       class="btn-2 row v-center"
       class:active={activeMenu === MenuItem.NEW}
       class:loading={activeMenu === MenuItem.NEW && loading}
-      on:click={() => changeMenu(MenuItem.NEW)}
-    >
+      on:click={() => changeMenu(MenuItem.NEW)}>
       <Svg id="time" w="16" class="mrg-s mrg--r" />
       New
     </div>
@@ -45,8 +43,7 @@
         class="btn-2 row v-center mrg-s mrg--r"
         class:active={activeMenu === MenuItem.LIKES}
         class:loading={activeMenu === MenuItem.LIKES && loading}
-        on:click={() => changeMenu(MenuItem.LIKES)}
-      >
+        on:click={() => changeMenu(MenuItem.LIKES)}>
         <Svg id="rocket" w="16" class="mrg-s mrg--r" />
         My likes
       </div>
@@ -54,8 +51,7 @@
         class="btn-2 row v-center"
         class:active={activeMenu === MenuItem.MY_CREATIONS}
         class:loading={activeMenu === MenuItem.MY_CREATIONS && loading}
-        on:click={() => changeMenu(MenuItem.MY_CREATIONS)}
-      >
+        on:click={() => changeMenu(MenuItem.MY_CREATIONS)}>
         <Svg id="user" w="16" class="mrg-s mrg--r" />
         My creations
       </div>
@@ -80,6 +76,11 @@
   :global(.tablet) .aside {
     /* TODO: removed component using js */
     display: none;
+  }
+  @media screen and (max-width: 1260px) {
+    .aside {
+      display: none;
+    }
   }
 
   main {


### PR DESCRIPTION
## Changes
Hiding `Aside` widget on small screens.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)


