### PR TITLE
fix/mobile-asset-chart-tooltip

### DIFF
--- a/src/ducks/SANCharts/tooltip/MobilePriceTooltip.module.scss
+++ b/src/ducks/SANCharts/tooltip/MobilePriceTooltip.module.scss
@@ -3,10 +3,6 @@
 .wrapper {
   background: var(--white);
   width: calc(50vw - 16px);
-
-  @media (orientation: landscape) {
-    width: 30vw;
-  }
 }
 
 .price {
@@ -16,13 +12,6 @@
   min-height: 40px;
 
   @include text('h3');
-
-  @media (orientation: landscape) {
-    @include text('body-1', 'l');
-
-    min-height: 26px;
-    margin-bottom: 0;
-  }
 }
 
 .date {
@@ -31,8 +20,4 @@
   margin-bottom: 6px;
 
   @include text('caption');
-
-  @media (orientation: landscape) {
-    @include text('caption');
-  }
 }

--- a/src/pages/Detailed/mobile/MobileAssetChart.js
+++ b/src/pages/Detailed/mobile/MobileAssetChart.js
@@ -86,9 +86,10 @@ const MobileAssetChart = ({
           />
           {isTouch && (
             <Tooltip
+              wrapperStyle={{ zIndex: 999999, position: 'fixed' }}
               isAnimationActive={false}
               cursor={{ stroke: 'var(--casper)' }}
-              position={{ x: 0, y: isLandscapeMode ? -49 : -62.5 }}
+              position={{ x: 0, y: 0 }}
               content={(props) => (
                 <>
                   <MobilePriceTooltip {...props} labelFormatter={tooltipLabelFormatter} />


### PR DESCRIPTION
## Changes
Displaying hovered asset mobile chart info 


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
![CleanShot 2022-09-27 at 12 00 27@2x](https://user-images.githubusercontent.com/25135650/192482469-76e596e2-3491-4ee7-9351-ce0f82a1477f.jpg)

![CleanShot 2022-09-27 at 11 59 38@2x](https://user-images.githubusercontent.com/25135650/192482246-209bf3c0-295f-413a-a9ff-6beadcfc8bc3.jpg)


