### PR TITLE
Explorer trending tab added, favoriates removed

### DIFF
--- a/src/pages/Explorer/Category/ExplorerCategory.svelte
+++ b/src/pages/Explorer/Category/ExplorerCategory.svelte
@@ -36,7 +36,7 @@
   $: favorites = activeMenu === MenuItem.FAVORITES
   $: currentUserDataOnly = activeMenu === MenuItem.MY_CREATIONS
   $: userRoleDataOnly = activeMenu === MenuItem.SANTIMENT
-  $: isFeaturedDataOnly = activeMenu === MenuItem.SANTIMENT
+  $: isFeaturedDataOnly = [MenuItem.TRENDING, MenuItem.SANTIMENT].includes(activeMenu)
   $: range, assets, displayingTypes, page, fetch()
   $: displayingTypes, filterInsights()
   $: onLoadingChange(loading)
@@ -92,7 +92,7 @@
       page: insightsPage,
     })
       .then((res) => {
-        if (activeMenu === MenuItem.FAVORITES) {
+        if (activeMenu === MenuItem.TRENDING) {
           insightsPages = res.pages
           insights = insightsPage === 1 ? res.items : insights.concat(res.items)
         }
@@ -156,7 +156,7 @@
   }
 
   onMount(() => {
-    if (activeMenu === MenuItem.FAVORITES) {
+    if (activeMenu === MenuItem.TRENDING) {
       queryExplorerItems({
         types: getDisplayingType(displayingTypes),
         voted,

--- a/src/pages/Explorer/Components/EmptyState.svelte
+++ b/src/pages/Explorer/Components/EmptyState.svelte
@@ -10,7 +10,7 @@
     <EmptyCreations id="rocket" action="like" title="No liked" />
   {:else if activeMenu === MenuItem.MY_CREATIONS}
     <EmptyCreations id="browser" action="make" title="No" />
-  {:else if activeMenu === MenuItem.NEW || activeMenu === MenuItem.FAVORITES}
+  {:else if activeMenu === MenuItem.NEW || activeMenu === MenuItem.TRENDING}
     <EmptyCreations
       id="browser"
       description="There are no entities for your filtering"

--- a/src/pages/Explorer/Components/ExplorerFilter.svelte
+++ b/src/pages/Explorer/Components/ExplorerFilter.svelte
@@ -9,12 +9,12 @@
 <div class="wrapper row hv-center mrg--b mrg-xl">
   <div
     class="btn-2 row v-center"
-    class:active={activeMenu === MenuItem.FAVORITES}
-    class:loading={activeMenu === MenuItem.FAVORITES && loading}
-    on:click={() => !loading && (activeMenu = MenuItem.FAVORITES)}
+    class:active={activeMenu === MenuItem.TRENDING}
+    class:loading={activeMenu === MenuItem.TRENDING && loading}
+    on:click={() => !loading && (activeMenu = MenuItem.TRENDING)}
   >
-    <Svg id="star" w="16" class="mrg--r" />
-    Favorites
+    <Svg id="fire" w="16" class="mrg--r" />
+    Trending
   </div>
   <div
     class="btn-2 row v-center"

--- a/src/pages/Explorer/const.js
+++ b/src/pages/Explorer/const.js
@@ -6,6 +6,7 @@ export const MenuItem = {
   NEW: 'New',
   LIKES: 'Likes',
   MY_CREATIONS: 'My creations',
+  TRENDING: 'Trending',
 }
 
 export const EntityKeys = {

--- a/src/pages/Explorer/index.svelte
+++ b/src/pages/Explorer/index.svelte
@@ -8,7 +8,7 @@
   export let user = {}
   export let userSubscriptionData = {}
 
-  let activeMenu = MenuItem.FAVORITES
+  let activeMenu = MenuItem.TRENDING
   let loading = true
 
   $: currentUser.set(user)


### PR DESCRIPTION
## Changes
- FAVORITES tab removed
- TRENDING tab added
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/Explorer-trending-9173cd1ca1fd45f58fd928047d848125

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

![image](https://user-images.githubusercontent.com/6568353/196426829-b3af8da3-021e-4ee2-a79b-8b9c5b672f58.png)
