### PR TITLE
Added Email preferences to settings

### DIFF
--- a/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/channels/TriggerChannelSettings.js
+++ b/src/ducks/Signals/signalFormManager/signalCrudForm/formParts/channels/TriggerChannelSettings.js
@@ -5,7 +5,6 @@ import ConnectTelegramBlock from '../../../../../../pages/Account/ConnectTelegra
 import SettingsTelegramNotifications from '../../../../../../pages/Account/SettingsTelegramNotifications'
 import SettingsEmailNotifications from '../../../../../../pages/Account/SettingsEmailNotifications'
 import SettingsSonarWebPushNotifications from '../../../../../../pages/Account/SettingsSonarWebPushNotifications'
-import ShowIf from '../../../../../../components/ShowIf/ShowIf'
 import { useDialogState } from '../../../../../../hooks/dialog'
 import styles from './TriggerChannelSettings.module.scss'
 
@@ -46,15 +45,11 @@ const TriggerChannelSettings = ({
           )}
 
           {showWebPush && (
-            <>
-              <ShowIf beta>
-                <SettingsSonarWebPushNotifications
-                  classes={styles}
-                  className={styles.notifications}
-                  recheckBrowserNotifications={recheckBrowserNotifications}
-                />
-              </ShowIf>
-            </>
+            <SettingsSonarWebPushNotifications
+              classes={styles}
+              className={styles.notifications}
+              recheckBrowserNotifications={recheckBrowserNotifications}
+            />
           )}
         </Dialog.ScrollContent>
       </Dialog>

--- a/src/pages/Account/AccountPage.js
+++ b/src/pages/Account/AccountPage.js
@@ -1,12 +1,14 @@
 import React from 'react'
 import { Redirect } from 'react-router-dom'
 import { HashLink as Link } from 'react-router-hash-link'
+import cx from 'classnames'
 import Tabs from '@santiment-network/ui/Tabs'
 import Button from '@santiment-network/ui/Button'
 import { DesktopOnly, MobileOnly } from '../../components/Responsive'
 import MobileHeader from './../../components/MobileHeader/MobileHeader'
 import SettingsGeneral from './SettingsGeneral'
 import SettingsConnections from './SettingsConnections'
+import SettingsEmailPreferences from './SettingsEmailPreferences/SettingsEmailPreferences'
 import SettingsNotifications from './SettingsNotifications'
 import SettingsGetTokens from './SettingsGetTokens'
 import SettingsAPIKeys from './SettingsAPIKeys'
@@ -57,13 +59,21 @@ const tabs = [
   {
     index: 5,
     content: (
+      <Link className={styles.tab} to='#email-preferences'>
+        Email Preferences
+      </Link>
+    ),
+  },
+  {
+    index: 6,
+    content: (
       <Link className={styles.tab} to='#get-tokens'>
         Get tokens
       </Link>
     ),
   },
   {
-    index: 6,
+    index: 7,
     content: (
       <Link className={styles.tab} to='#api-keys'>
         API keys
@@ -71,7 +81,7 @@ const tabs = [
     ),
   },
   {
-    index: 7,
+    index: 8,
     content: (
       <Link className={styles.tab} to='#sessions'>
         Sessions
@@ -79,7 +89,7 @@ const tabs = [
     ),
   },
   {
-    index: 8,
+    index: 9,
     content: (
       <Link className={styles.tab} to={ACCOUNT_PAGE_HASHES.subscription}>
         Subscription
@@ -112,12 +122,18 @@ const AccountPage = ({ history, location }) => {
       <MobileOnly>
         <MobileHeader title='Account settings' />
       </MobileOnly>
-      <Tabs className={styles.tabs} options={tabs} defaultSelectedIndex={selectedIndex} />
+      <Tabs
+        className={cx(styles.tabs, 'row justify')}
+        classes={{ tab: styles.tabWrapper }}
+        options={tabs}
+        defaultSelectedIndex={selectedIndex}
+      />
       <div className={styles.container}>
         <SettingsGeneral {...user} />
         <SettingsAffiliate />
         <SettingsConnections />
         <SettingsNotifications />
+        <SettingsEmailPreferences />
         <SettingsGetTokens />
         <SettingsAPIKeys />
         <SettingsSessions />

--- a/src/pages/Account/AccountPage.module.scss
+++ b/src/pages/Account/AccountPage.module.scss
@@ -6,14 +6,21 @@
 
 .title {
   color: var(--rhino);
-  margin-bottom: 21px;
 
   @include text('h3');
 }
 
 .tabs {
+  position: sticky;
+  top: 0;
   width: 100%;
+  padding-top: 20px;
+  flex-wrap: wrap;
   margin-bottom: 25px;
+  row-gap: 20px;
+  column-gap: 32px;
+  z-index: 1;
+  background-color: var(--white);
 
   @include responsive('phone', 'phone-xs') {
     padding: 0 20px;
@@ -28,6 +35,11 @@
       margin: 0;
     }
   }
+}
+
+.tabWrapper {
+  margin: 0;
+  padding: 0 0 15px !important;
 }
 
 .tab {

--- a/src/pages/Account/EmailSetting.js
+++ b/src/pages/Account/EmailSetting.js
@@ -35,8 +35,9 @@ const EmailSetting = ({
   const ref = useRef()
 
   useEffect(() => {
-    if (!ref) return
-    ref.current.inputRef.current.type = 'email'
+    if (ref && ref.current && ref.current.inputRef) {
+      ref.current.inputRef.current.type = 'email'
+    }
   }, [])
 
   const onSubmit = (value) => {

--- a/src/pages/Account/SettingsEmailPreferences/EmailPreference/EmailPreference.js
+++ b/src/pages/Account/SettingsEmailPreferences/EmailPreference/EmailPreference.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import cx from 'classnames'
+import { Link } from 'react-router-dom'
+import Toggle from '@santiment-network/ui/Toggle'
+import { useUpdateUserSettings } from '../../../../stores/user/settings'
+import { useUserSubscriptionStatus } from '../../../../stores/user/subscriptions'
+import styles from './EmailPreference.module.scss'
+
+const EmailPreference = ({ settings, title, description, isPro, settingsPropName, notProText }) => {
+  const [updateUserSettings] = useUpdateUserSettings()
+  const { isPro: isProStatus, isProPlus: isProPlusStatus } = useUserSubscriptionStatus()
+
+  const emailPreferenceSetting = settings[settingsPropName]
+
+  function handleUpdateEmailPreference() {
+    updateUserSettings({
+      [settingsPropName]: !emailPreferenceSetting,
+    })
+  }
+
+  const isDisabled = !isProStatus && !isProPlusStatus && notProText
+
+  return (
+    <div className='row fluid v-center justify'>
+      <div className={cx(styles.textWrapper, 'column')}>
+        <div className='row v-center txt-m c-black'>
+          {title}
+          {isPro && (
+            <div className={cx(styles.proBadge, 'mrg--l mrg-s caption txt-m c-white')}>PRO</div>
+          )}
+        </div>
+        <div className='c-waterloo'>
+          {description}
+          {isDisabled && (
+            <span>
+              <Link to='/pricing' className={cx(styles.link, 'mrg--l mrg--r mrg-xs txt-m')}>
+                Update your Plan
+              </Link>
+              {notProText}
+            </span>
+          )}
+        </div>
+      </div>
+      <div className='row v-center'>
+        {!isDisabled && <div className='mrg--r mrg-s'>{emailPreferenceSetting ? 'On' : 'Off'}</div>}
+        <Toggle
+          isActive={emailPreferenceSetting}
+          onClick={handleUpdateEmailPreference}
+          disabled={isDisabled}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default EmailPreference

--- a/src/pages/Account/SettingsEmailPreferences/EmailPreference/EmailPreference.module.scss
+++ b/src/pages/Account/SettingsEmailPreferences/EmailPreference/EmailPreference.module.scss
@@ -1,0 +1,17 @@
+.textWrapper {
+  gap: 6px;
+}
+
+.proBadge {
+  padding: 2px 8px;
+  background: var(--orange);
+  border-radius: 4px;
+}
+
+.link {
+  color: var(--orange);
+
+  &:hover {
+    color: var(--orange-hover);
+  }
+}

--- a/src/pages/Account/SettingsEmailPreferences/SettingsEmailPreferences.js
+++ b/src/pages/Account/SettingsEmailPreferences/SettingsEmailPreferences.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import cx from 'classnames'
+import Settings from '../Settings'
+import EmailPreference from './EmailPreference/EmailPreference'
+import { useUpdateUserSettings, useUserSettings } from '../../../stores/user/settings'
+import { EMAIL_PREFERENCES } from './constants'
+import styles from './SettingsEmailPreferences.module.scss'
+
+const SettingsEmailPreferences = () => {
+  const { settings } = useUserSettings()
+  const [updateUserSettings] = useUpdateUserSettings()
+
+  function handleUnsubscribeAll() {
+    updateUserSettings({
+      isSubscribedBiweeklyReport: false,
+      isSubscribedCommentsEmails: false,
+      isSubscribedEduEmails: false,
+      isSubscribedLikesEmails: false,
+      isSubscribedMarketingEmails: false,
+      isSubscribedMonthlyNewsletter: false,
+    })
+  }
+
+  return (
+    <Settings id='email-preferences' header='Email Preferences'>
+      {EMAIL_PREFERENCES.map((preference) => (
+        <Settings.Row key={preference.title}>
+          <EmailPreference {...preference} settings={settings} />
+        </Settings.Row>
+      ))}
+      <Settings.Row>
+        <div className='column mrg--t mrg--b mrg-s'>
+          <button className={cx(styles.btn, 'btn')} onClick={handleUnsubscribeAll}>
+            Unsubscribe from all of the above
+          </button>
+          <div className='c-waterloo'>
+            You will still receive important administrative emails, such as login information
+          </div>
+        </div>
+      </Settings.Row>
+    </Settings>
+  )
+}
+
+export default SettingsEmailPreferences

--- a/src/pages/Account/SettingsEmailPreferences/SettingsEmailPreferences.module.scss
+++ b/src/pages/Account/SettingsEmailPreferences/SettingsEmailPreferences.module.scss
@@ -1,0 +1,7 @@
+.btn {
+  --color: var(--green);
+  --color-hover: var(--green-hover);
+
+  max-width: 207px;
+  margin-bottom: 6px;
+}

--- a/src/pages/Account/SettingsEmailPreferences/constants.js
+++ b/src/pages/Account/SettingsEmailPreferences/constants.js
@@ -1,0 +1,48 @@
+export const EMAIL_PREFERENCES = [
+  {
+    title: 'Educational emails',
+    description:
+      'Learn about our features, receive Santiment case studies, and other educations materials',
+    settingsPropName: 'isSubscribedEduEmails',
+    isPro: false,
+    notProText: '',
+  },
+  {
+    title: 'Monthly newsletter',
+    description:
+      'Keep up to date with the latest news from the crypto markets, and learn about our newly announced insights and webinars',
+    settingsPropName: 'isSubscribedMonthlyNewsletter',
+    isPro: false,
+    notProText: '',
+  },
+  {
+    title: 'Marketing emails',
+    description: 'Don’t miss our special upgrade offers, limited-time events, and coupons',
+    settingsPropName: 'isSubscribedMarketingEmails',
+    isPro: false,
+    notProText: '',
+  },
+  {
+    title: 'Bi-weekly report',
+    description: 'Exclusive weekly reports for Pro users.',
+    settingsPropName: 'isSubscribedBiweeklyReport',
+    isPro: true,
+    notProText: 'to receive your first report from Santiment',
+  },
+  {
+    title: 'Comments',
+    description:
+      'Receive email notifications when someone comments on an insight or mentions you on Santiment',
+    settingsPropName: 'isSubscribedCommentsEmails',
+    isPro: false,
+    notProText: '',
+  },
+  {
+    title: 'Likes',
+    description:
+      'Receive email notifications when someone likes any of your insights or other items',
+    settingsPropName: 'isSubscribedLikesEmails',
+    isPro: false,
+    notProText: '',
+  },
+]

--- a/src/pages/Account/SettingsNotifications.js
+++ b/src/pages/Account/SettingsNotifications.js
@@ -4,7 +4,6 @@ import Settings from './Settings'
 import SettingsTelegramNotifications from './SettingsTelegramNotifications'
 import SettingsEmailNotifications from './SettingsEmailNotifications'
 import SettingsSonarWebPushNotifications from './SettingsSonarWebPushNotifications'
-import ShowIf from '../../components/ShowIf/ShowIf'
 import { filterByChannels, useSignals } from '../../ducks/Signals/common/getSignals'
 import { CHANNEL_TYPES } from '../../ducks/Signals/utils/constants'
 import { useUserSettings } from '../../stores/user/settings'
@@ -56,19 +55,17 @@ const SettingsNotifications = () => {
         />
       </Settings.Row>
 
-      <ShowIf beta>
-        <Settings.Row>
-          <SettingsSonarWebPushNotifications
-            count={countWithBrowserPush}
-            description={SignalsDescription(
-              countWithBrowserPush,
-              allCount,
-              CHANNEL_TYPES.Browser,
-              'web push',
-            )}
-          />
-        </Settings.Row>
-      </ShowIf>
+      <Settings.Row>
+        <SettingsSonarWebPushNotifications
+          count={countWithBrowserPush}
+          description={SignalsDescription(
+            countWithBrowserPush,
+            allCount,
+            CHANNEL_TYPES.Browser,
+            'web push',
+          )}
+        />
+      </Settings.Row>
 
       <Settings.Row>
         <SignalLimits alertsPerDayLimit={alertsPerDayLimit} classes={styles} />

--- a/src/pages/Account/SettingsSonarWebPushNotifications.js
+++ b/src/pages/Account/SettingsSonarWebPushNotifications.js
@@ -145,7 +145,7 @@ const SettingsSonarWebPushNotifications = ({
 
   return (
     <div className={cx(classes.container, styles.settingBlock, className)}>
-      <div className={classes.left}>
+      <div className={cx(classes.left, 'row v-center')}>
         <div className='row v-center'>
           <span className='mrg--r mrg-xs'>Push notifications</span>
           {count > 0 && (

--- a/src/stores/user/settings.js
+++ b/src/stores/user/settings.js
@@ -28,6 +28,12 @@ export const USER_SETTINGS_FRAGMENT = gql`
     hasTelegramConnected
     alertsPerDayLimit
     theme
+    isSubscribedBiweeklyReport
+    isSubscribedCommentsEmails
+    isSubscribedEduEmails
+    isSubscribedLikesEmails
+    isSubscribedMarketingEmails
+    isSubscribedMonthlyNewsletter
   }
 `
 
@@ -130,8 +136,9 @@ export function useUpdateUserSettings() {
 
   function update(newSettings) {
     const currentUser = getCurrentUser()
+    const { newsletterSubscription, ...otherSettings } = currentUser.settings
 
-    const merged = { ...currentUser.settings, ...newSettings }
+    const merged = { ...otherSettings, ...newSettings }
 
     if (typeof merged.alertsPerDayLimit === 'object') {
       merged.alertsPerDayLimit = JSON.stringify(merged.alertsPerDayLimit)


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Added email preferences to settings

## Notion's card

<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/Add-notification-switcher-likes-shares-to-account-settings-76e8c0ad67ef4919bf0d86b9ac61bed9

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
![Снимок экрана 2022-06-20 в 00 21 07](https://user-images.githubusercontent.com/46782114/174500755-c5e3bd57-9574-40eb-869b-b3c84af04e54.png)

