### PR TITLE
open pro popup for free users bug fixeD

### DIFF
--- a/src/components/ProPopup/Wrapper.js
+++ b/src/components/ProPopup/Wrapper.js
@@ -42,7 +42,14 @@ const MODULE = {
   },
 }
 
-const ProPopupWrapper = ({ type, trigger: Trigger, children, className }) => {
+const ProPopupWrapper = ({
+  type,
+  trigger: Trigger,
+  children,
+  className,
+  toggleOpen,
+  isOpen = false,
+}) => {
   const { isPro } = useUserSubscriptionStatus()
   const module = TypeAlias[type] || type
 
@@ -53,6 +60,8 @@ const ProPopupWrapper = ({ type, trigger: Trigger, children, className }) => {
   return (
     <ProPopup
       trigger={Trigger ? <Trigger /> : <div className={className}>{children}</div>}
+      isOpen={isOpen}
+      toggleOpen={toggleOpen}
       {...MODULE[module]}
     />
   )

--- a/src/components/ProPopup/index.js
+++ b/src/components/ProPopup/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import Button from '@santiment-network/ui/Button'
@@ -7,22 +7,18 @@ import styles from './index.module.scss'
 
 const EMPTY_ARRAY = []
 
-const ProPopup = ({ title, description, features, ...props }) => {
-  const [isOpen, setOpen] = useState(false)
-
-  const onOpenClick = () => setOpen(true)
-  const onCloseClick = () => setOpen(false)
+const ProPopup = ({
+  title,
+  description,
+  features,
+  toggleOpen = () => {},
+  isOpen = false,
+  ...props
+}) => {
+  const onCloseClick = () => toggleOpen(false)
 
   return (
-    <Dialog
-      size='m'
-      title={title}
-      open={isOpen}
-      onOpen={onOpenClick}
-      onClose={onCloseClick}
-      classes={styles}
-      {...props}
-    >
+    <Dialog size='m' title={title} open={isOpen} onClose={onCloseClick} classes={styles} {...props}>
       <div className={styles.container}>
         <div className={styles.description}>{description}</div>
         <div className={styles.features}>

--- a/src/ducks/Watchlists/Actions/SaveAs/index.js
+++ b/src/ducks/Watchlists/Actions/SaveAs/index.js
@@ -17,7 +17,15 @@ const SaveAs = ({ watchlist, trigger, type, prefix = 'Duplicate', open, customTo
   const { closeDialog, isOpened, toggleOpen } = useDialogState(false)
 
   if (type === SCREENER && !isPro) {
-    return <ProPopupWrapper type={type}>{trigger}</ProPopupWrapper>
+    return (
+      <ProPopupWrapper
+        isOpen={open}
+        type={type}
+        toggleOpen={customToggleOpen ? customToggleOpen : toggleOpen}
+      >
+        {trigger}
+      </ProPopupWrapper>
+    )
   }
 
   if (!isLoggedIn) {

--- a/src/ducks/Watchlists/Widgets/TopBar/TopBar.js
+++ b/src/ducks/Watchlists/Widgets/TopBar/TopBar.js
@@ -162,7 +162,6 @@ const TopBar = ({
             watchlist={entity}
             type={type}
             open={isEditFormOpened}
-            trigger={<></>}
             customToggleOpen={setIsEditFormOpened}
           />
         )}

--- a/src/pages/Explorer/Category/ExplorerCategory.svelte
+++ b/src/pages/Explorer/Category/ExplorerCategory.svelte
@@ -132,7 +132,8 @@
   {items}
   {loading}
   onMore={() => (page += 1)}
-  hasMore={page < pages}>
+  hasMore={page < pages}
+>
   <div slot="header" class="controls row mrg-a mrg--l">
     <TypeSelector
       flat
@@ -140,7 +141,8 @@
         displayingTypes = newTypes
         page = 1
       }}
-      {displayingTypes} />
+      {displayingTypes}
+    />
   </div>
 
   <svelte:fragment let:item>
@@ -150,13 +152,15 @@
         showActions
         type="CHART"
         hasIcons
-        assets={getAssets(item.chartConfiguration)} />
+        assets={getAssets(item.chartConfiguration)}
+      />
     {:else if item.screener}
       <LayoutItem
         item={item.screener}
         showActions
         type="SCREENER"
-        id="{item.screener.id}-watchlist" />
+        id="{item.screener.id}-watchlist"
+      />
     {:else if item.projectWatchlist}
       <LayoutItem item={item.projectWatchlist} showActions type="WATCHLIST" />
     {:else if item.addressWatchlist}
@@ -164,7 +168,8 @@
         item={item.addressWatchlist}
         showActions
         type="ADDRESS"
-        assets={getAddressLabels(item.addressWatchlist.listItems)} />
+        assets={getAddressLabels(item.addressWatchlist.listItems)}
+      />
     {:else if item.userTrigger}
       <LayoutItem item={item.userTrigger} showActions type="ALERT" hasIcons />
     {/if}

--- a/src/pages/Explorer/Components/ActionButton.svelte
+++ b/src/pages/Explorer/Components/ActionButton.svelte
@@ -18,14 +18,16 @@
     class="actionbutton row hv-center"
     class:padding={!isLike}
     slot="trigger"
-    on:click={isLike ? undefined : onClick}>
+    on:click={isLike ? undefined : onClick}
+  >
     {#if isLike}
       <LikeButton
         totalVotes={counter}
         {userVotes}
         onVote={onClick}
         hasBorder={false}
-        class="$style.like" />
+        class="$style.like"
+      />
     {:else}
       <Svg id={svgid} w={width} class="$style.svg" />
       {#if counter >= 0}


### PR DESCRIPTION
## Changes
- `toggleOpen` and `isOpen` props added to `ProPopup` component
- internal state tracker for `isOpen` removed in `ProPopup` component
- 
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/free-user-save-as-screeners-bug-399af4b8ee634647baaa746d9784e50a
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

