### PR TITLE
hover night mode color bug fixed

### DIFF
--- a/src/ducks/Watchlists/Widgets/TopBar/CreationInfoWrapper.svelte
+++ b/src/ducks/Watchlists/Widgets/TopBar/CreationInfoWrapper.svelte
@@ -27,7 +27,8 @@
   {votes}
   {onVote}
   {editLabel}
-  {titleHoverTooltipClass}>
+  {titleHoverTooltipClass}
+>
   <svelte:fragment slot="info">
     <div class="row mrg-s mrg--b">
       <Svg id="description" w="16" class="mrg-m mrg--r" />

--- a/src/pages/Explorer/Category/Category.svelte
+++ b/src/pages/Explorer/Category/Category.svelte
@@ -135,7 +135,7 @@
   .border .more {
     border-radius: 0;
     border-top: 1px solid var(--porcelain);
-    --bg-hover: #fbfcfe;
+    --bg-hover: var(--whale);
   }
 
   .center {
@@ -145,7 +145,7 @@
 
   .more.last,
   .isMain .item {
-    --bg-hover: #fbfcfe;
+    --bg-hover: var(--whale);
   }
 
   .isMain .item {


### PR DESCRIPTION
## Changes
- hardcoded color code replace with var
<!--- Describe your changes -->

## Notion's card
https://discord.com/channels/334289660698427392/646705213893378068/986903336584359966
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
![image](https://user-images.githubusercontent.com/6568353/174028973-36a565cb-6723-42fd-b1bc-7a742ffd50ef.png)

