### PR TITLE
pagination dropdown zindex fixed

### DIFF
--- a/src/ducks/Table/Pagination/index.module.scss
+++ b/src/ducks/Table/Pagination/index.module.scss
@@ -8,7 +8,6 @@
   background-color: var(--white);
   z-index: 23;
   position: relative;
-  overflow: hidden;
 }
 
 .totalPages {

--- a/src/ducks/Watchlists/Widgets/Table/index.module.scss
+++ b/src/ducks/Watchlists/Widgets/Table/index.module.scss
@@ -15,6 +15,7 @@
   bottom: 0;
   left: 40px;
   right: 0;
+  z-index: 23 !important;
 }
 
 .headerColumn {


### PR DESCRIPTION
## Changes
- Styles fixed
<!--- Describe your changes -->

## Notion's card
https://discord.com/channels/334289660698427392/636880296347959316/1023982612433338388
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

![image](https://user-images.githubusercontent.com/6568353/192331762-8de3dd33-afef-4b7d-b06f-e43b84f60f1a.png)
