### PR TITLE
Fixed header shift on Twitter review

### DIFF
--- a/src/pages/Pricing/twitter.module.scss
+++ b/src/pages/Pricing/twitter.module.scss
@@ -12,6 +12,10 @@
   right: 50%;
   margin-left: -50vw;
   margin-right: -50vw;
+
+  article header {
+    margin: 0;
+  }
 }
 
 .header {


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
1. Update Twitter review style, changed margin of header in order to remove shift 

## Notion's card

<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/Fix-Twitter-reviews-header-shift-on-Pricing-page-9d7abe87084a4476bd4f5e7689b9555e?pvs=4

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

<img width="832" alt="Снимок экрана 2023-03-01 в 20 28 26" src="https://user-images.githubusercontent.com/46782114/222139380-e1561cb6-2f9c-4bd4-aeb3-0aa8d3df830c.png">
