### PR TITLE
feature/dashboard-eth-staking-pools-distributions-charts

### DIFF
--- a/src/components/DashboardMetricChart/DashboardMetricChart.js
+++ b/src/components/DashboardMetricChart/DashboardMetricChart.js
@@ -89,6 +89,10 @@ const DashboardMetricChart = ({
   onLoad,
   projectSelector,
   canvasSettings,
+  useMetricsData = useTimeseries,
+  noBrush = false,
+  noIntervals = false,
+  isSharedAxisDefault = false,
 }) => {
   const MetricTransformer = useMirroredTransformer(metrics)
   const [MetricSettingsMap] = useState(new Map())
@@ -121,23 +125,29 @@ const DashboardMetricChart = ({
     [metrics, disabledMetrics],
   )
 
-  const [data, loadings] = useTimeseries(
+  const [data, loadings] = useMetricsData(
     activeMetrics,
     settings,
     MetricSettingsMap,
     MetricTransformer,
   )
 
-  const { allTimeData, allTimeDataLoadings, onBrushChangeEnd } = useBrush({
-    settings,
-    setSettings,
-    data,
-    metrics,
-    slug: metrics[0].reqMeta.slug,
-  })
+  const {
+    allTimeData = data,
+    allTimeDataLoadings = [],
+    onBrushChangeEnd,
+  } = noBrush
+    ? {}
+    : useBrush({
+        settings,
+        setSettings,
+        data,
+        metrics,
+        slug: metrics[0].reqMeta.slug,
+      })
 
   const [isDomainGroupingActive, setIsDomainGroupingActive] = useState(
-    domainGroups && domainGroups.length > mirrorDomainGroups.length,
+    isSharedAxisDefault || (domainGroups && domainGroups.length > mirrorDomainGroups.length),
   )
 
   const MetricColor = useChartColors(activeMetrics, metricsColor)
@@ -212,11 +222,13 @@ const DashboardMetricChart = ({
             disabledMetrics={disabledMetrics}
             colors={MetricColor}
           />
-          <DashIntervalSettings
-            metrics={metrics}
-            settings={settings}
-            updateInterval={updateSettingsMap}
-          />
+          {noIntervals ? null : (
+            <DashIntervalSettings
+              metrics={metrics}
+              settings={settings}
+              updateInterval={updateSettingsMap}
+            />
+          )}
         </div>
       </DesktopOnly>
 
@@ -243,11 +255,13 @@ const DashboardMetricChart = ({
           setInterval={onChangeInterval}
           intervals={intervals}
         />
-        <DashIntervalSettings
-          metrics={metrics}
-          settings={settings}
-          updateInterval={updateSettingsMap}
-        />
+        {noIntervals ? null : (
+          <DashIntervalSettings
+            metrics={metrics}
+            settings={settings}
+            updateInterval={updateSettingsMap}
+          />
+        )}
         <DashboardChartMetrics
           metrics={metrics}
           loadings={loadings}

--- a/src/pages/Dashboards/constants.js
+++ b/src/pages/Dashboards/constants.js
@@ -102,7 +102,6 @@ export const DASHBOARDS = [
         title: 'Total Staked in USD',
         key: 'total-staked',
       },
-      /*
       {
         title: 'Staking Pool Distributions',
         key: 'distributions',
@@ -111,7 +110,6 @@ export const DASHBOARDS = [
         title: 'Staking Pool Distributions Delta',
         key: 'distributions-delta',
       },
-      */
     ],
     Content: EthStakingPools,
   },

--- a/src/pages/Dashboards/dashboards/EthStakingPools/index.js
+++ b/src/pages/Dashboards/dashboards/EthStakingPools/index.js
@@ -1,9 +1,82 @@
-import React from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
+import { query } from 'webkit/api'
 import Header from '../Header/Header'
 import { Block } from '../../../StablecoinsPage/StablecoinsPageStructure'
 import EthStakingPools from '../../../../ducks/Eth2.0/EthStakingPools/EthStakingPools'
 import { withRenderQueueProvider } from '../../../../ducks/renderQueue/viewport'
+import { QueuedDashboardMetricChart as DashboardMetricChart } from '../../../../components/DashboardMetricChart/DashboardMetricChart'
 import dashboardsStyles from '../dashboards.module.scss'
+
+const QUERY = `query getMetric($metric: String!, $from: DateTime!, $to: DateTime!) {
+getMetric(metric:$metric) {
+    histogramData(selector: {slug: "ethereum"}, from: $from, to: $to, interval: "1d", limit: 10) {
+      values {
+        ... on Eth2StakingPoolsValidatorsCountOverTimeList {
+          data {
+            d:datetime
+            v:value {
+              s:stakingPool
+              v:valuation
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+const metricsMapper = (key) => ({
+  key,
+  label: key,
+  node: 'line',
+  domainGroup: 'eth2',
+})
+
+const DistributionBtcOnEth = ({ metric }) => {
+  const [metrics, setMetrics] = useState([])
+
+  const useMetricsData = useCallback((_metrics, settings) => {
+    const [data, setData] = useState([])
+    const [loadings, setLoadings] = useState([{}])
+    const { from, to } = settings
+
+    useEffect(() => {
+      const assets = new Set()
+
+      query(QUERY, {
+        variables: { metric, from, to },
+      })
+        .then(({ getMetric }) => getMetric.histogramData.values.data)
+        .then((data) =>
+          data.map(({ d, v }) => {
+            const item = { datetime: Date.parse(d) }
+            v.forEach(({ s, v }) => {
+              if (assets.size < 10) assets.add(s)
+              item[s] = v
+            })
+            setMetrics([...assets].map(metricsMapper))
+            return item
+          }),
+        )
+        .then((data) => {
+          setData(data)
+          setLoadings([])
+        })
+    }, [from, to])
+
+    return [data, loadings]
+  }, [])
+
+  return (
+    <DashboardMetricChart
+      noBrush
+      noIntervals
+      isSharedAxisDefault
+      metrics={metrics}
+      useMetricsData={useMetricsData}
+    />
+  )
+}
 
 const EthStakingPoolsPage = ({ submenu, shareLinkText, description }) => (
   <div className='column fluid'>
@@ -14,6 +87,14 @@ const EthStakingPoolsPage = ({ submenu, shareLinkText, description }) => (
       </Block>
       <Block title={submenu[1].title} tag={submenu[1].key}>
         <EthStakingPools metric='eth2_staking_pools_usd' />
+      </Block>
+
+      <Block title={submenu[2].title} tag={submenu[2].key}>
+        <DistributionBtcOnEth metric='eth2_staking_pools_validators_count_over_time' />
+      </Block>
+
+      <Block title={submenu[3].title} tag={submenu[3].key}>
+        <DistributionBtcOnEth metric='eth2_staking_pools_validators_count_over_time_delta' />
       </Block>
     </div>
   </div>


### PR DESCRIPTION
## Changes
Displaying `Staking Pool Distributions` and `Staking Pool Distributions Delta` charts in `Ethereum Staking Pools` dashboard.

## Notion's card
https://www.notion.so/santiment/ETH-staking-pool-dashboard-a4d7ca57e50a4a3fb00169814f7c7569

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

![CleanShot 2022-10-06 at 19 16 24@2x](https://user-images.githubusercontent.com/25135650/194365398-0f55ffdb-ed78-488d-9d44-d685e5c343ec.jpg)
![CleanShot 2022-10-06 at 19 16 33@2x](https://user-images.githubusercontent.com/25135650/194365422-57021269-b571-4f5d-bb4f-dd962af475c2.jpg)
