### PR TITLE
fix/historical-balance-top-transfers-table-query

### DIFF
--- a/src/ducks/HistoricalBalance/queries.js
+++ b/src/ducks/HistoricalBalance/queries.js
@@ -65,9 +65,9 @@ export const RECENT_TRANSACTIONS_QUERY = gql`
 export const TOP_TRANSACTIONS_QUERY = gql`
   query topTransfers(
     $addressSelector: AddressSelector
-    $from: DateTime
+    $from: DateTime!
     $to: DateTime = "utc_now"
-    $slug: String
+    $slug: String!
     $page: Int
     $pageSize: Int = 20
   ) {


### PR DESCRIPTION
## Changes
Fixing the query arguments' types for the `Top Transfers` table in `Historical Balance` lab.

## Notion's card
https://www.notion.so/santiment/Top-Transfers-query-incorrect-arg-types-7bd0e1586b7b46b0bb925893c841ed58

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)


