### PR TITLE
Fixed insights text size and color

### DIFF
--- a/src/pages/Explorer/Layouts/ExplorerItem.svelte
+++ b/src/pages/Explorer/Layouts/ExplorerItem.svelte
@@ -47,7 +47,7 @@
           Insights
         </div>
       </div>
-      <InsightText text={pulseText} class="$style.text body-2" />
+      <InsightText text={pulseText} class="$style.text body-3 c-waterloo" />
       {#if showShowReadMore}
         <div class="readMore fluid row h-center">
           <button class="btn-2">Read more</button>


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Fixed pulse insights text and color on Explorer page

## Notion's card

<!--- Issue to which the pull request is related -->
-

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
<img width="705" alt="Снимок экрана 2022-09-15 в 12 19 27" src="https://user-images.githubusercontent.com/46782114/190366540-22df5396-77e2-4aa7-b123-0ebd900032a6.png">

