### PR TITLE
Added zero balanced tokens to historical balance

### DIFF
--- a/src/ducks/HistoricalBalance/Address/AssetsDistribution.js
+++ b/src/ducks/HistoricalBalance/Address/AssetsDistribution.js
@@ -19,7 +19,6 @@ const COLORS = [
 const MAX_COLOR_PROJECTS = COLORS.length
 const MAX_DESCRIBED_PROJECTS = 6
 
-export const existingAssetsFilter = ({ balanceUsd }) => balanceUsd
 export const distributionSorter = ({ balanceUsd: a }, { balanceUsd: b }) => b - a
 const checkIsSmallDistribution = (percent) => percent < 0.5
 const smallDistributionFinder = ({ percent }) => checkIsSmallDistribution(percent)
@@ -30,7 +29,7 @@ export function useDistributions(walletAssets) {
   return useMemo(() => {
     if (projects.length === 0) return []
 
-    const sortedAssets = walletAssets.filter(existingAssetsFilter).sort(distributionSorter)
+    const sortedAssets = walletAssets.sort(distributionSorter)
     const { length } = sortedAssets
     const distributions = new Array(length)
     let totalBalance = 0

--- a/src/ducks/HistoricalBalance/Address/CurrentBalance.js
+++ b/src/ducks/HistoricalBalance/Address/CurrentBalance.js
@@ -1,10 +1,6 @@
 import React, { useMemo } from 'react'
 import cx from 'classnames'
-import {
-  distributionSorter,
-  existingAssetsFilter,
-  CollapsedDistributions,
-} from './AssetsDistribution'
+import { distributionSorter, CollapsedDistributions } from './AssetsDistribution'
 import { useProjects, getProjectInfo } from '../../../stores/projects'
 import { millify } from '../../../utils/formatting'
 import styles from './CurrentBalance.module.scss'
@@ -31,7 +27,7 @@ export function useCurrentBalance(walletAssets) {
   return useMemo(() => {
     if (projects.length === 0) return { distributions: [] }
 
-    const sortedAssets = walletAssets.filter(existingAssetsFilter).sort(distributionSorter)
+    const sortedAssets = walletAssets.sort(distributionSorter)
     const { length } = sortedAssets
     const distributions = new Array(length)
 

--- a/src/ducks/HistoricalBalance/queries.js
+++ b/src/ducks/HistoricalBalance/queries.js
@@ -2,7 +2,10 @@ import gql from 'graphql-tag'
 
 export const WALLET_ASSETS_QUERY = gql`
   query assetsHeldByAddress($address: String!, $infrastructure: String!) {
-    assetsHeldByAddress(selector: { address: $address, infrastructure: $infrastructure }) {
+    assetsHeldByAddress(
+      selector: { address: $address, infrastructure: $infrastructure }
+      showAssetsWithZeroBalance: true
+    ) {
       slug
       balance
       balanceUsd

--- a/src/ducks/Watchlists/Widgets/VolumeChart/ColorsExplanation.js
+++ b/src/ducks/Watchlists/Widgets/VolumeChart/ColorsExplanation.js
@@ -59,7 +59,8 @@ const ColorsExplanation = ({ colorMaps, range }) => {
         {COLORS.map((key) => {
           return (
             <div key={key} className={styles.card} style={{ backgroundColor: colorMaps[key] }}>
-              {key}{key !== '0' && '%'}
+              {key}
+              {key !== '0' && '%'}
             </div>
           )
         })}


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
There was a request from @balance to show zero balanced tokens in Historical Balance page in order to understand that we can track them via our tools

## Notion's card

<!--- Issue to which the pull request is related -->
https://discord.com/channels/334289660698427392/646705213893378068/1020324170736865301

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

<img width="1321" alt="Снимок экрана 2022-09-16 в 17 36 17" src="https://user-images.githubusercontent.com/46782114/190664521-0b337f72-3f38-4ee2-b3c0-0e0948b723fa.png">
