### PR TITLE
moderator delete button show bug fixed

### DIFF
--- a/src/pages/Explorer/Components/Actions.svelte
+++ b/src/pages/Explorer/Components/Actions.svelte
@@ -114,9 +114,6 @@
         <Svg id="comment" w="16" class="btn $style.svg" on:click={onComment} />
       {/if}
     {:else}
-      {#if $currentUser && $currentUser.isModerator}
-        <Svg id="delete" w="16" class="btn $style.svg" on:click={onDelete} />
-      {/if}
       {#if showCommentAction}
         <Svg id="comment" w="16" class="btn $style.svg" on:click={onComment} />
       {/if}
@@ -124,6 +121,7 @@
       <Svg id="share-dots" w="16" class="btn $style.svg" on:click={onShare} />
       {#if $currentUser && $currentUser.isModerator}
         <Svg id="eye-crossed" w="16" class="btn $style.svg" on:click={onHide} />
+        <Svg id="delete" w="16" class="btn $style.svg" on:click={onDelete} />
       {/if}
     {/if}
   </div>


### PR DESCRIPTION
## Changes
- moderator delete button show bug fixed
<!--- Describe your changes -->

## Notion's card
https://discord.com/channels/334289660698427392/413675697815683072/981543304564969593
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

