### PR TITLE
Addresses count on preview cards 

### DIFF
--- a/src/ducks/HistoricalBalance/Address/AddToWatchlist.js
+++ b/src/ducks/HistoricalBalance/Address/AddToWatchlist.js
@@ -7,7 +7,8 @@ import { useAddressWatchlists } from '../../Watchlists/gql/lists/hooks'
 import { updateWatchlistShort } from '../../Watchlists/gql/list/mutations'
 import styles from './index.module.scss'
 
-const updateWatchlist = ({ id, listItems }) => updateWatchlistShort({ id: +id, listItems })
+const addToWatchlist = ({ id, listItems }) =>
+  updateWatchlistShort({ id: +id, listItems }, 'ADD_ITEMS')
 
 const AddToWatchlist = ({ address, infrastructure, note }) => {
   function checkIsListItemTheAddress({ blockchainAddress }) {
@@ -18,7 +19,7 @@ const AddToWatchlist = ({ address, infrastructure, note }) => {
     return listItems.some(checkIsListItemTheAddress)
   }
 
-  function onChangesApply(addToWatchlists, removeFromWatchlists) {
+  function onChangesApply(addToWatchlists) {
     const newListItem = {
       blockchainAddress: {
         address,
@@ -29,13 +30,12 @@ const AddToWatchlist = ({ address, infrastructure, note }) => {
       __typename: 'ListItem',
     }
 
-    removeFromWatchlists.forEach(({ listItems }) =>
-      listItems.splice(listItems.findIndex(checkIsListItemTheAddress), 1),
-    )
+    const updatedWatchlists = addToWatchlists.map(({ id }) => ({
+      listItems: [newListItem],
+      id,
+    }))
 
-    addToWatchlists.forEach(({ listItems }) => listItems.push(newListItem))
-
-    return Promise.all(addToWatchlists.concat(removeFromWatchlists).map(updateWatchlist))
+    return Promise.all(updatedWatchlists.map(addToWatchlist))
   }
 
   return (

--- a/src/ducks/Watchlists/Cards/AddressCard.js
+++ b/src/ducks/Watchlists/Cards/AddressCard.js
@@ -3,18 +3,19 @@ import Card from './Card'
 import styles from './AddressCard.module.scss'
 
 const AddressCard = (props) => {
-  const { stats } = props.watchlist
-  const { blockchainAddressesCount } = stats
+  const { listItems } = props.watchlist
+
+  const addressesCount = listItems.length
 
   return (
     <Card
       {...props}
       classes={styles}
       middleChildren={
-        blockchainAddressesCount ? (
+        addressesCount ? (
           <>
-            {blockchainAddressesCount}
-            <div className={styles.address}>address{blockchainAddressesCount > 1 && 'es'}</div>
+            {addressesCount}
+            <div className={styles.address}>address{addressesCount > 1 && 'es'}</div>
           </>
         ) : (
           <div className={styles.address}>No addresses</div>

--- a/src/ducks/Watchlists/gql/cache.js
+++ b/src/ducks/Watchlists/gql/cache.js
@@ -20,7 +20,10 @@ export function updateWatchlistOnEdit(cache, { data }) {
   const query = getWatchlistsShortQuery(type)
   const store = cache.readQuery({ query: query })
   const index = store.watchlists.findIndex(({ id }) => id === updateWatchlist.id)
-  store.watchlists[index] = { ...store.watchlists[index], ...updateWatchlist }
+  store.watchlists[index] = {
+    ...store.watchlists[index],
+    ...updateWatchlist,
+  }
 
   cache.writeQuery({ query: query, data: store })
 }

--- a/src/ducks/Watchlists/gql/list/queries.js
+++ b/src/ducks/Watchlists/gql/list/queries.js
@@ -81,7 +81,7 @@ export const UPDATE_WATCHLIST_MUTATION = (type) => gql`
 export const ADD_LIST_ITEMS_MUTATION = (type) => gql`
   mutation addWatchlistItems(
     $id: Int!
-    $listItems: [InputListItem]
+    $listItems: [InputListItem]!
   ) {
     addWatchlistItems(
       id: $id

--- a/src/pages/Watchlists/index.js
+++ b/src/pages/Watchlists/index.js
@@ -20,7 +20,7 @@ import {
 } from '../../ducks/renderQueue/sized'
 import { useUser } from '../../stores/user'
 import {
-  useUserAddressWatchlists,
+  useAddressWatchlists,
   useUserProjectWatchlists,
   useUserScreeners,
 } from '../../ducks/Watchlists/gql/lists/hooks'
@@ -121,7 +121,7 @@ const MyScreeners = () => {
 const Watchlists = ({ isDesktop }) => {
   const { isLoggedIn, loading } = useUser()
   const userWatchlistsData = useUserProjectWatchlists()
-  const userAddressesWatchlistsData = useUserAddressWatchlists()
+  const userAddressesWatchlistsData = useAddressWatchlists()
 
   return (
     <Page


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
1. Updated query for adding items to watchlists on Historical Balance page
2. Fixed preview cards addresses count 

## Notion's card

<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/Watchlists-stats-updating-issue-ca494656712347e2a7cd28948a5ee4c6?pvs=4

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

