### PR TITLE
fix/first-login-query

### DIFF
--- a/src/epics/handleEmailLogin.js
+++ b/src/epics/handleEmailLogin.js
@@ -52,6 +52,7 @@ export const handleLoginSuccess = (action$) =>
 
       const loggedEmails = localStorage.getItem('loggedEmails') || ''
       const { email } = user
+      const isFirstLogin = window.isFirstLogin || user.firstLogin
 
       window.$FPROM &&
         window.$FPROM.trackSignup(
@@ -66,7 +67,7 @@ export const handleLoginSuccess = (action$) =>
       GA.update(user)
 
       const { method = LoginType.EMAIL } = getSavedLoginMethod() || {}
-      if (user.firstLogin) {
+      if (isFirstLogin) {
         window.onGdprAccept = () => {
           trackSignupFinish(method)
         }
@@ -74,7 +75,7 @@ export const handleLoginSuccess = (action$) =>
         trackLoginFinish(method)
       }
 
-      if (user.firstLogin || (email && !loggedEmails.includes(email))) {
+      if (isFirstLogin || (email && !loggedEmails.includes(email))) {
         trackTwitterSignUpEvent()
         if (email) {
           localStorage.setItem('loggedEmails', loggedEmails + email + ';')

--- a/src/firstLogin.js
+++ b/src/firstLogin.js
@@ -1,0 +1,9 @@
+import { query } from 'webkit/api'
+
+query(`{
+  currentUser {
+    firstLogin
+  }
+}`).then(({ currentUser }) => {
+  window.isFirstLogin = Boolean(currentUser && currentUser.firstLogin)
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import './firstLogin' // NOTE: ENFORCING FIRST IMPORT ORDER
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Router, Route, Switch } from 'react-router-dom'


### PR DESCRIPTION
## Changes
Enforcing the `currentUser.firstLogin` query to be the first one during app start. It's needed because **_only the first_** `currentUser` query return `firstLogin: true`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [ ] If I make changes to another person's module, I've asked how to use it or request a review
- [ ] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [ ] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [ ] I've added tests (if necessary)

