### PR TITLE
fix/studio-shared-time-frame

### DIFF
--- a/src/ducks/HistoricalBalance/queries.js
+++ b/src/ducks/HistoricalBalance/queries.js
@@ -65,9 +65,9 @@ export const RECENT_TRANSACTIONS_QUERY = gql`
 export const TOP_TRANSACTIONS_QUERY = gql`
   query topTransfers(
     $addressSelector: AddressSelector
-    $from: DateTime
+    $from: DateTime!
     $to: DateTime = "utc_now"
-    $slug: String
+    $slug: String!
     $page: Int
     $pageSize: Int = 20
   ) {

--- a/src/pages/Studio/Studio.js
+++ b/src/pages/Studio/Studio.js
@@ -77,8 +77,15 @@ const Studio = ({
   const [modRange, setModRange] = useState()
   const [modDate, setModDate] = useState(getToday)
   const [isLoginCTAOpened, setIsLoginCTAOpened] = useState(false)
+  const { from, to } = (props.parsedUrl || {}).settings || {}
 
   useMemo(() => (address || slug) && settingsStore.setProject({ slug, address }), [slug, address])
+
+  useMemo(() => {
+    if (from && to) {
+      settingsStore.setPeriod(new Date(from), new Date(to))
+    }
+  }, [])
 
   const onChartPointClick = (point, e) => setModDate(new Date(point.value))
 


### PR DESCRIPTION
## Changes
Fixing the issue when the shared timeframe were not applied to Studio's charts

## Notion's card
https://www.notion.so/santiment/Shared-timeframe-is-not-applied-to-charts-333cbd1b6d234ae192cbabf58dcfeddb

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)



