### PR TITLE
Enhance/handle enter key press on dialaog

### DIFF
--- a/src/pages/Explorer/Components/DeleteConfirmationDialog.svelte
+++ b/src/pages/Explorer/Components/DeleteConfirmationDialog.svelte
@@ -23,6 +23,12 @@
     deleteAction(id, deleteKey, isModerator)
       .then(() => filterExplorerItems(item))
       .then(closeDialog)
+
+  function onEnterKeyPressed(event) {
+    event.stopPropagation()
+    event.preventDefault()
+    console.log({ key: event.code })
+  }
 </script>
 
 <Dialog {...$$props} noTitle bind:closeDialog>
@@ -36,7 +42,8 @@
     </div>
     <div class="row hv-center">
       <button class="btn-1 mrg-m mrg--r" on:click={onDeleteClick}>Delete</button>
-      <button class="btn-2" on:click={closeDialog}>Cancel</button>
+      <!-- svelte-ignore a11y-autofocus -->
+      <button class="btn-2" autofocus on:click={closeDialog}>Cancel</button>
     </div>
   </div>
 </Dialog>

--- a/src/pages/Explorer/Components/DeleteConfirmationDialog.svelte
+++ b/src/pages/Explorer/Components/DeleteConfirmationDialog.svelte
@@ -23,12 +23,6 @@
     deleteAction(id, deleteKey, isModerator)
       .then(() => filterExplorerItems(item))
       .then(closeDialog)
-
-  function onEnterKeyPressed(event) {
-    event.stopPropagation()
-    event.preventDefault()
-    console.log({ key: event.code })
-  }
 </script>
 
 <Dialog {...$$props} noTitle bind:closeDialog>

--- a/src/pages/Explorer/Components/HideConfirmationDialog.svelte
+++ b/src/pages/Explorer/Components/HideConfirmationDialog.svelte
@@ -36,7 +36,8 @@
     </div>
     <div class="row hv-center">
       <button class="btn-1 mrg-m mrg--r" on:click={onHide}>Hide</button>
-      <button class="btn-2" on:click={closeDialog}>Cancel</button>
+      <!-- svelte-ignore a11y-autofocus -->
+      <button class="btn-2" autofocus on:click={closeDialog}>Cancel</button>
     </div>
   </div>
 </Dialog>

--- a/src/pages/Explorer/index.svelte
+++ b/src/pages/Explorer/index.svelte
@@ -26,7 +26,8 @@
       class="btn-2 row v-center mrg-s mrg--r"
       class:active={activeMenu === MenuItem.SANTIMENT}
       class:loading={activeMenu === MenuItem.SANTIMENT && loading}
-      on:click={() => changeMenu(MenuItem.SANTIMENT)}>
+      on:click={() => changeMenu(MenuItem.SANTIMENT)}
+    >
       <Svg id="santiment" w="16" class="mrg-s mrg--r" />
       By Santiment
     </div>
@@ -34,7 +35,8 @@
       class="btn-2 row v-center"
       class:active={activeMenu === MenuItem.NEW}
       class:loading={activeMenu === MenuItem.NEW && loading}
-      on:click={() => changeMenu(MenuItem.NEW)}>
+      on:click={() => changeMenu(MenuItem.NEW)}
+    >
       <Svg id="time" w="16" class="mrg-s mrg--r" />
       New
     </div>
@@ -43,7 +45,8 @@
         class="btn-2 row v-center mrg-s mrg--r"
         class:active={activeMenu === MenuItem.LIKES}
         class:loading={activeMenu === MenuItem.LIKES && loading}
-        on:click={() => changeMenu(MenuItem.LIKES)}>
+        on:click={() => changeMenu(MenuItem.LIKES)}
+      >
         <Svg id="rocket" w="16" class="mrg-s mrg--r" />
         My likes
       </div>
@@ -51,7 +54,8 @@
         class="btn-2 row v-center"
         class:active={activeMenu === MenuItem.MY_CREATIONS}
         class:loading={activeMenu === MenuItem.MY_CREATIONS && loading}
-        on:click={() => changeMenu(MenuItem.MY_CREATIONS)}>
+        on:click={() => changeMenu(MenuItem.MY_CREATIONS)}
+      >
         <Svg id="user" w="16" class="mrg-s mrg--r" />
         My creations
       </div>


### PR DESCRIPTION
## Changes
- autofocus added to cancel buttons
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/Handle-Enter-key-press-on-action-confirmation-19168520cf4b476aad42a1931d87ae4b
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

