### PR TITLE
displayingTypes bugs fixed

### DIFF
--- a/src/pages/Explorer/Category/ExplorerCategory.svelte
+++ b/src/pages/Explorer/Category/ExplorerCategory.svelte
@@ -42,7 +42,7 @@
     return items.filter((item) => !deletedSet.has(getExplorerItem(item)))
   }
 
-  function getDisplayingType() {
+  function getDisplayingType(displayingTypes) {
     if (displayingTypes.size < 1) return filterableTabKeys
 
     const values = new Set(displayingTypes)
@@ -80,7 +80,7 @@
     }
     if (!bypassLoading) loading = true
     queryExplorerItems({
-      types: getDisplayingType(),
+      types: getDisplayingType(displayingTypes),
       voted,
       range,
       page,
@@ -128,7 +128,14 @@
 
 <Category isMain title="Explorer" {items} onMore={() => (page += 1)} hasMore={page < pages}>
   <div slot="header" class="controls row mrg-a mrg--l">
-    <TypeSelector flat onChange={(newTypes) => (displayingTypes = newTypes)} {displayingTypes} />
+    <TypeSelector
+      flat
+      onChange={(newTypes) => {
+        displayingTypes = newTypes
+        page = 1
+      }}
+      {displayingTypes}
+    />
   </div>
 
   <svelte:fragment let:item>


### PR DESCRIPTION
## Changes
- reset `page` to 1 when user changes the displaying types added to prevent conflict
- `getDisplayingType` argument added to make it reactive
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/filter-by-entity-type-bug-b411fcff877b40c583954c40b2f584b9
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

