### PR TITLE
update name bug fixed

### DIFF
--- a/src/ducks/Watchlists/Actions/Edit/EditForm/index.js
+++ b/src/ducks/Watchlists/Actions/Edit/EditForm/index.js
@@ -132,7 +132,7 @@ const EditForm = ({
             maxLength='25'
             autoComplete='off'
             className={styles.input}
-            onChange={(e) => formState.error && onInputChange(e)}
+            onChange={onInputChange}
             onBlur={onInputChange}
             isError={formState.error}
             errorText={formState.error}

--- a/src/ducks/Watchlists/Widgets/Table/CompareInfo/CompareAction.js
+++ b/src/ducks/Watchlists/Widgets/Table/CompareInfo/CompareAction.js
@@ -8,7 +8,7 @@ const CompareTooltip = ({ disabledComparision }) => {
   return (
     <DarkTooltip
       align='center'
-      position='top'
+      position='bottom'
       on='hover'
       className={styles.tooltip}
       trigger={


### PR DESCRIPTION
## Changes
- Tooltip moved to bottom
- Update name bug fixed
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/Screener-Changes-80df26a9c2dc4c1bb2b7032b2631b749

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
![image](https://user-images.githubusercontent.com/6568353/172563552-2307c4f3-e23d-409a-8176-7c5293cd7e32.png)

