### PR TITLE
views moved and only available for moderators

### DIFF
--- a/src/pages/Explorer/Components/Actions.svelte
+++ b/src/pages/Explorer/Components/Actions.svelte
@@ -28,6 +28,7 @@
   $: id = item.trigger ? item.trigger.id : item.id
   $: ({ key, voteKey, deleteKey, singular } = EntityType[type])
   $: isPublic = item.trigger ? item.trigger.isPublic : item.isPublic
+  $: views = item.trigger ? item.trigger.views : item.views
 
   const filterExplorerItems = getContext('filterExplorerItems')
   const updateExplorerItem = getContext('updateExplorerItem')
@@ -160,6 +161,7 @@
         {/if}
         <ActionButton svgid="eye-crossed" onClick={onHide} tooltip="Hide" />
         <ActionButton svgid="delete" onClick={onDelete} tooltip="Delete" />
+        <ActionButton svgid="eye" tooltip="Views" counter={views} hasbackground={false} />
       {/if}
     {/if}
   </div>

--- a/src/pages/Explorer/Layouts/ExplorerItem.svelte
+++ b/src/pages/Explorer/Layouts/ExplorerItem.svelte
@@ -8,7 +8,6 @@
   import AssetIcons from '../Components/AssetIcons.svelte'
   import AssetTags from '../Components/AssetTags.svelte'
   import Actions from '../Components/Actions.svelte'
-  import ActionButton from '../Components/ActionButton.svelte'
 
   export let item
   export let type = 'CHART'
@@ -28,7 +27,6 @@
   $: description = item.trigger ? item.trigger.description : item.description
   $: type === 'INSIGHT' && project && loadPrice()
   $: if (pulseInsightHeight >= 400) showShowReadMore = true
-  $: views = item.trigger ? item.trigger.views : item.views
 
   function loadPrice() {
     queryPriceSincePublication(project.slug, publishedAt).then((result) => (projectData = result))
@@ -95,7 +93,6 @@
             ? limitUsername(user.username)
             : user.email}
         </div>
-        <ActionButton svgid="eye" tooltip="Views" counter={views} hasbackground={false} />
         <div class="row v-center">
           <Actions {item} {type} />
         </div>


### PR DESCRIPTION
## Changes
- views moved to moderators section
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/Explorer-bugs-57168da2c6bb4c7680422071cf3c853f
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

![image](https://user-images.githubusercontent.com/6568353/196421654-ae7fe5ec-6264-417d-b111-9fcdbe5d5c9c.png)
