### PR TITLE
hotfix(alerts type): Fixed type for wallet assets held

### DIFF
--- a/src/ducks/Alert/AlertModalForm.js
+++ b/src/ducks/Alert/AlertModalForm.js
@@ -71,7 +71,7 @@ const AlertModalForm = ({
           }
           if (
             signal.settings.type === 'wallet_usd_valuation' ||
-            signal.settings.type === 'wallet_assets'
+            signal.settings.type === 'wallet_assets_held'
           ) {
             return index === 3
           }

--- a/src/ducks/Alert/components/AlertModalContent/StepsContent/entities/WalletAndConditionsSelector/EventSelector/EventSelector.js
+++ b/src/ducks/Alert/components/AlertModalContent/StepsContent/entities/WalletAndConditionsSelector/EventSelector/EventSelector.js
@@ -37,7 +37,7 @@ const EventSelector = ({ address, onEventChange, setSelectedAsset }) => {
 
         if (
           eventSettings.type === 'wallet_usd_valuation' ||
-          eventSettings.type === 'wallet_assets'
+          eventSettings.type === 'wallet_assets_held'
         ) {
           eventSettings.selector = { infrastructure: settings.selector.infrastructure }
         }

--- a/src/ducks/Alert/components/AlertModalContent/StepsContent/entities/WalletAndConditionsSelector/EventSelector/constants.js
+++ b/src/ducks/Alert/components/AlertModalContent/StepsContent/entities/WalletAndConditionsSelector/EventSelector/constants.js
@@ -36,7 +36,7 @@ export const WALLET_EVENTS = [
       'Track a list of assets inside the particular wallet for entering or exiting the wallet. Assets have to be with non-zero balance.',
     isNew: true,
     settings: {
-      type: 'wallet_assets',
+      type: 'wallet_assets_held',
       channel: [],
       target: { address: '' },
       selector: { infrastructure: '' },

--- a/src/ducks/Alert/components/AlertModalContent/StepsContent/entities/WalletAndConditionsSelector/WalletAndConditionsSelector.js
+++ b/src/ducks/Alert/components/AlertModalContent/StepsContent/entities/WalletAndConditionsSelector/WalletAndConditionsSelector.js
@@ -66,7 +66,7 @@ const WalletAndConditionsSelector = () => {
         )
         break
       }
-      case 'wallet_assets': {
+      case 'wallet_assets_held': {
         children = <></>
         break
       }

--- a/src/ducks/Alert/components/AlertStepsSelector/AlertStepDescription/steps/WalletAndConditions/WalletAndConditions.js
+++ b/src/ducks/Alert/components/AlertStepsSelector/AlertStepDescription/steps/WalletAndConditions/WalletAndConditions.js
@@ -32,7 +32,7 @@ const WalletAndConditions = ({ description, invalidStepsMemo, selected, isFinish
     ) {
       invalidStepsMemo.delete('wallet')
     }
-    if (type === 'wallet_assets' && isInitialValuesInvalid && selector.infrastructure) {
+    if (type === 'wallet_assets_held' && isInitialValuesInvalid && selector.infrastructure) {
       invalidStepsMemo.delete('wallet')
     }
   }, [selector, target, loading, isInvalid, type])
@@ -89,7 +89,7 @@ const WalletAndConditions = ({ description, invalidStepsMemo, selected, isFinish
     )
   }
 
-  if (type === 'wallet_assets' && target.address && selector.infrastructure && !loading) {
+  if (type === 'wallet_assets_held' && target.address && selector.infrastructure && !loading) {
     children = (
       <div className={styles.wrapper}>
         <div className={styles.address}>{clipText(target.address, 24)}</div>

--- a/src/ducks/Alert/utils.js
+++ b/src/ducks/Alert/utils.js
@@ -268,7 +268,7 @@ function validateWalletStep({ invalidSteps, settings, cooldown, title, stepIndex
       invalidSteps.push('wallet')
     }
     if (
-      (settings.type === 'wallet_usd_valuation' || settings.type === 'wallet_assets') &&
+      (settings.type === 'wallet_usd_valuation' || settings.type === 'wallet_assets_held') &&
       (!settings.target.address || !settings.selector.infrastructure)
     ) {
       invalidSteps.push('wallet')


### PR DESCRIPTION
## Changes
<!--- Describe your changes -->
1. Updated alerts type (fixed it)

## Notion's card
<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/Fix-Wallet-assets-held-type-of-alert-114b99857097475a8d1b1f50c954f136?pvs=4

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I've performed a self-review, followed all rules from [Frontend style guide](https://www.notion.so/santiment/Front-end-style-guide-81750096b38c4bea9a29b14fd4ab8667)
- [ ] If I make changes to another person's module, I've asked how to use it or request a review
- [ ] I've updated the [documentation](https://github.com/santiment/academy), if necessary (Keyboard shortcuts, Account settings)
- [ ] I've checked night mode, mobile & tablet screens (if have changes in UI)
- [ ] I've added tests (if necessary)

## Screenshots or GIFs
<!--- (if appropriate) -->

