### PR TITLE
enhance/featured-watchlists-section-screeners-appended

### DIFF
--- a/src/ducks/Watchlists/Cards/Featured.js
+++ b/src/ducks/Watchlists/Cards/Featured.js
@@ -3,11 +3,12 @@ import gql from 'graphql-tag'
 import { useQuery } from '@apollo/react-hooks'
 import { WatchlistCards } from './Card'
 import ProjectCard, { useMarketcap } from './ProjectCard'
-import { useFeaturedWatchlists } from '../gql/lists/hooks'
+import { useFeaturedScreeners, useFeaturedWatchlists } from '../gql/lists/hooks'
+import { SCREENER } from '../detector'
 
-const FEATURED_WATCHLISTS_MARKETCAP_HISTORY_QUERY = gql`
+const FEATURED_MARKETCAP_HISTORY_QUERY = (query) => gql`
   query {
-    featuredWatchlists {
+    featuredWatchlists:${query} {
       id
       historicalStats(from: "utc_now-7d", to: "utc_now", interval: "6h") {
         marketcap
@@ -15,12 +16,22 @@ const FEATURED_WATCHLISTS_MARKETCAP_HISTORY_QUERY = gql`
     }
   }
 `
+const FEATURED_WATCHLISTS_MARKETCAP_HISTORY_QUERY =
+  FEATURED_MARKETCAP_HISTORY_QUERY('featuredWatchlists')
+
+const FEATURED_SCREENERS_MARKETCAP_HISTORY_QUERY =
+  FEATURED_MARKETCAP_HISTORY_QUERY('featuredScreeners')
 
 const marketcapAccessor = ({ featuredWatchlists }, { id }) =>
   featuredWatchlists.find((watchlist) => watchlist.id === id)
 
-function useWatchlistMarketcap(watchlist, skip, onLoad) {
-  const { data } = useQuery(FEATURED_WATCHLISTS_MARKETCAP_HISTORY_QUERY, {
+function useWatchlistMarketcap(
+  watchlist,
+  skip,
+  onLoad,
+  query = FEATURED_WATCHLISTS_MARKETCAP_HISTORY_QUERY,
+) {
+  const { data } = useQuery(query, {
     skip,
   })
 
@@ -29,17 +40,35 @@ function useWatchlistMarketcap(watchlist, skip, onLoad) {
 
 const FeaturedWatchlists = ({ className, ...props }) => {
   const [watchlists] = useFeaturedWatchlists()
+  const [screeners] = useFeaturedScreeners()
 
   return (
-    <WatchlistCards
-      Card={ProjectCard}
-      {...props}
-      className={className}
-      watchlists={watchlists}
-      path='/watchlist/projects/'
-      useWatchlistMarketcap={useWatchlistMarketcap}
-      isWithVisibility={false}
-    />
+    <>
+      <WatchlistCards
+        Card={ProjectCard}
+        {...props}
+        className={className}
+        watchlists={watchlists}
+        path='/watchlist/projects/'
+        useWatchlistMarketcap={useWatchlistMarketcap}
+        isWithVisibility={false}
+      />
+
+      {screeners.length ? (
+        <WatchlistCards
+          Card={ProjectCard}
+          {...props}
+          className={className}
+          watchlists={screeners}
+          path='/screener/'
+          useWatchlistMarketcap={(...args) =>
+            useWatchlistMarketcap(...args, FEATURED_SCREENERS_MARKETCAP_HISTORY_QUERY)
+          }
+          isWithVisibility={false}
+          type={SCREENER}
+        />
+      ) : null}
+    </>
   )
 }
 


### PR DESCRIPTION
## Changes

Displaying featured screeners at the end of the `Explore watchlists` section on `/watchlists` page.

## Notion's card
https://www.notion.so/santiment/Featured-screeners-on-the-watchlists-page-7d90192d90ba455db69d12f064332cb2

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs

![CleanShot 2023-01-19 at 16 12 32@2x](https://user-images.githubusercontent.com/25135650/213451659-d992e26b-6efe-4fcf-8f4b-06f17506e46b.jpg)

