### PR TITLE
Fixed modal width

### DIFF
--- a/src/ducks/Alert/AlertModal.js
+++ b/src/ducks/Alert/AlertModal.js
@@ -80,7 +80,12 @@ const AlertModal = ({
           )
         }
         classes={{
-          dialog: cx(styles.dialog, isClosing && styles.hidden, isPreview && styles.preview),
+          dialog: cx(
+            styles.dialog,
+            isClosing && styles.hidden,
+            isPreview && styles.preview,
+            isRecommendedSignal && styles.recommended,
+          ),
           title: cx(styles.dialogTitle, isMobile && 'body-2 txt-m'),
         }}
       >

--- a/src/ducks/Alert/AlertModal.module.scss
+++ b/src/ducks/Alert/AlertModal.module.scss
@@ -30,9 +30,12 @@
   visibility: hidden;
 }
 
-.preview {
+.recommended {
   max-width: 496px;
   width: 100%;
+}
+
+.preview {
   max-height: unset;
   height: auto;
 }


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Fixed modal width of alerts

## Notion's card

<!--- Issue to which the pull request is related -->
https://discord.com/channels/334289660698427392/491515703548182528/1019739994358816849

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

