### PR TITLE
Redirecting old trends to new dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9555,7 +9555,7 @@
     "css-color-function": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/css-color-function/-/css-color-function-1.3.3.tgz",
-      "integrity": "sha512-YD/WhiRZIYgadwFJ48X5QmlOQ/w8Me4yQI6/eSUoiE8spIFp+S/rGpsAH48iyq/0ZWkCDWqVQKUlQmUzn7BQ9w==",
+      "integrity": "sha1-jtJMLAIFBzM5+voAS8jBQfzLKC4=",
       "dev": true,
       "requires": {
         "balanced-match": "0.1.0",
@@ -9567,19 +9567,19 @@
         "balanced-match": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
-          "integrity": "sha512-4xb6XqAEo3Z+5pEDJz33R8BZXI8FRJU+cDNLdKgDpmnz+pKKRVYLpdv+VvUAC7yUhBMj4izmyt19eCGv1QGV7A==",
+          "integrity": "sha1-tQS9BYabOSWd0MXvw12EMXbczEo=",
           "dev": true
         },
         "clone": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
           "dev": true
         },
         "color": {
           "version": "0.11.4",
           "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-          "integrity": "sha512-Ajpjd8asqZ6EdxQeqGzU5WBhhTfJ/0cA4Wlbre7e5vXfmDSmda7Ov6jeKoru+b0vHcb1CqvuroTHp5zIWzhVMA==",
+          "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
           "dev": true,
           "requires": {
             "clone": "^1.0.2",
@@ -9590,7 +9590,7 @@
         "color-string": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-          "integrity": "sha512-sz29j1bmSDfoAxKIEU6zwoIZXN6BrFbAMIhfYCNyiZXBDuU/aiHlN84lp/xDzL2ubyFhLDobHIlU1X70XRrMDA==",
+          "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
           "dev": true,
           "requires": {
             "color-name": "^1.0.0"
@@ -16491,7 +16491,7 @@
     "isnumeric": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/isnumeric/-/isnumeric-0.2.0.tgz",
-      "integrity": "sha512-uSJoAwnN1eCKDFKi8hL3UCYJSkQv+NwhKzhevUPIn/QZ8ILO21f+wQnlZHU0eh1rsLO1gI4w/HQdeOSTKwlqMg==",
+      "integrity": "sha1-ojR7o2DeGeM9D/1ZD933dVy/LmQ=",
       "dev": true
     },
     "isobject": {
@@ -20933,7 +20933,7 @@
     "pixrem": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pixrem/-/pixrem-4.0.1.tgz",
-      "integrity": "sha512-sFMGjkE42jNwAMBvBdWSx9f6MGZfufkfChzLxow7JmKY6XHWpNqLIwTQABcJOek0LCdtNf22cdL5fYzKLELmCA==",
+      "integrity": "sha1-LaSh3m7EQjxfw3lOkwuB1EkOxoY=",
       "dev": true,
       "requires": {
         "browserslist": "^2.0.0",
@@ -21038,7 +21038,7 @@
     "pleeease-filters": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-4.0.0.tgz",
-      "integrity": "sha512-EtyjMK41s2+q/eM6wED/9U5bWzowfP/ImQb9AxKzt/+Xlbb5CxQ7dAToEoSQuxyidmkZzHAl483m2sBm2XvfFw==",
+      "integrity": "sha1-ZjKy+wVkjSdY2GU4T7zteeHMrsc=",
       "dev": true,
       "requires": {
         "onecolor": "^3.0.4",
@@ -21157,7 +21157,7 @@
     "postcss-apply": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/postcss-apply/-/postcss-apply-0.8.0.tgz",
-      "integrity": "sha512-J8HDo5oAW4HSZ8rsSQrfUC4kRurHZFzNC0gGIrJEuRu0imobXMtPhAXQN7d44eDXKWshABjtFxowbQi8OIznwg==",
+      "integrity": "sha1-FOVEu7XLbxweBIhXll15rgZrE0M=",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.23.0",
@@ -21168,7 +21168,7 @@
         "balanced-match": {
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha512-STw03mQKnGUYtoNjmowo4F2cRmIIxYEGiMsjjwla/u5P1lxadj/05WkNaFjNiKTgJkj8KiXbgAiRTmcQRwQNtg==",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         },
         "postcss": {
@@ -21381,7 +21381,7 @@
     "postcss-color-hsl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-color-hsl/-/postcss-color-hsl-2.0.0.tgz",
-      "integrity": "sha512-4DNpOj3NWejHtjV4mLxf+rmE1KA+IKDJH8QSThgJOrjGFuiqOPxkFSZX1RQJ+XQISZD3MW/JDaZoNnmxS9pSBQ==",
+      "integrity": "sha1-EnA2ZvoxBDDj8wpFTawThjF9WEQ=",
       "dev": true,
       "requires": {
         "postcss": "^6.0.1",
@@ -21411,7 +21411,7 @@
     "postcss-color-hwb": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-color-hwb/-/postcss-color-hwb-3.0.0.tgz",
-      "integrity": "sha512-53CnpaKZKKiuQ2KvVStY4uVYnp2UCSUCDGYnW2sbe4oJBq3/H4eCcO4My2cMv3l8czsh3yBRLNA9Ls8IwqARhA==",
+      "integrity": "sha1-NAKxnvTYSXVAwftQcr6YY8qVVx4=",
       "dev": true,
       "requires": {
         "color": "^1.0.3",
@@ -21423,7 +21423,7 @@
         "color": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/color/-/color-1.0.3.tgz",
-          "integrity": "sha512-HWCZFEr1styyDW4BAYpeDtVrUfTzPK0XOxs8izgcGofpl/T9U2m5f7cYjcPKorrCLKDrFlmcHciMdktwxr1btw==",
+          "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.8.2",
@@ -21513,7 +21513,7 @@
     "postcss-color-rgb": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-color-rgb/-/postcss-color-rgb-2.0.0.tgz",
-      "integrity": "sha512-oGgwvqUHEz4CYmbwUwQ4LwIr4Wqw9p1r+6fJFQqdZPp+ulXFsmJ1cAqJ+V7x5VoNMOuAi1e3UPyJ01JpUtX+Vw==",
+      "integrity": "sha1-FFOcinExSUtILg3RzCZf9lFLUmM=",
       "dev": true,
       "requires": {
         "postcss": "^6.0.1",
@@ -21542,7 +21542,7 @@
     "postcss-color-rgba-fallback": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-3.0.0.tgz",
-      "integrity": "sha512-RBCHHCQ0sVJH+y31jiVSLBM/b3vvfiU8g9tyAglpF7NOuYzcw41Tu+iGEm8B2zVEAYYgEhWCASNY/j4Wh3vi4w==",
+      "integrity": "sha1-N9XJNToHoJJwkSqCYGu0Kg1wLAQ=",
       "dev": true,
       "requires": {
         "postcss": "^6.0.6",
@@ -21698,7 +21698,7 @@
         "caniuse-api": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-2.0.0.tgz",
-          "integrity": "sha512-425yJRcUDCCMKc0Zga2KSUe7Qp7nCtL8H0BJIsDxF9yMzG2eSYvOggi5U1wXzxgcSgDGnzVLvZ8dZGMBrA6Ltg==",
+          "integrity": "sha1-sd21pZZrFvSNxJmERNS7xsfZ2DQ=",
           "dev": true,
           "requires": {
             "browserslist": "^2.0.0",
@@ -21737,7 +21737,7 @@
         "postcss-attribute-case-insensitive": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-2.0.0.tgz",
-          "integrity": "sha512-J8sdzNF8glKA0ZpNLOftTaNu12a48wJ97sVDTYGRR6gX8cSoRE4tXoVgYRemFz3TvSurbmVuMQUmqUclA0hL/Q==",
+          "integrity": "sha1-lNxCLI+QmX8WvTOjZUu77AhJY7Q=",
           "dev": true,
           "requires": {
             "postcss": "^6.0.0",
@@ -21783,7 +21783,7 @@
         "postcss-color-hex-alpha": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-3.0.0.tgz",
-          "integrity": "sha512-Tpg2yEBcdE0e7jJSyRaLinX8xqf4geXIBClhbSA3hhnpXELJcqfvoRD8V9RHV6oYyoR/vyS3dCg1EuCEw6CvhQ==",
+          "integrity": "sha1-HlPmyKyyN5Vej9CLfs2xuLgwn5U=",
           "dev": true,
           "requires": {
             "color": "^1.0.3",
@@ -21794,7 +21794,7 @@
             "color": {
               "version": "1.0.3",
               "resolved": "https://registry.npmjs.org/color/-/color-1.0.3.tgz",
-              "integrity": "sha512-HWCZFEr1styyDW4BAYpeDtVrUfTzPK0XOxs8izgcGofpl/T9U2m5f7cYjcPKorrCLKDrFlmcHciMdktwxr1btw==",
+              "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
               "dev": true,
               "requires": {
                 "color-convert": "^1.8.2",
@@ -21816,7 +21816,7 @@
         "postcss-custom-media": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-6.0.0.tgz",
-          "integrity": "sha512-MLjf2Yghub+USZpLWCB11hLrEEaCWM4lYf4UR9ui3iPCQFdywvEaY5yt4PnOClGrACGaHTNKPF9koiZLdJOmYw==",
+          "integrity": "sha1-vlMnhBEOyylQRPtTlaGABushpzc=",
           "dev": true,
           "requires": {
             "postcss": "^6.0.1"
@@ -21835,7 +21835,7 @@
         "postcss-custom-selectors": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-4.0.1.tgz",
-          "integrity": "sha512-mXhdsA16oq2xbXhIJs6LscTq8peUrvAD4w6I8+BhfIK5ZQH2sVjSM1xYJdadFBfR8MISg4466I+V860Hi68PfQ==",
+          "integrity": "sha1-eBOC+UxS5yfvXKR3bqKt9JphE4I=",
           "dev": true,
           "requires": {
             "postcss": "^6.0.1",
@@ -21845,7 +21845,7 @@
         "postcss-font-variant": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-3.0.0.tgz",
-          "integrity": "sha512-zZ89AX55J3Bfn6xQBOwNV75I+4Mqj7fhILlwu2KT+pDC3Xsu5vI0YQil3Q1imJQGhN5XnN/DMFQp+UvV91IXig==",
+          "integrity": "sha1-CMzIj2BQuoLtjvLMdsDGprQfGD4=",
           "dev": true,
           "requires": {
             "postcss": "^6.0.1"
@@ -21854,7 +21854,7 @@
         "postcss-initial": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-2.0.0.tgz",
-          "integrity": "sha512-XiU1taLGTuHjr/9QMrGMA3Y6zIIxlUudHL7XwLDepPPNSp8pJTYkv5VCQC8IynXGsXa3FKzNJ37eZdfsI71NjA==",
+          "integrity": "sha1-cnFfczbgu3k1HZnuZcSiU6hEG6Q=",
           "dev": true,
           "requires": {
             "lodash.template": "^4.2.4",
@@ -21864,7 +21864,7 @@
         "postcss-media-minmax": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-3.0.0.tgz",
-          "integrity": "sha512-lYwGbUhk6+8NSMJ4P2T4+Zi0tbHUDFgdHXC4zTe/P7zkIk+lRuaEpZcZFzlL3dxWarnwc6ImpDV4MGBV4uDDXg==",
+          "integrity": "sha1-Z1JWA3pD70C8Twdgv9BtTcadSNI=",
           "dev": true,
           "requires": {
             "postcss": "^6.0.1"
@@ -21882,7 +21882,7 @@
         "postcss-pseudo-class-any-link": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-4.0.0.tgz",
-          "integrity": "sha512-xindgr9qqu6HDnHKk7lJSIII6nvNmGKxIb8BOUUfteLctichwaNEGtwWvq66Sc/EuTu/bK/+fAyLRwWkPx/nFA==",
+          "integrity": "sha1-kVKgYT00UHIFE+iJKFS65C0O5o4=",
           "dev": true,
           "requires": {
             "postcss": "^6.0.1",
@@ -21892,7 +21892,7 @@
         "postcss-replace-overflow-wrap": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-2.0.0.tgz",
-          "integrity": "sha512-JNYt+DiUQiCtsy17cqcHQlCJ5huBPDq8F49hlnTd747GCMvaUEq4ouI0QR0E38zdKs1ptnzhoGYwm6mvpbeD5w==",
+          "integrity": "sha1-eU22+qVPjbEAhUOSqTr0V2i04ls=",
           "dev": true,
           "requires": {
             "postcss": "^6.0.1"
@@ -21901,7 +21901,7 @@
         "postcss-selector-matches": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-3.0.1.tgz",
-          "integrity": "sha512-R8p740Ufx5ho+agdlZ389OOOrylLJGMWwnpbm9LBoV/L4aL12MRR+zuGWJo03XYUAeXtAggSEnn6wngoSOqweQ==",
+          "integrity": "sha1-5WNAEeE5UIgYYbvdWMLQER/8lqs=",
           "dev": true,
           "requires": {
             "balanced-match": "^0.4.2",
@@ -21911,7 +21911,7 @@
             "balanced-match": {
               "version": "0.4.2",
               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-              "integrity": "sha512-STw03mQKnGUYtoNjmowo4F2cRmIIxYEGiMsjjwla/u5P1lxadj/05WkNaFjNiKTgJkj8KiXbgAiRTmcQRwQNtg==",
+              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
               "dev": true
             }
           }
@@ -21919,7 +21919,7 @@
         "postcss-selector-not": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-3.0.1.tgz",
-          "integrity": "sha512-Tt/45Rvaj3I/nCHHMG3L9ioiJjI2YEk8lsvQbko+N6wrOBfLOx0yk51DMT3Ynhd7GzQwXinzeO3gYnwtUe83pA==",
+          "integrity": "sha1-Lk2y8JZTNsAefOx9tsYN/3ZzNdk=",
           "dev": true,
           "requires": {
             "balanced-match": "^0.4.2",
@@ -21929,7 +21929,7 @@
             "balanced-match": {
               "version": "0.4.2",
               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-              "integrity": "sha512-STw03mQKnGUYtoNjmowo4F2cRmIIxYEGiMsjjwla/u5P1lxadj/05WkNaFjNiKTgJkj8KiXbgAiRTmcQRwQNtg==",
+              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
               "dev": true
             }
           }
@@ -21937,7 +21937,7 @@
         "postcss-selector-parser": {
           "version": "2.2.3",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-          "integrity": "sha512-3pqyakeGhrO0BQ5+/tGTfvi5IAUAhHRayGK8WFSu06aEv2BmHoXw/Mhb+w7VY5HERIuC+QoUI7wgrCcq2hqCVA==",
+          "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
           "dev": true,
           "requires": {
             "flatten": "^1.0.2",
@@ -22596,7 +22596,7 @@
     "postcss-image-set-polyfill": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/postcss-image-set-polyfill/-/postcss-image-set-polyfill-0.3.5.tgz",
-      "integrity": "sha512-4Df/0UNixbXqkw8k+j4CWbicfeZe8/pzkePgBRwWk+iA8wpz1r9ac0YZoXAFAtGISGrw+2d+Kzm/RItZIlu43Q==",
+      "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "dev": true,
       "requires": {
         "postcss": "^6.0.1",
@@ -23177,7 +23177,7 @@
     "postcss-message-helpers": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-      "integrity": "sha512-tPLZzVAiIJp46TBbpXtrUAKqedXSyW5xDEo1sikrfEfnTs+49SBZR/xDdqCiJvSSbtr615xDsaMF3RrxS2jZlA==",
+      "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
       "dev": true
     },
     "postcss-minify-font-values": {
@@ -23998,7 +23998,7 @@
     "postcss-pseudoelements": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-pseudoelements/-/postcss-pseudoelements-5.0.0.tgz",
-      "integrity": "sha512-XHKyn37k6nm8R9C1g+PXisjp5Y8ISOpeuQe9IVCAe5I2+t2WVBtF3YhS1TsRz3asMkW1zg+tIe6g7eX/sT/QOg==",
+      "integrity": "sha1-7vGU6NUkZFylIKlJ6V5RjoEkAss=",
       "dev": true,
       "requires": {
         "postcss": "^6.0.0"
@@ -27700,7 +27700,7 @@
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
       "dev": true,
       "requires": {
         "pify": "^2.3.0"
@@ -28796,13 +28796,13 @@
     "rgb": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/rgb/-/rgb-0.1.0.tgz",
-      "integrity": "sha512-F49dXX73a92N09uQkfCp2QjwXpmJcn9/i9PvjmwsSIXUGqRLCf/yx5Q9gRxuLQTq248kakqQuc8GX/U/CxSqlA==",
+      "integrity": "sha1-vieykej+/+rBvZlylyG/pA/AN7U=",
       "dev": true
     },
     "rgb-hex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/rgb-hex/-/rgb-hex-2.1.0.tgz",
-      "integrity": "sha512-1hDa60MqECZiEGsa9TtcOE9VbV6fhZSMQARy7U+a2HkhIJyoEBhcG4v/qYAJYzV3Bbj+j52sBoAIKKF5EPuQZw==",
+      "integrity": "sha1-x3PF/iJoolV42SU5qCp6XOU77aY=",
       "dev": true
     },
     "rgb-regex": {
@@ -29615,8 +29615,8 @@
       "from": "git+https://github.com/santiment/san-studio.git#d22bbbd"
     },
     "san-webkit": {
-      "version": "git+https://github.com/santiment/san-webkit.git#2aeab55dca761d53273054dd16e2b2c2c138dd63",
-      "from": "git+https://github.com/santiment/san-webkit.git#2aeab55",
+      "version": "git+https://github.com/santiment/san-webkit.git#de818d0d28a19065e37353acf84de33b3e06c26b",
+      "from": "git+https://github.com/santiment/san-webkit.git#de818d0",
       "requires": {
         "@types/gtag.js": "0.0.4",
         "@types/jest": "^26.0.23",
@@ -34611,7 +34611,7 @@
     "units-css": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
-      "integrity": "sha512-WijzYC+chwzg2D6HmNGUSzPAgFRJfuxVyG9oiY28Ei5E+g6fHoPkhXUr5GV+5hE/RTHZNd9SuX2KLioYHdttoA==",
+      "integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
       "dev": true,
       "requires": {
         "isnumeric": "^0.2.0",
@@ -34895,7 +34895,7 @@
     "viewport-dimensions": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
-      "integrity": "sha512-94JqlKxEP4m7WO+N3rm4tFRGXZmXXwSPQCoV+EPxDnn8YAGiLU3T+Ha1imLreAjXsHl0K+ELnIqv64i1XZHLFQ==",
+      "integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w=",
       "dev": true
     },
     "vinyl": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "rxjs": "5.x.x",
     "san-insights": "https://github.com/santiment/insights-app#0137632",
     "san-studio": "https://github.com/santiment/san-studio#d22bbbd",
-    "san-webkit": "https://github.com/santiment/san-webkit#2aeab55",
+    "san-webkit": "https://github.com/santiment/san-webkit#de818d0",
     "san-queries": "https://github.com/santiment/san-queries#0f5250c",
     "sanitize-html": "^1.18.2",
     "svg-sprite": "1.5.0",

--- a/src/App.js
+++ b/src/App.js
@@ -397,6 +397,7 @@ export const App = ({
             <Redirect from='/sonar/signal/:id' to={`/alerts/:id/${search}`} />
             <Redirect from='/sonar/my-signals' to={`/alerts${search}`} />
             <Redirect from='/sonar/my-alerts' to={`/alerts${search}`} />
+            <Redirect from='/dashboards/labs/trends' to='/dashboards/social-tool' />
             <Route path='/logout' component={LogoutPage} />
             <Route
               exact

--- a/src/ducks/TrendsTable/columns.js
+++ b/src/ducks/TrendsTable/columns.js
@@ -1,5 +1,4 @@
 import React, { memo } from 'react'
-import cx from 'classnames'
 import { Link } from 'react-router-dom'
 import { Skeleton } from '../../components/Skeleton'
 import MiniChart from '../../components/MiniChart'

--- a/src/pages/Dashboards/dashboards/SocialTool/TopTrends/TopBar/TopBar.js
+++ b/src/pages/Dashboards/dashboards/SocialTool/TopTrends/TopBar/TopBar.js
@@ -23,8 +23,8 @@ const TopBar = ({ setTrendPeriod }) => {
           className={cx(styles.tooltip, 'border box body-3')}
         >
           <div className='relative row body-3'>
-            This metric calculates the social volume for a list of words, and measures what its
-            discussion rate is vs. all other topics
+            Current discussion percentage of top 10 keywords compared to all keywords on crypto
+            platforms.
           </div>
         </Tooltip>
       </p>


### PR DESCRIPTION
## Changes
- Redirecting old trends to new dashboard `/dashboards/labs/trends` -> `/dashboards/social-tool`;
- `Social Dominance SUM` label changed.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
![CleanShot 2022-10-21 at 16 36 16@2x](https://user-images.githubusercontent.com/25135650/197208905-d3bd2a5f-246b-4e65-8904-7e5817e4fcf3.jpg)


