### PR TITLE
enhance/signup-analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29119,8 +29119,8 @@
       "from": "git+https://github.com/santiment/san-studio.git#d1c72d9"
     },
     "san-webkit": {
-      "version": "git+https://github.com/santiment/san-webkit.git#f0bf01cc0509b640898c027dfc7803d4dbd5ca90",
-      "from": "git+https://github.com/santiment/san-webkit.git#f0bf01c",
+      "version": "git+https://github.com/santiment/san-webkit.git#e8ec94d9abbf73bdde1fb8c91f601c9ca342029c",
+      "from": "git+https://github.com/santiment/san-webkit.git#e8ec94d",
       "requires": {
         "fast-glob": "^3.2.5",
         "patch-package": "^6.4.7"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "rxjs": "5.x.x",
     "san-insights": "https://github.com/santiment/insights-app#0aebf0e",
     "san-studio": "https://github.com/santiment/san-studio#d1c72d9",
-    "san-webkit": "https://github.com/santiment/san-webkit#f0bf01c",
+    "san-webkit": "https://github.com/santiment/san-webkit#e8ec94d",
     "san-queries": "https://github.com/santiment/san-queries#678df71",
     "sanitize-html": "^1.18.2",
     "svg-sprite": "1.5.0",

--- a/src/epics/handleEmailLogin.js
+++ b/src/epics/handleEmailLogin.js
@@ -4,14 +4,14 @@ import gql from 'graphql-tag'
 import { replace } from 'react-router-redux'
 import { trackTwitterSignUpEvent } from 'webkit/analytics/twitter'
 import { getSavedLoginMethod } from 'webkit/analytics/events/utils'
-import { trackLoginFinish, LoginType } from 'webkit/analytics/events/general'
-import { trackSignupFinish } from 'webkit/analytics/events/onboarding'
+import { LoginType } from 'webkit/analytics/events/general'
 import { showNotification } from '../actions/rootActions'
 import * as actions from './../actions/types'
 import { savePrevAuthProvider } from '../utils/localStorage'
 import GA from './../utils/tracking'
 import { setCoupon } from '../utils/coupon'
 import { USER_GQL_FRAGMENT } from './handleLaunch'
+import { trackSignupLogin } from '../firstLogin'
 
 const EMAIL_LOGIN_VERIFY_MUTATION = gql`
   mutation emailLoginVerify($email: String!, $token: String!) {
@@ -66,13 +66,7 @@ export const handleLoginSuccess = (action$) =>
       GA.update(user)
 
       const { method = LoginType.EMAIL } = getSavedLoginMethod() || {}
-      if (isFirstLogin) {
-        window.onGdprAccept = () => {
-          trackSignupFinish(method)
-        }
-      } else {
-        trackLoginFinish(method)
-      }
+      trackSignupLogin(method)
 
       if (isFirstLogin || (email && !loggedEmails.includes(email))) {
         trackTwitterSignUpEvent()

--- a/src/firstLogin.js
+++ b/src/firstLogin.js
@@ -1,5 +1,6 @@
 import { query } from 'webkit/api'
 import { parseAuthSearchParams } from 'webkit/utils/auth'
+import { Tracker } from 'webkit/analytics'
 import { trackLoginFinish } from 'webkit/analytics/events/general'
 import { trackSignupFinish } from 'webkit/analytics/events/onboarding'
 
@@ -13,14 +14,17 @@ query(`{
   const { auth } = parseAuthSearchParams()
 
   if (auth) {
-    if (window.isFirstLogin) {
-      window.onGdprAccept = () => {
-        trackSignupFinish(auth)
-      }
-    } else {
-      trackLoginFinish(auth)
-    }
-
+    trackSignupLogin(auth)
     window.history.replaceState(window.history.state, null, window.location.pathname)
   }
 })
+
+export function trackSignupLogin(method) {
+  if (window.isFirstLogin) {
+    trackSignupFinish(method, [Tracker.GA, Tracker.AMPLITUDE])
+
+    window.onGdprAccept = () => trackSignupFinish(method, [Tracker.SAN])
+  } else {
+    trackLoginFinish(method)
+  }
+}


### PR DESCRIPTION
## Changes
Reusing single track handler for oauth and email/metamask logins.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

