### PR TITLE
infographic styles fixed

### DIFF
--- a/src/ducks/SANCharts/tooltip/CommonChartTooltip.module.scss
+++ b/src/ducks/SANCharts/tooltip/CommonChartTooltip.module.scss
@@ -23,6 +23,8 @@
 .title {
   color: var(--rhino);
   padding: 8px 14px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
   border-bottom: 1px solid var(--porcelain);
   background: var(--bgcolor, var(--athens));
 

--- a/src/ducks/Watchlists/Widgets/VolumeChart/ColorsExplanation.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/ColorsExplanation.js
@@ -13,9 +13,9 @@ const TREEMAP_COLORS = [
 ]
 
 export const COLOR_MAPS = {
-  10: TREEMAP_COLORS[0],
-  5: TREEMAP_COLORS[1],
-  1: TREEMAP_COLORS[2],
+  '+10': TREEMAP_COLORS[0],
+  '+5': TREEMAP_COLORS[1],
+  '+1': TREEMAP_COLORS[2],
   0: TREEMAP_COLORS[3],
   '-1': TREEMAP_COLORS[4],
   '-5': TREEMAP_COLORS[5],
@@ -24,11 +24,11 @@ export const COLOR_MAPS = {
 
 export const getTreeMapColor = (value) => {
   if (value > 10) {
-    return COLOR_MAPS['10']
+    return COLOR_MAPS['+10']
   } else if (value > 5) {
-    return COLOR_MAPS['5']
+    return COLOR_MAPS['+5']
   } else if (value > 1) {
-    return COLOR_MAPS['1']
+    return COLOR_MAPS['+1']
   } else if (value <= 1 && value >= -1) {
     return COLOR_MAPS['0']
   } else if (value >= -5) {
@@ -40,7 +40,7 @@ export const getTreeMapColor = (value) => {
   }
 }
 
-const COLORS = ['-10', '-5', '-1', '0', '1', '5', '10']
+const COLORS = ['-10', '-5', '-1', '0', '+1', '+5', '+10']
 
 const DATE_MAPS = {
   '24h': "today's",
@@ -59,7 +59,7 @@ const ColorsExplanation = ({ colorMaps, range }) => {
         {COLORS.map((key) => {
           return (
             <div key={key} className={styles.card} style={{ backgroundColor: colorMaps[key] }}>
-              {key}%
+              {key}{key !== '0' && '%'}
             </div>
           )
         })}

--- a/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.js
@@ -38,12 +38,11 @@ const renderCustomizedLabel = (props) => {
 
   const xValue = x + width / 2
   const yValue = y + position
-  const translateY = +value >= 0 ? -10 : 8
+  const translateY = +value > 0 ? -10 : 8
   const barValue = getBarValue(+value)
-  const shouldRotate = width < 40 && barValue.toString().length > 3
 
   return (
-    <g style={{ transform: shouldRotate && `translateY(${translateY}px)` }}>
+    <g style={{ transform: `translateY(${translateY}px)` }}>
       <text
         x={xValue}
         y={yValue}
@@ -51,8 +50,8 @@ const renderCustomizedLabel = (props) => {
         textAnchor='middle'
         fontSize={fontSize}
         fontWeight={500}
-        dominant-baseline={shouldRotate && 'central'}
-        transform={shouldRotate && `rotate(270, ${xValue}, ${yValue})`}
+        dominant-baseline={'central'}
+        transform={`rotate(270, ${xValue}, ${yValue})`}
       >
         {value && barValue}
       </text>

--- a/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.module.scss
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/ProjectsChart.module.scss
@@ -3,7 +3,7 @@
 .container {
   display: flex;
   flex-direction: column;
-  margin: 0 32px 0 32px;
+  margin: 0 32px 40px 32px;
 }
 
 .chartWrapper {

--- a/src/pages/Watchlist/Infographics/index.module.scss
+++ b/src/pages/Watchlist/Infographics/index.module.scss
@@ -11,7 +11,7 @@
 }
 
 .treeMaps {
-  margin: 0 32px 24px 32px;
+  margin: 8px 32px 32px 32px;
 }
 
 .twoTrees {


### PR DESCRIPTION
## Changes
- `COLOR_MAPS` const updated
- `ProjectsChart` updated
- styles fixed
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/Infographic-paddings-fix-84fff5903b414c2098228021f7d57ddb
https://www.figma.com/file/ZK4JWoABGW3XTt2dRxIWmU/Sanbase%3A-Explorer
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
![image](https://user-images.githubusercontent.com/6568353/190589813-633d6d77-c355-464d-aa82-6c32a5395491.png)
![image](https://user-images.githubusercontent.com/6568353/190589887-1c20a3e9-a6c7-4e22-b4e1-896457519e82.png)
![image](https://user-images.githubusercontent.com/6568353/190589949-edbbe1db-9a12-4885-8005-0d794455366b.png)

