### PR TITLE
enhance/footer-google-play-link-removed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29615,8 +29615,8 @@
       "from": "git+https://github.com/santiment/san-studio.git#65afee1"
     },
     "san-webkit": {
-      "version": "git+https://github.com/santiment/san-webkit.git#2b10ec09db4714102078b23667c068005c1a0729",
-      "from": "git+https://github.com/santiment/san-webkit.git#2b10ec0",
+      "version": "git+https://github.com/santiment/san-webkit.git#fdce93de627d1f133ef3cce2205fde1dc79f34f3",
+      "from": "git+https://github.com/santiment/san-webkit.git#fdce93d",
       "requires": {
         "@types/gtag.js": "0.0.4",
         "@types/jest": "^26.0.23",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "rxjs": "5.x.x",
     "san-insights": "https://github.com/santiment/insights-app#0137632",
     "san-studio": "https://github.com/santiment/san-studio#65afee1",
-    "san-webkit": "https://github.com/santiment/san-webkit#2b10ec0",
+    "san-webkit": "https://github.com/santiment/san-webkit#fdce93d",
     "san-queries": "https://github.com/santiment/san-queries#0f5250c",
     "sanitize-html": "^1.18.2",
     "svg-sprite": "1.5.0",

--- a/src/pages/ProMetrics/ProMetricsFooter/CommonFooter.js
+++ b/src/pages/ProMetrics/ProMetricsFooter/CommonFooter.js
@@ -2,9 +2,8 @@ import React from 'react'
 import cx from 'classnames'
 import SocialMediaLinks from '../../../components/SocialMediaLinks/SocialMediaLinks'
 import SubscriptionForm from '../../../components/SubscriptionForm/SubscriptionForm'
-import downloadLinkSvg from './../../../assets/google-play.svg'
-import styles from './CommonFooter.module.scss'
 import Version from '../../../components/Version/Version'
+import styles from './CommonFooter.module.scss'
 
 const LEFT_LINKS = [
   {
@@ -186,18 +185,6 @@ const CommonFooter = ({ className }) => {
                 subscribeBtnLabel='Subscribe'
                 subscriptionLabel='Send me weekly updates from crypto market'
               />
-            </div>
-
-            <div className={styles.appBlock}>
-              <div className={styles.downloadTitle}>Download Santiment app</div>
-              <a
-                href='https://play.google.com/store/apps/details?id=net.santiment.sanbase.android'
-                target='_blank'
-                rel='noopener noreferrer'
-                className={styles.downloadLink}
-              >
-                <img src={downloadLinkSvg} alt='Google play' />
-              </a>
             </div>
           </div>
         </div>

--- a/src/pages/ProMetrics/ProMetricsFooter/CommonFooter.module.scss
+++ b/src/pages/ProMetrics/ProMetricsFooter/CommonFooter.module.scss
@@ -260,15 +260,6 @@
   flex: 1;
 }
 
-.appBlock {
-  display: flex;
-  flex-direction: column;
-
-  @include responsive('tablet', 'laptop') {
-    margin-right: 100px;
-  }
-}
-
 .subcriptionTitle {
   @include text('body-2', 'm');
 
@@ -283,27 +274,6 @@
     @include text('body-2', 'l');
 
     margin-bottom: 16px;
-  }
-}
-
-.downloadLink {
-  width: 136px;
-}
-
-.downloadTitle {
-  @include text('body-2', 'm');
-
-  color: var(--waterloo);
-  margin: 24px 0 12px 0;
-
-  @include responsive('phone', 'phone-xs') {
-    @include text('body-2', 'l');
-
-    margin: 40px 0 16px 0;
-  }
-
-  @include responsive('laptop', 'tablet') {
-    margin: 0 0 10px 0;
   }
 }
 


### PR DESCRIPTION
## Changes
Google Play app link removed from a footer

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

