### PR TITLE
mobile search term trimmed, profile activities set as sticky, jumping bug fixed

### DIFF
--- a/src/pages/SearchMobilePage/SearchBar.js
+++ b/src/pages/SearchMobilePage/SearchBar.js
@@ -9,7 +9,7 @@ const DEFAULT_TEXT = 'Search for assets, trends...'
 const SearchBar = ({ onChange, placeholder = DEFAULT_TEXT }) => {
   const [term, setTerm] = useState('')
 
-  useDebounceEffect(() => onChange(term), 300, [term])
+  useDebounceEffect(() => onChange(term.trim()), 300, [term])
 
   function handleChange(event) {
     event.preventDefault()

--- a/src/pages/profile/activities/ProfileActivities.module.scss
+++ b/src/pages/profile/activities/ProfileActivities.module.scss
@@ -31,7 +31,7 @@
 
 .container {
   display: flex;
-  min-height: 100%;
+  min-height: 100vh;
 
   @include responsive('phone', 'phone-xs') {
     flex-direction: column;
@@ -45,6 +45,9 @@
   display: flex;
   flex-direction: column;
   width: 195px;
+  position: sticky;
+  top: 24px;
+  align-self: flex-start;
 
   @include responsive('phone', 'phone-xs') {
     width: 100%;


### PR DESCRIPTION
## Changes
- mobile search term trimmed
- profile activities set as sticky
- jumping bug fixed
<!--- Describe your changes -->

## Notion's card

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

