### PR TITLE
Removed auto-update notification settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18633,7 +18633,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -18649,7 +18649,7 @@
     "lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
     },
     "lodash.every": {
       "version": "4.6.0",
@@ -30537,7 +30537,7 @@
     "srcset": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
-      "integrity": "sha512-UH8e80l36aWnhACzjdtLspd4TAWldXJMa45NuOkTTU+stwekswObdqM63TtQixN4PPd/vO/kxLa6RD+tUPeFMg==",
+      "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
       "requires": {
         "array-uniq": "^1.0.2",
         "number-is-nan": "^1.0.0"

--- a/src/ducks/Alert/AlertModalForm.js
+++ b/src/ducks/Alert/AlertModalForm.js
@@ -6,7 +6,6 @@ import { useUpdateFinishedSteps } from './hooks/useUpdateFinishedSteps'
 import { useUpdateNameAndDescription } from './hooks/useUpdateNameAndDescription'
 import { ALERT_TYPES } from './constants'
 import styles from './AlertModalForm.module.scss'
-import { useUpdateNotificationSettings } from './hooks/useUpdateNotificationSettings'
 
 const AlertModalForm = ({
   selectorSettings,
@@ -30,19 +29,7 @@ const AlertModalForm = ({
     selectedStep,
     setFormPreviousValues,
     setInitialState,
-    setSelectedStep,
-    setInvalidSteps,
-    invalidStepsMemo,
   } = selectorSettings
-
-  useUpdateNotificationSettings({
-    values,
-    visitedSteps,
-    setSelectedStep,
-    selectedType,
-    setInvalidSteps,
-    invalidStepsMemo,
-  })
 
   useUpdateFinishedSteps({
     selectedType,


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Removed notification settings auto-update based on previous alert creating.
Need time to check if it solves the issue, if yes, I'll refactor this part of the code

## Notion's card

<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/Alerts-crash-14cbf46fb3294419ba7b2eb96c76dd09

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

