### PR TITLE
sidebar scrollbar toggle on hover added

### DIFF
--- a/src/components/SideNav/Section.svelte
+++ b/src/components/SideNav/Section.svelte
@@ -10,13 +10,15 @@
 </script>
 
 <div
-  class="category btn row v-center mrg-xl mrg--t txt-b"
+  class="category btn row justify v-center mrg-xl mrg--t txt-b"
   class:opened={isOpened}
   on:click={() => (isOpened = !isOpened)}
 >
-  <Svg id={icon} w="16" class="mrg-s mrg--r $style.icon" />
-  {title}
-  <Svg id="arrow-down" w="10" h="5.5" class="mrg-a mrg--l $style.arrow" />
+  <div class="row v-center">
+    <Svg id={icon} w="16" class="mrg-s mrg--r $style.icon" />
+    {title}  
+  </div>
+  <Svg id="arrow-down" w="10" h="5.5" class="$style.arrow" />
 </div>
 
 {#if isOpened}

--- a/src/components/SideNav/Section.svelte
+++ b/src/components/SideNav/Section.svelte
@@ -10,15 +10,13 @@
 </script>
 
 <div
-  class="category btn row justify v-center mrg-xl mrg--t txt-b"
+  class="category btn row v-center mrg-xl mrg--t txt-b"
   class:opened={isOpened}
   on:click={() => (isOpened = !isOpened)}
 >
-  <div class="row v-center">
-    <Svg id={icon} w="16" class="mrg-s mrg--r $style.icon" />
-    {title}  
-  </div>
-  <Svg id="arrow-down" w="10" h="5.5" class="$style.arrow" />
+  <Svg id={icon} w="16" class="mrg-s mrg--r $style.icon" />
+  {title}
+  <Svg id="arrow-down" w="10" h="5.5" class="mrg-a mrg--l $style.arrow" />
 </div>
 
 {#if isOpened}

--- a/src/components/SideNav/index.svelte
+++ b/src/components/SideNav/index.svelte
@@ -104,7 +104,7 @@
   .container {
     position: sticky;
     top: 0;
-    height: 100vh;
+    height: calc(100vh - 64px);
     padding: 24px 16px;
     overflow: auto;
 

--- a/src/components/SideNav/index.svelte
+++ b/src/components/SideNav/index.svelte
@@ -104,9 +104,17 @@
   .container {
     position: sticky;
     top: 0;
-    height: calc(100vh - 64px);
+    height: 100vh;
     padding: 24px 16px;
     overflow: auto;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    &:hover::-webkit-scrollbar {
+      display: initial;
+    }
   }
 
   .collapsed {


### PR DESCRIPTION
## Changes
- styles fixed, hover state style added
<!--- Describe your changes -->

## Notion's card
https://www.notion.so/santiment/sidebar-show-scroll-on-hover-8170237166994ea4a81598ac3cb801b7
<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

Not mouse over:
![image](https://user-images.githubusercontent.com/6568353/202212560-9196d32d-7074-4a04-a5a2-d2a05eaa3ca7.png)


On mouse over:
![image](https://user-images.githubusercontent.com/6568353/202213108-387d4fb8-5d67-415f-af24-f442cd83b4e9.png)

