### PR TITLE
hotfix(screener select asset): Fixed selection when anon user

### DIFF
--- a/src/ducks/Table/Checkbox/column.js
+++ b/src/ducks/Table/Checkbox/column.js
@@ -1,10 +1,38 @@
 import React from 'react'
 import Checkbox from './index'
+import PopupBanner from '../../../components/banners/feature/PopupBanner'
+import { useUser } from '../../../stores/user'
 
 export const CHECKBOX_COLUMN = {
   id: 'Checkboxes',
-  Header: ({ getToggleAllRowsSelectedProps }) => <Checkbox {...getToggleAllRowsSelectedProps()} />,
-  Cell: ({ row }) => <Checkbox {...row.getToggleRowSelectedProps()} />,
+  Header: ({ getToggleAllRowsSelectedProps }) => {
+    const { isLoggedIn } = useUser()
+    const { onChange, ...rest } = getToggleAllRowsSelectedProps()
+
+    function handleChange(e) {
+      if (isLoggedIn) onChange(e)
+    }
+
+    return (
+      <PopupBanner>
+        <Checkbox {...rest} onChange={handleChange} />
+      </PopupBanner>
+    )
+  },
+  Cell: ({ row }) => {
+    const { isLoggedIn } = useUser()
+    const { onChange, ...rest } = row.getToggleRowSelectedProps()
+
+    function handleChange(e) {
+      if (isLoggedIn) onChange(e)
+    }
+
+    return (
+      <PopupBanner>
+        <Checkbox {...rest} onChange={handleChange} />
+      </PopupBanner>
+    )
+  },
   disableSortBy: true,
   collapse: true,
 }


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
1. Added "Login banner" to select

## Notion's card
<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/Feature-Change-template-924f4b1c97964e2fa9606b4492afdd7b?pvs=4

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [x] If I make changes to another person's module, I've asked how to use it or request a review
- [x] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [x] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [x] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->
<img width="1133" alt="Снимок экрана 2023-03-28 в 19 53 12" src="https://user-images.githubusercontent.com/46782114/228312372-48f0c06b-586f-4cdd-b4ab-057980ca1b4b.png">

