### PR TITLE
Fixed pricing page sticky

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -279,7 +279,11 @@ export const App = ({
                 }}
               />
             ))}
-            <Route exact path='/pricing' component={LoadablePricingPage} />
+            <Route
+              exact
+              path='/pricing'
+              render={(props) => <LoadablePricingPage {...props} isDesktop={isDesktop} />}
+            />
             <Route
               exact
               path={PATHS.GDPR}

--- a/src/pages/Pricing/index.js
+++ b/src/pages/Pricing/index.js
@@ -12,20 +12,28 @@ import PageLoader from '@cmp/Loader/PageLoader'
 import twitterStyles from './twitter.module.scss'
 import styles from './index.module.scss'
 
-export default () => {
+export default ({ isDesktop }) => {
   const ref = useRef()
   const [referencedNode, setReferencedNode] = useState()
   const [twitterNode, setTwitterNode] = useState()
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    const root = document.getElementById('root')
     let race = false
+
     Promise.all([querySanbasePlans(), subscription$.query(), customerData$.query()]).finally(() => {
       if (race) return
       setLoading(false)
     })
 
-    return () => (race = true)
+    !isDesktop && (root.style.overflow = 'clip')
+
+    return () => {
+      race = true
+
+      !isDesktop && root.removeAttribute('style')
+    }
   }, [])
 
   useEffect(() => {
@@ -40,7 +48,7 @@ export default () => {
   }, [loading])
 
   return (
-    <div ref={ref}>
+    <div ref={ref} className={styles.wrapper}>
       {loading && <PageLoader />}
 
       {referencedNode &&

--- a/src/pages/Pricing/index.module.scss
+++ b/src/pages/Pricing/index.module.scss
@@ -1,5 +1,13 @@
 @import '~@santiment-network/ui/mixins.scss';
 
+.wrapper {
+  :global(.phone-xs) &,
+  :global(.phone) &,
+  :global(.tablet) & {
+    margin-bottom: 64px;
+  }
+}
+
 .title {
   @include text('h3', 'l');
 
@@ -32,7 +40,13 @@
 .img {
   mix-blend-mode: normal;
   opacity: 0.8;
-  background: linear-gradient(180deg, var(--white) -27.4%, rgba(255, 255, 255, 0) 22.37%, var(--white) 75.8%), url('./headerBg.svg') no-repeat 100%;
+  background: linear-gradient(
+      180deg,
+      var(--white) -27.4%,
+      rgba(255, 255, 255, 0) 22.37%,
+      var(--white) 75.8%
+    ),
+    url('./headerBg.svg') no-repeat 100%;
   height: 250px;
   width: 290px;
   position: absolute;
@@ -157,7 +171,8 @@
   display: flex;
   align-items: center;
 
-  &::before, &::after {
+  &::before,
+  &::after {
     content: '';
     width: 5px;
     height: 5px;


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
1. Fixed sticky positioning of header in plans table
2. Updated margin

## Notion's card

<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/Fix-table-header-for-mob-on-pricing-e5231e36866648d4ac2da356d217c0cb

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
<img width="396" alt="Снимок экрана 2022-10-25 в 12 06 36" src="https://user-images.githubusercontent.com/46782114/197732644-790d2dd7-b7bf-4a0a-81b9-ebe2c41e954e.png">

