### PR TITLE
feature/screener-price-volatility-metric

### DIFF
--- a/src/ducks/Watchlists/Widgets/Filter/dataHub/metrics.js
+++ b/src/ducks/Watchlists/Widgets/Filter/dataHub/metrics.js
@@ -72,6 +72,11 @@ export const Metric = {
     label: 'Price BTC',
     badge: '₿',
   },
+  price_volatility_1w: {
+    category: CATEGORIES.FINANCIAL,
+    label: 'Price Volatility',
+    tableColumnFormatter: (value) => value && +value.toFixed(6),
+  },
   marketcap_usd: {
     category: CATEGORIES.FINANCIAL,
     label: 'Marketcap',
@@ -633,6 +638,7 @@ Object.keys(Metric).forEach((key) => {
 export const metrics = [
   Metric.price_usd,
   Metric.price_btc,
+  Metric.price_volatility_1w,
   Metric.marketcap_usd,
   Metric.rank,
   Metric.eth_spent,


### PR DESCRIPTION
## Changes
`price_volatility_1w` metric added as a column to `Screener`.

## Notion's card
https://www.notion.so/santiment/Add-price_volatility-metric-to-Screener-a3efe266af8947bc9dfc63975b547af0

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
![CleanShot 2022-12-02 at 10 19 39@2x](https://user-images.githubusercontent.com/25135650/205237398-2069469e-4ce6-4a42-8c18-acf8612b7a43.jpg)
