### PR TITLE
default value for isPublic changed to true

### DIFF
--- a/src/ducks/Watchlists/Actions/Edit/EditForm/index.js
+++ b/src/ducks/Watchlists/Actions/Edit/EditForm/index.js
@@ -193,7 +193,7 @@ export default ({ settings = {}, ...props }) => (
     defaultSettings={{
       name: '',
       description: '',
-      isPublic: false,
+      isPublic: true,
       listItems: props.watchlist ? props.watchlist.listItems : [],
       ...settings,
     }}


### PR DESCRIPTION
## Changes
- default value for isPublic changed to true
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/Make-Public-setting-as-default-while-creating-saving-a-watchlist-or-screener-a19438073bc74851b72fe76b6925b521
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

![image](https://user-images.githubusercontent.com/6568353/175479904-2aa14ba7-4028-4ae8-9d54-e2adec2965f6.png)
