### PR TITLE
ctrl+click opens in a new tab bug fixed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,9 @@ window.__onLinkClick = (data) => {
 
   if (!href) return
 
-  if (href.includes(APP_LINK) || href.startsWith('/')) {
+  if (data && data.ctrlKey) {
+    window.open(href, '_blank')
+  } else if (href.includes(APP_LINK) || href.startsWith('/')) {
     history.push(href.replace('https://app.santiment.net', ''))
   } else {
     window.location.href = href

--- a/src/pages/Explorer/Layouts/ExplorerItem.svelte
+++ b/src/pages/Explorer/Layouts/ExplorerItem.svelte
@@ -7,36 +7,18 @@
   import AssetTags from '../Components/AssetTags.svelte'
   import Actions from '../Components/Actions.svelte'
   import { currentUser } from '../store'
-  import { history } from '../../../redux'
-  import { EntityType, getItemRoute } from '../const'
+  import { EntityType } from '../const'
 
   export let item
   export let type = 'CHART'
   export let url
   export let hasIcons = false
   export let assets = []
-
-  const ACTION_BUTTON_CLASS = 'actionbutton'
+  export let onClick = () => {}
 
   $: ({ user } = item)
   $: title = item.trigger ? item.trigger.title : item.title ? item.title : ''
   $: description = item.trigger ? item.trigger.description : item.description
-
-  function onClick(e) {
-    const isIcon = e.target && ['use', 'svg'].includes(e.target.tagName)
-    const isActionButton =
-      e.target.classList.contains(ACTION_BUTTON_CLASS) ||
-      (e.target.parentElement && e.target.parentElement.classList.contains(ACTION_BUTTON_CLASS))
-    if (isIcon || isActionButton) {
-      e.preventDefault()
-      return
-    }
-    if (url.includes(location.hostname)) {
-      e.preventDefault()
-      history.push(getItemRoute(item, type))
-      return
-    }
-  }
 </script>
 
 <a class="explorerItem" href={url} on:click={onClick}>

--- a/src/pages/Explorer/Layouts/LayoutItem.svelte
+++ b/src/pages/Explorer/Layouts/LayoutItem.svelte
@@ -1,7 +1,8 @@
 <script>
   import SidebarItem from '../Layouts/SidebarItem.svelte'
   import ExplorerItem from '../Layouts/ExplorerItem.svelte'
-  import { getItemUrl } from '../const'
+  import { getItemRoute, getItemUrl } from '../const'
+  import { history } from '../../../redux'
 
   export let small = false
   export let item
@@ -9,10 +10,33 @@
   export let showActions = false
   export let hasIcons = false
   export let assets = []
+
+  const ACTION_BUTTON_CLASS = 'actionbutton'
+
+  $: url = getItemUrl(item, type)
+
+  function onClick(e) {
+    const isIcon = e.target && ['use', 'svg'].includes(e.target.tagName)
+
+    const isActionButton =
+      e.target.classList.contains(ACTION_BUTTON_CLASS) ||
+      (e.target.parentElement && e.target.parentElement.classList.contains(ACTION_BUTTON_CLASS))
+
+    if (isIcon || isActionButton) {
+      e.preventDefault()
+      return
+    }
+
+    if (!e.ctrlKey && url.includes(location.hostname)) {
+      e.preventDefault()
+      history.push(getItemRoute(item, type))
+      return
+    }
+  }
 </script>
 
 {#if small}
-  <SidebarItem {item} {small} {type} {showActions} url={getItemUrl(item, type)} />
+  <SidebarItem {item} {small} {showActions} {url} {onClick} />
 {:else}
-  <ExplorerItem {item} {type} url={getItemUrl(item, type)} {hasIcons} {assets} />
+  <ExplorerItem {item} {type} {url} {hasIcons} {assets} {onClick} />
 {/if}

--- a/src/pages/Explorer/Layouts/SidebarItem.svelte
+++ b/src/pages/Explorer/Layouts/SidebarItem.svelte
@@ -4,29 +4,16 @@
   import Tooltip from 'webkit/ui/Tooltip/svelte'
   import Info from 'webkit/ui/Profile/Info.svelte'
   import { currentUser } from '../store'
-  import { history } from '../../../redux'
-  import { getItemRoute } from '../const'
 
   export let item = {}
   export let small = false
   export let url
-  export let type
+  export let onClick = () => {}
 
   let hoverActions = false
 
   $: totalVotes = item.votes.totalVotes
   $: ({ user, commentsCount } = item)
-
-  function onClick(e) {
-    if (['use', 'svg'].includes(e.target.tagName)) {
-      e.preventDefault()
-      return
-    }
-    if (url.includes(location.hostname)) {
-      e.preventDefault()
-      history.push(getItemRoute(item, type))
-    }
-  }
 </script>
 
 <a href={url} target="_blank" on:click={onClick} class="hoverable {hoverActions && 'forcehover'}">


### PR DESCRIPTION
## Changes
- Check for `ctrlKey` property added
- duplicate codes removed

<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/ctrl-click-not-working-on-some-links-0f882d47b0444bbd971e98293c4e2227
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

