### PR TITLE
not show delete action for not owner fixed

### DIFF
--- a/src/ducks/Watchlists/Widgets/Table/CompareInfo/Actions/index.js
+++ b/src/ducks/Watchlists/Widgets/Table/CompareInfo/Actions/index.js
@@ -6,6 +6,7 @@ import Delete from './Delete'
 import Copy from './Copy'
 import SaveAs from './SaveAs'
 import styles from './Actions.module.scss'
+import { useUser } from '../../../../../../stores/user'
 
 const reportError = (err) =>
   store.dispatch(
@@ -17,6 +18,10 @@ const reportError = (err) =>
   )
 
 const Actions = ({ selected, watchlist, onAdd, onRemove, assets }) => {
+  const {user} = useUser()
+  const watchlistUserId = watchlist && watchlist.user.id
+  const isOwner = watchlistUserId === user.id
+
   const selectedText = useMemo(
     () => `${selected.length} ${selected.length > 1 ? 'items' : 'item'}`,
     [selected],
@@ -43,18 +48,18 @@ const Actions = ({ selected, watchlist, onAdd, onRemove, assets }) => {
   }
 
   return (
-    <>
-      <div className={styles.actions}>
-        <Copy
-          selectedText={selectedText}
-          watchlist={watchlist}
-          assets={assets}
-          selected={selected}
-        />
-        <SaveAs selectedText={selectedText} watchlist={watchlist} />
+    <div className={styles.actions}>
+      <Copy
+        selectedText={selectedText}
+        watchlist={watchlist}
+        assets={assets}
+        selected={selected}
+      />
+      <SaveAs selectedText={selectedText} watchlist={watchlist} />
+      {isOwner &&
         <Delete selected={selected} onRemove={removeHandler} selectedText={selectedText} />
-      </div>
-    </>
+      }
+    </div>
   )
 }
 

--- a/src/ducks/Watchlists/Widgets/Table/CompareInfo/Actions/index.js
+++ b/src/ducks/Watchlists/Widgets/Table/CompareInfo/Actions/index.js
@@ -19,8 +19,12 @@ const reportError = (err) =>
 
 const Actions = ({ selected, watchlist, onAdd, onRemove, assets }) => {
   const { user, isLoggedIn } = useUser()
-  const watchlistUserId = isLoggedIn && watchlist && watchlist.user.id
-  const isOwner = isLoggedIn && watchlistUserId === user.id
+  let isOwner = false
+
+  if (isLoggedIn) {
+    const watchlistUserId = watchlist && watchlist.user.id
+    isOwner = watchlistUserId === user.id
+  }
 
   const selectedText = useMemo(
     () => `${selected.length} ${selected.length > 1 ? 'items' : 'item'}`,

--- a/src/ducks/Watchlists/Widgets/Table/CompareInfo/Actions/index.js
+++ b/src/ducks/Watchlists/Widgets/Table/CompareInfo/Actions/index.js
@@ -18,9 +18,9 @@ const reportError = (err) =>
   )
 
 const Actions = ({ selected, watchlist, onAdd, onRemove, assets }) => {
-  const {user} = useUser()
-  const watchlistUserId = watchlist && watchlist.user.id
-  const isOwner = watchlistUserId === user.id
+  const { user, isLoggedIn } = useUser()
+  const watchlistUserId = isLoggedIn && watchlist && watchlist.user.id
+  const isOwner = isLoggedIn && watchlistUserId === user.id
 
   const selectedText = useMemo(
     () => `${selected.length} ${selected.length > 1 ? 'items' : 'item'}`,
@@ -49,16 +49,11 @@ const Actions = ({ selected, watchlist, onAdd, onRemove, assets }) => {
 
   return (
     <div className={styles.actions}>
-      <Copy
-        selectedText={selectedText}
-        watchlist={watchlist}
-        assets={assets}
-        selected={selected}
-      />
+      <Copy selectedText={selectedText} watchlist={watchlist} assets={assets} selected={selected} />
       <SaveAs selectedText={selectedText} watchlist={watchlist} />
-      {isOwner &&
+      {isOwner && (
         <Delete selected={selected} onRemove={removeHandler} selectedText={selectedText} />
-      }
+      )}
     </div>
   )
 }

--- a/src/ducks/Watchlists/Widgets/Table/CompareInfo/Actions/index.js
+++ b/src/ducks/Watchlists/Widgets/Table/CompareInfo/Actions/index.js
@@ -5,8 +5,8 @@ import NotificationActions from '../../../../../../components/NotificationAction
 import Delete from './Delete'
 import Copy from './Copy'
 import SaveAs from './SaveAs'
-import styles from './Actions.module.scss'
 import { useUser } from '../../../../../../stores/user'
+import styles from './Actions.module.scss'
 
 const reportError = (err) =>
   store.dispatch(


### PR DESCRIPTION
## Changes
- `isOwner` check added to guard showing delete action
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/delete-item-for-not-owner-0c4ce2e9d7a1443aa1050dace33c30e8
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

![image](https://user-images.githubusercontent.com/6568353/176120173-4e327b37-6f13-4789-97a4-6672eb0d917b.png)
