### PR TITLE
mobile upates: part 1 done

### DIFF
--- a/src/components/Loader/PageLoader.module.scss
+++ b/src/components/Loader/PageLoader.module.scss
@@ -12,8 +12,6 @@
     position: fixed;
     left: 0;
     right: 0;
-    top: 50%;
-    margin-top: -25vh;
   }
 
   &__img {

--- a/src/components/MobileNavbar/MobileNavbar.js
+++ b/src/components/MobileNavbar/MobileNavbar.js
@@ -6,7 +6,6 @@ import Button from '@santiment-network/ui/Button'
 import MobileNavbarAction from './MobileNavbarAction'
 import SantimentLogo from './SantimentLogo'
 import AssetsIcon from './AssetsIcon'
-import FeedIcon from './FeedIcon'
 import InsightsIcon from './InsightsIcon'
 import WatchlistsIcon from './WatchlistsIcon'
 import MenuIcon from './MenuIcon'
@@ -15,11 +14,6 @@ import ContactUs from '../ContactUs/ContactUs'
 import styles from './MobileNavbar.module.scss'
 
 const NAVBAR_LINKS = [
-  {
-    label: 'Feed',
-    linkTo: '/feed',
-    Icon: FeedIcon,
-  },
   {
     label: 'Market',
     linkTo: '/assets',

--- a/src/ducks/Page/index.module.scss
+++ b/src/ducks/Page/index.module.scss
@@ -11,8 +11,8 @@
   @media only screen and (max-width: 1170px) {
     .header,
     .main {
-      padding-left: 16px;
-      padding-right: 16px;
+      padding-left: 20px;
+      padding-right: 20px;
     }
   }
 }
@@ -46,8 +46,8 @@
 @include responsive('phone', 'phone-xs') {
   .header,
   .main {
-    padding-left: 16px;
-    padding-right: 16px;
+    padding-left: 20px;
+    padding-right: 20px;
   }
 
   .title {

--- a/src/pages/Assets/index.js
+++ b/src/pages/Assets/index.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { Redirect } from 'react-router-dom'
 import Section from '../Watchlists/Section'
 import Page from '../../ducks/Page'
-import StoriesList from '../../components/Stories/StoriesList'
 import Trends from '../../components/Trends/Trends'
 import RecentlyWatched from '../../components/RecentlyWatched/RecentlyWatched'
 import FeaturedWatchlistCards from '../../ducks/Watchlists/Cards/Featured'
@@ -15,8 +14,6 @@ const Assets = ({ isDesktop }) => {
 
   return (
     <Page title='Explore assets' className={styles.wrapper}>
-      <StoriesList classes={styles} />
-
       <RecentlyWatched type='assets' />
 
       <Section title='Indices'>

--- a/src/pages/Watchlists/index.js
+++ b/src/pages/Watchlists/index.js
@@ -3,7 +3,6 @@ import Section, { Title, Content } from './Section'
 import Page from '../../ducks/Page'
 import { useUser } from '../../stores/user'
 import { DesktopOnly, MobileOnly } from '../../components/Responsive'
-import StoriesList from '../../components/Stories/StoriesList'
 import RecentlyWatched from '../../components/RecentlyWatched/RecentlyWatched'
 import WatchlistCard from '../../ducks/Watchlists/Cards/ProjectCard'
 import WatchlistAddressCard from '../../ducks/Watchlists/Cards/AddressCard'
@@ -106,7 +105,6 @@ const Watchlists = ({ isDesktop }) => {
       isWithPadding={!isDesktop}
     >
       <MobileOnly>
-        <StoriesList classes={styles} />
         <RecentlyWatched type='watchlists' />
       </MobileOnly>
 


### PR DESCRIPTION
## Changes
- Update spacing from content to edges 20px
- Remove Feed (first section)  
- Hide stories
- Move loading to the center of the page
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/Mobile-fixes-Iter-1-Part-1-cf7bd56a84b04ed48c87602df65d8820
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
![image](https://user-images.githubusercontent.com/6568353/179908647-0dfaba69-244d-41ad-a933-27dd9932c936.png)
![image](https://user-images.githubusercontent.com/6568353/179908676-62743628-c508-452d-ad5c-86c982feae3d.png)

